### PR TITLE
Mvvm or Mvux should only be added with Extensions Navigation

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -758,12 +758,12 @@
     "useMvux": {
       "type": "computed",
       "datatype": "bool",
-      "value": "architectureEvaluator == 'mvux'"
+      "value": "architectureEvaluator == 'mvux' && useExtensionsNavigation"
     },
     "useMvvm": {
       "type": "computed",
       "datatype": "bool",
-      "value": "architectureEvaluator == 'mvvm'"
+      "value": "architectureEvaluator == 'mvvm' && useExtensionsNavigation"
     },
     "useGtk": {
       "type": "computed",

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -742,7 +742,7 @@
           },
           {
             "condition": "(preset == 'blank')",
-            "value": "none"
+            "value": "mvvm"
           }
         ]
       }

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.recommended.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.recommended.cs
@@ -13,7 +13,6 @@ public class App : Application
 #endif
 	{
 		var builder = this.CreateBuilder(args)
-
 #if (useNavigationToolkit)
 			// Add navigation support for toolkit controls such as TabBar and NavigationView
 			.UseToolkitNavigation()


### PR DESCRIPTION
GitHub Issue (If applicable): #

- closes #12

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

CommunityToolkit or Reactive packages can be added to the project without a ViewModel/Model

## What is the new behavior?

These now require that Extensions Navigation be enabled as well.

