### PR TITLE
Fix Build Error for additive template

### DIFF
--- a/build/.azure-pipelines.TemplateValidation.yml
+++ b/build/.azure-pipelines.TemplateValidation.yml
@@ -8,64 +8,44 @@ jobs:
   strategy:
     matrix:
       DefaultArguments:
-        createdProjectName: UnoApp01
         templateArgs: ''
       BlankApp:
-        createdProjectName: UnoAppBlank01
         templateArgs: '-preset blank'
       SkiaOnlyHeads:
-        createdProjectName: UnoAppSkiaOnlyHeads01
         templateArgs: '-platforms gtk wpf linux-fb'
       MobileOnlyHeads:
-        createdProjectName: UnoAppMobileOnlyHeads01
         templateArgs: '-platforms android ios maccatalyst'
     #   BlankMarkupApp:
-    #     createdProjectName: UnoAppBlank01
     #     templateArgs: '-preset blank -markup csharp'
       BlankAppCpm:
-        createdProjectName: UnoAppBlank01
         templateArgs: '-preset blank --cpm true'
       MVVM:
-        createdProjectName: UnoAppNoReactive01
         templateArgs: '-presentation mvvm'
       CentralPackageManagement:
-        createdProjectName: UnoAppCPM01
         templateArgs: '--cpm true'
     #   CSharpMarkup:
-    #     createdProjectName: UnoAppCSharpMarkup01
     #     templateArgs: '-markup csharp'
       NoAppHosting:
-        createdProjectName: UnoAppNoAppHosting01
         templateArgs: '-di false'
       HostingOnly:
-        createdProjectName: UnoAppHostingOnly01
         templateArgs: '-config false -loc false -http false -log none --navigation blank'
       NoConfiguration:
-        createdProjectName: UnoAppNoConfiguration01
         templateArgs: '-config false'
       NoLocalization:
-        createdProjectName: UnoAppNoLocalization01
         templateArgs: '-loc false'
       NoHttp:
-        createdProjectName: UnoAppNoHttp01
         templateArgs: '-http false'
       NoSerilog:
-        createdProjectName: UnoAppNoSerilog01
         templateArgs: '-log default'
       NoServer:
-        createdProjectName: UnoAppNoServer01
         templateArgs: '-server false'
       NoServerNoHttp:
-        createdProjectName: UnoAppNoServerNoHttp01
         templateArgs: '-server false -http false'
       FrameNavigation:
-        createdProjectName: UnoAppFrameNavigation01
         templateArgs: '--navigation blank'
       Net6:
-        createdProjectName: UnoAppNet6
         templateArgs: '-tfm net6.0'
       Issue22:
-        createdProjectName: UnoAppIssue22
         templateArgs: '-preset blank -tfm net7.0 -platforms android -platforms ios -platforms maccatalyst -platforms macos -platforms windows -platforms wasm -platforms gtk -platforms wpf -platforms linux-fb -presentation mvvm -server false -tests "" -vscode false -pwa false -di true -nav regions -log none -theme material'
 
   variables:
@@ -73,62 +53,6 @@ jobs:
       value: false
 
   steps:
-  - checkout: self
-    clean: 'true'
-
-  - template: templates/dotnet7-install-windows.yml
-  
-  - template: templates/install-windows-sdk.yml
+  - template: templates/package-validation.yml
     parameters:
-      sdkVersion: 18362
-
-  - task: DownloadBuildArtifacts@0
-    inputs:
-      artifactName: $(Build.DefinitionName)
-
-  - powershell: |
-        & choco install vswhere
-        $msbuildpath=(vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe -nologo)
-        echo "##vso[task.setvariable variable=msbuildpath]$msbuildpath"
-    displayName: Set MSBUILDPATH
-
-  - script: |
-        md $(Build.SourcesDirectory)\src\PackageCache
-        copy "$(System.ArtifactsDirectory)\$(Build.DefinitionName)\*.nupkg" $(Build.SourcesDirectory)\src\PackageCache
-    displayName: Copy Artifacts to PackageCache
-
-  - script: dotnet new install "$(System.ArtifactsDirectory)\$(Build.DefinitionName)\Uno.Templates*.nupkg"
-    displayName: Install Project Templates
-
-  - powershell: |
-        dotnet nuget add source -n nuget_local $(Build.SourcesDirectory)\src\PackageCache
-        dotnet nuget add source -n uno_dev "https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json"
-
-        Set-PSDebug -Trace 1
-        $ErrorActionPreference = 'Stop'
-
-        # Create app with defaults
-        dotnet new unoapp -o $env:createdProjectName $env:templateArgs
-        if ($LASTEXITCODE -ne 0)
-        {
-            throw "Exit code must be zero."
-        }
-
-    displayName: Create template app
-
-  - template: templates/canary-updater.yml
-
-  - powershell: |
-        Set-PSDebug -Trace 1
-        $ErrorActionPreference = 'Stop'
-
-        cd $env:createdProjectName
-
-        & $env:msbuildpath /r /m $env:createdProjectName.sln
-        if ($LASTEXITCODE -ne 0)
-        {
-            throw "Exit code must be zero."
-        }
-        cd ..
-
-    displayName: Build template app
+      arguments: ${{ parameters.templateArgs }}

--- a/build/.azure-pipelines.TemplateValidation.yml
+++ b/build/.azure-pipelines.TemplateValidation.yml
@@ -64,6 +64,9 @@ jobs:
       Net6:
         createdProjectName: UnoAppNet6
         templateArgs: '-tfm net6.0'
+      Issue22:
+        createdProjectName: UnoAppIssue22
+        templateArgs: '-preset blank -tfm net7.0 -platforms android -platforms ios -platforms maccatalyst -platforms macos -platforms windows -platforms wasm -platforms gtk -platforms wpf -platforms linux-fb -presentation mvvm -server false -tests "" -vscode false -pwa false -di true -nav regions -log none -theme material'
 
   variables:
     - name: UseDotNetNativeToolchain

--- a/build/.azure-pipelines.TemplateValidation.yml
+++ b/build/.azure-pipelines.TemplateValidation.yml
@@ -108,7 +108,7 @@ jobs:
         $ErrorActionPreference = 'Stop'
 
         # Create app with defaults
-        Invoke-Expression -Command "dotnet new unoapp -o $env:createdProjectName $env:templateArgs"
+        dotnet new unoapp -o $env:createdProjectName $env:templateArgs
         if ($LASTEXITCODE -ne 0)
         {
             throw "Exit code must be zero."

--- a/build/templates/package-validation.yml
+++ b/build/templates/package-validation.yml
@@ -1,0 +1,65 @@
+parameters:
+- name: arguments
+  type: string
+  default: ''
+
+steps:
+- checkout: self
+  clean: 'true'
+
+- template: dotnet7-install-windows.yml
+
+- template: install-windows-sdk.yml
+  parameters:
+    sdkVersion: 18362
+
+- task: DownloadBuildArtifacts@0
+  inputs:
+    artifactName: $(Build.DefinitionName)
+
+- powershell: |
+      & choco install vswhere
+      $msbuildpath=(vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe -nologo)
+      echo "##vso[task.setvariable variable=msbuildpath]$msbuildpath"
+  displayName: Set MSBUILDPATH
+
+- script: |
+      md $(Build.SourcesDirectory)\src\PackageCache
+      copy "$(System.ArtifactsDirectory)\$(Build.DefinitionName)\*.nupkg" $(Build.SourcesDirectory)\src\PackageCache
+  displayName: Copy Artifacts to PackageCache
+
+- script: dotnet new install "$(System.ArtifactsDirectory)\$(Build.DefinitionName)\Uno.Templates*.nupkg"
+  displayName: Install Project Templates
+
+- powershell: |
+      dotnet nuget add source -n nuget_local $(Build.SourcesDirectory)\src\PackageCache
+      dotnet nuget add source -n uno_dev "https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json"
+
+      Set-PSDebug -Trace 1
+      $ErrorActionPreference = 'Stop'
+
+      # Create app with defaults
+      dotnet new unoapp -o UnoApp1 ${{ parameters.arguments }}
+      if ($LASTEXITCODE -ne 0)
+      {
+          throw "Exit code must be zero."
+      }
+
+  displayName: Create template app
+
+- template: templates/canary-updater.yml
+
+- powershell: |
+      Set-PSDebug -Trace 1
+      $ErrorActionPreference = 'Stop'
+
+      cd UnoApp1
+
+      & $env:msbuildpath /r /m UnoApp1.sln
+      if ($LASTEXITCODE -ne 0)
+      {
+          throw "Exit code must be zero."
+      }
+      cd ..
+
+  displayName: Build template app

--- a/build/templates/package-validation.yml
+++ b/build/templates/package-validation.yml
@@ -47,7 +47,7 @@ steps:
 
   displayName: Create template app
 
-- template: templates/canary-updater.yml
+- template: canary-updater.yml
 
 - powershell: |
       Set-PSDebug -Trace 1

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Server/MyExtensionsApp.1.Server.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Server/MyExtensionsApp.1.Server.csproj
@@ -10,7 +10,7 @@
 		<!--#if (useWasm)-->
 		<ProjectReference Include="..\MyExtensionsApp.1.Wasm\MyExtensionsApp.1.Wasm.csproj" />
 		<!--#endif -->
-		<!--#if (useRecommendedAppTemplate)-->
+		<!--#if (useDataContracts)-->
 		<ProjectReference Include="..\MyExtensionsApp.1.DataContracts\MyExtensionsApp.1.DataContracts.csproj" />
 		<!--#endif -->
 	</ItemGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/GlobalUsings.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/GlobalUsings.cs
@@ -50,7 +50,7 @@ global using Uno.Extensions.Navigation;
 #if (useHttp)
 global using Refit;
 #endif
-#if (useRecommendedAppTemplate)
+#if (useDependencyInjection)
 global using Uno.Extensions;
 #endif
 #if (useConfiguration)


### PR DESCRIPTION
GitHub Issue (If applicable): #

- closes #22

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Using the following:
```bash
dotnet new unoapp -n Issue22 -preset blank -tfm net7.0 -platforms android -platforms ios -platforms maccatalyst -platforms macos -platforms windows -platforms wasm -platforms gtk -platforms wpf -platforms linux-fb -presentation mvvm -server false -tests "" -vscode false -pwa false -di true -nav regions -log none -theme material
msbuild ./Issue22.sln
```

This will fail with a build error because the Uno.Extensions namespace is not included in the global namespaces.

## What is the new behavior?

Removes invalid conditions for additive process. Replaces `useRecommendedAppTemplate` condition
- and uses `useDependencyInjection` for the Uno.Extensions namespace
- and uses `useDataContracts` for the DataContracts project reference in the Server
