### PR TITLE
feat: UI Test net6+ support

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -537,7 +537,7 @@
     "unoUITestHelpersVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "1.1.0-dev.32",
+      "defaultValue": "1.1.0-dev.55",
       "replaces": "$UnoUITestHelpersVersion$"
     },
     "isVsix": {

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/MyExtensionsApp.1.UITests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/MyExtensionsApp.1.UITests.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net48</TargetFramework>
-		<!--#if (!useLangVersion)-->
-		<LangVersion>latest</LangVersion>
-		<!--#endif-->
+		<TargetFramework>$baseTargetFramework$</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/TestBase.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/TestBase.cs
@@ -55,10 +55,10 @@ public class TestBase
 		var fileInfo = App.Screenshot(title);
 
 		var fileNameWithoutExt = Path.GetFileNameWithoutExtension(fileInfo.Name);
-		if (fileNameWithoutExt != title)
+		if (fileNameWithoutExt != title && fileInfo.DirectoryName != null)
 		{
 			var destFileName = Path
-				.Combine(Path.GetDirectoryName(fileInfo.FullName), title + Path.GetExtension(fileInfo.Name));
+				.Combine(fileInfo.DirectoryName, title + Path.GetExtension(fileInfo.Name));
 
 			if (File.Exists(destFileName))
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): #

- closes #28 

## PR Type

What kind of change does this PR introduce?

- Refactoring

## What is the current behavior?

UI Test project targets net48

## What is the new behavior?

UI Test project will target which ever version of .NET that the solution is created with using the new UI Test Helpers which provides support for net6+
