### PR TITLE
Remove nowarn for Uno0001

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -15,7 +15,7 @@
 		<!--#endif-->
 
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-		<NoWarn>$(NoWarn);CS1998;CA1416;NU1507</NoWarn>
+		<NoWarn>$(NoWarn);CA1416;NU1507</NoWarn>
 
 		<DefaultLanguage>en</DefaultLanguage>
 

--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -15,7 +15,7 @@
 		<!--#endif-->
 
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-		<NoWarn>$(NoWarn);Uno0001;CS1998;CA1416;NU1507</NoWarn>
+		<NoWarn>$(NoWarn);CS1998;CA1416;NU1507</NoWarn>
 
 		<DefaultLanguage>en</DefaultLanguage>
 


### PR DESCRIPTION
GitHub Issue (If applicable): #

- closes #26 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

NoWarn includes Uno0001

## What is the new behavior?

Uno0001 is removed from the NoWarn overrides
