### PR TITLE
Fix run issue with the labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,7 @@
+# https://github.com/actions/labeler
+
+area/build
+- build/*
+
+area/solution-templates
+- src/Uno.Templates/content/*


### PR DESCRIPTION
GitHub Issue (If applicable): #

- n/a

## PR Type

What kind of change does this PR introduce?

- Project Automation

## What is the current behavior?

there is no labeler.yml in the .github directory

## What is the new behavior?

there is now a labeler.yml defined
