### PR TITLE
fix: Remove platform-specific implicit usings

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project ToolsVersion="15.0">
+<Project>
 	<PropertyGroup>
 		<!--#if (useLangVersion)-->
 		<LangVersion>10</LangVersion>

--- a/src/Uno.Templates/content/unoapp/Directory.Build.targets
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.targets
@@ -1,2 +1,5 @@
-<Project ToolsVersion="15.0">
+<Project>
+    <ItemGroup>
+        <Using Remove="@(Using->HasMetadata('Platform'))" />
+    </ItemGroup>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/GlobalUsings.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/GlobalUsings.cs
@@ -1,8 +1,6 @@
 ﻿//-:cnd:noEmit
-
 global using NUnit.Framework;
 global using Uno.UITest;
 global using Uno.UITest.Helpers.Queries;
 global using Uno.UITests.Helpers;
 global using Query = System.Func<Uno.UITest.IAppQuery, Uno.UITest.IAppQuery>;
-

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/GlobalUsings.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/GlobalUsings.cs
@@ -1,11 +1,5 @@
 ﻿//-:cnd:noEmit
-global using System;
-global using System.Collections.Generic;
 global using System.Collections.Immutable;
-global using System.Linq;
-global using System.Net.Http;
-global using System.Threading;
-global using System.Threading.Tasks;
 global using Microsoft.Extensions.DependencyInjection;
 //+:cnd:noEmit
 #if (useDependencyInjection)

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/GlobalUsings.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/GlobalUsings.cs
@@ -10,10 +10,12 @@ global using Microsoft.Extensions.Localization;
 #endif
 global using Microsoft.Extensions.Logging;
 global using Microsoft.UI.Xaml;
-global using Microsoft.UI.Xaml.Controls;
 #if (useCsharpMarkup)
 global using Microsoft.UI.Xaml.Automation;
+global using Microsoft.UI.Xaml.Controls;
 global using Microsoft.UI.Xaml.Data;
+#else
+global using Microsoft.UI.Xaml.Controls;
 #endif
 global using Microsoft.UI.Xaml.Media;
 global using Microsoft.UI.Xaml.Navigation;

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/GlobalUsings.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/GlobalUsings.cs
@@ -10,12 +10,10 @@ global using Microsoft.Extensions.Localization;
 #endif
 global using Microsoft.Extensions.Logging;
 global using Microsoft.UI.Xaml;
+global using Microsoft.UI.Xaml.Controls;
 #if (useCsharpMarkup)
 global using Microsoft.UI.Xaml.Automation;
-global using Microsoft.UI.Xaml.Controls;
 global using Microsoft.UI.Xaml.Data;
-#else
-global using Microsoft.UI.Xaml.Controls;
 #endif
 global using Microsoft.UI.Xaml.Media;
 global using Microsoft.UI.Xaml.Navigation;
@@ -73,10 +71,8 @@ global using Uno.Toolkit.UI.Material;
 #endif
 #endif
 global using Windows.ApplicationModel;
-global using Application = Microsoft.UI.Xaml.Application;
 global using ApplicationExecutionState = Windows.ApplicationModel.Activation.ApplicationExecutionState;
 #if (useCsharpMarkup)
-global using Button = Microsoft.UI.Xaml.Controls.Button;
 global using Color = Windows.UI.Color;
 #endif
 //-:cnd:noEmit


### PR DESCRIPTION
GitHub Issue (If applicable): closes #34

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Setting `ImplicitUsings` to `enable` or `true` brings more namespaces than we need, e.g:

https://github.com/xamarin/xamarin-android/blob/3f756cc5ed7154f6384a53da62d60d77e0dd9e3d/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/Sdk/AutoImport.props#L19-L23 for Android, and https://github.com/xamarin/xamarin-macios/blob/1fd05057ed96083fc70ba0f0afb8bb544592ad3b/dotnet/Makefile#L143 https://github.com/xamarin/xamarin-macios/blob/1fd05057ed96083fc70ba0f0afb8bb544592ad3b/dotnet/Makefile#L17-L20 for ios/macos.

## What is the new behavior?

The platform-specific usings are now removed to avoid conflicts. From example, Android.Widget.Button conflicts with Microsoft.UI.Xaml.Controls.Button.

So now, we only include non-platform-specific usings that come from the .NET SDK, for example [this](https://github.com/dotnet/sdk/blob/269bf2a2185b0a32d60aafdbc1e25090b978acf3/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.CSharp.props#L26-L34)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
