### PR TITLE
fix: Adding safe area if toolkit enabled

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1204,6 +1204,24 @@
         ]
       }
     },
+    "toolkitSafeArea":{
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "$toolkitSafeArea$",
+      "parameters": {
+        "evaluator": "C++",
+        "cases": [
+          {
+            "condition": "(useToolkit)",
+            "value": " utu:SafeArea.Insets=\"All\""
+          },
+          {
+            "condition": "(!useToolkit)",
+            "value": ""
+          }
+        ]
+      }
+    },
     "shellRouteViewModel":{
       "type": "generated",
       "generator": "switch",

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainPage.xaml
@@ -10,7 +10,7 @@
 	NavigationCacheMode="Required"
 	Background="{ThemeResource $themeBackgroundBrush$}">
 
-	<Grid>
+	<Grid$toolkitSafeArea$>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
 			<RowDefinition />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/SecondPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/SecondPage.xaml
@@ -7,7 +7,7 @@
 	xmlns:uen="using:Uno.Extensions.Navigation.UI"$toolkitNamespace$
 	Background="{ThemeResource $themeBackgroundBrush$}">
 
-	<Grid>
+	<Grid$toolkitSafeArea$>
 <!--#if (useToolkit)-->
 		<utu:NavigationBar Content="Second Page">
 			<utu:NavigationBar.MainCommand>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

When keyboard triggered, it can obscure textbox.

## What is the new behavior?

Safearea (when toolkit is enabled) moves textbox out of the way (and moves content out from under notches)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
