### PR TITLE
Exclude ItemGroup when not using CPM

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Base/base.props
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Base/base.props
@@ -1,10 +1,10 @@
 <Project>
-	<ItemGroup>
 	<!--#if (useCPM)-->
+	<ItemGroup>
 		<PackageReference Include="Uno.Resizetizer" />
-	<!--#endif-->
 	</ItemGroup>
 
+	<!--#endif-->
 	<ItemGroup>
 		<None Include="$(MSBuildThisFileDirectory)AppHead.xaml" />
 		<ApplicationDefinition Include="$(MSBuildThisFileDirectory)AppHead.xaml"


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

n/a

## PR Type

What kind of change does this PR introduce?

- Refactoring

## What is the current behavior?

When using CPM an ItemGroup is in the base.props to include Resizetizer... when not using CPM the ItemGroup remains but is empty

## What is the new behavior?

When not using Resizetizer the ItemGroup is excluded
