### PR TITLE
fix: Add app.manifest to Windows targets

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.Gtk/MyExtensionsApp.1.Skia.Gtk.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.Gtk/MyExtensionsApp.1.Skia.Gtk.csproj
@@ -3,9 +3,11 @@
 		<OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
 		<OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
 		<TargetFramework>$baseTargetFramework$</TargetFramework>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
 	</PropertyGroup>
 	<ItemGroup>
 		<EmbeddedResource Include="Package.appxmanifest" />
+		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
 
 	<!--#if (useCPM)-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.Gtk/app.manifest
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.Gtk/app.manifest
@@ -52,8 +52,8 @@
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
     </windowsSettings>
   </application>
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.WPF/MyExtensionsApp.1.Skia.WPF.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.WPF/MyExtensionsApp.1.Skia.WPF.csproj
@@ -4,6 +4,7 @@
 		<OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
 		<TargetFramework>$baseTargetFramework$-windows</TargetFramework>
 		<UseWPF>true</UseWPF>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
 	</PropertyGroup>
 	<ItemGroup Label="AssemblyInfo">
 		<AssemblyAttribute Include="System.Runtime.InteropServices.ComVisibleAttribute">
@@ -18,6 +19,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<EmbeddedResource Include="Package.appxmanifest" />
+		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
 
 	<!--#if (useCPM)-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.WPF/app.manifest
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.WPF/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="MyExtensionsApp.1.Windows.app"/>
+  <assemblyIdentity version="1.0.0.0" name="MyExtensionsApp.1.Skia.WPF.app"/>
 
 	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
 		<application>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Windows/MyExtensionsApp.1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Windows/MyExtensionsApp.1.Windows.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>$baseTargetFramework$-windows10.0.19041.0</TargetFramework>
 		<TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
 		<RootNamespace>UnoWinUIQuickStart</RootNamespace>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<Platforms>x86;x64;arm64</Platforms>
 		<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
 		<PublishProfile>win10-$(Platform).pubxml</PublishProfile>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

app.manifest is not properly used, which means the app don't adhere to DPI scaling changes (and fractional scaling)

## What is the new behavior?

- Add `<ApplicationManifest>` to all Windows targets
- Update `app.manifest` as per latest WinUI project template

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
