### PR TITLE
Add Mvvm/Mvux namespaces in GlobalUsings if selected

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/GlobalUsings.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/GlobalUsings.cs
@@ -1,7 +1,6 @@
 ﻿//-:cnd:noEmit
 global using System.Collections.Immutable;
 global using Microsoft.Extensions.DependencyInjection;
-global using Uno.Extensions.Serialization;
 global using Windows.Networking.Connectivity;
 global using Windows.Storage;
 //+:cnd:noEmit
@@ -40,6 +39,7 @@ global using MyExtensionsApp._1.DataContracts.Serialization;
 global using MyExtensionsApp._1.Services.Caching;
 global using MyExtensionsApp._1.Services.Endpoints;
 global using Uno.Extensions.Http;
+global using Uno.Extensions.Serialization;
 #endif
 #if (useExtensionsNavigation)
 global using Uno.Extensions.Navigation;

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/GlobalUsings.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/GlobalUsings.cs
@@ -77,4 +77,12 @@ global using ApplicationExecutionState = Windows.ApplicationModel.Activation.App
 #if (useCsharpMarkup)
 global using Color = Windows.UI.Color;
 #endif
+#if (useMvux)
+global using Uno.Extensions.Reactive;
+#endif
+#if (useMvvm)
+global using System.Windows.Input;
+global using CommunityToolkit.Mvvm.ComponentModel;
+global using CommunityToolkit.Mvvm.Input;
+#endif
 //-:cnd:noEmit

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/GlobalUsings.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/GlobalUsings.cs
@@ -1,6 +1,9 @@
 ﻿//-:cnd:noEmit
 global using System.Collections.Immutable;
 global using Microsoft.Extensions.DependencyInjection;
+global using Uno.Extensions.Serialization;
+global using Windows.Networking.Connectivity;
+global using Windows.Storage;
 //+:cnd:noEmit
 #if (useDependencyInjection)
 global using Microsoft.Extensions.Hosting;

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainModel.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainModel.cs
@@ -1,6 +1,4 @@
 //-:cnd:noEmit
-using Uno.Extensions.Reactive;
-
 namespace MyExtensionsApp._1.Presentation;
 
 public partial record MainModel

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainViewModel.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainViewModel.cs
@@ -1,7 +1,3 @@
-using System.Windows.Input;
-using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
-
 namespace MyExtensionsApp._1.Presentation;
 
 public partial class MainViewModel : ObservableObject

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Services/Caching/IWeatherCache.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Services/Caching/IWeatherCache.cs
@@ -1,6 +1,3 @@
-using MyExtensionsApp._1.DataContracts;
-using System.Collections.Immutable;
-
 namespace MyExtensionsApp._1.Services.Caching;
 
 public interface IWeatherCache

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Services/Caching/WeatherCache.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Services/Caching/WeatherCache.cs
@@ -1,7 +1,3 @@
-using Uno.Extensions.Serialization;
-using Windows.Networking.Connectivity;
-using Windows.Storage;
-
 namespace MyExtensionsApp._1.Services.Caching;
 
 public sealed class WeatherCache : IWeatherCache

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Services/Endpoints/IApiClient.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Services/Endpoints/IApiClient.cs
@@ -1,6 +1,3 @@
-using System.Collections.Immutable;
-using MyExtensionsApp._1.DataContracts;
-
 namespace MyExtensionsApp._1.Services.Endpoints;
 
 [Headers("Content-Type: application/json")]


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

closes: #3 

## PR Type

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

There are files that use local using.

## What is the new behavior?

Now the usings are located in the global.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
https://github.com/unoplatform/uno.templates/issues/3