### PR TITLE
Provide Back Navigation when not using Toolkit

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/SecondPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/SecondPage.xaml
@@ -8,6 +8,10 @@
 	Background="{ThemeResource $themeBackgroundBrush$}">
 
 	<Grid$toolkitSafeArea$>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
 <!--#if (useToolkit)-->
 		<utu:NavigationBar Content="Second Page">
 			<utu:NavigationBar.MainCommand>
@@ -18,13 +22,26 @@
 				</AppBarButton>
 			</utu:NavigationBar.MainCommand>
 		</utu:NavigationBar>
+		<TextBlock Grid.Row="1" Text="{Binding Entity.Name}"
+				HorizontalAlignment="Center"
+				VerticalAlignment="Center"
+				Margin="8" />
 <!--#else-->
 		<TextBlock Text="Second Page" HorizontalAlignment="Center" />
-<!--#endif-->
+		<StackPanel Grid.Row="1"
+					HorizontalAlignment="Center"
+					VerticalAlignment="Center">
+			<TextBlock Text="{Binding Entity.Name}"
+				HorizontalAlignment="Center"
+				VerticalAlignment="Center"
+				Margin="8" />
 
-		<TextBlock Text="{Binding Entity.Name}"
-				   HorizontalAlignment="Center"
-				   VerticalAlignment="Center"
-				   />
+			<Button Content="Back to Main Page"
+				HorizontalAlignment="Left"
+				VerticalAlignment="Top"
+				AutomationProperties.AutomationId="BackButton"
+				uen:Navigation.Request="-"/>
+		</StackPanel>
+<!--#endif-->
 	</Grid>
 </Page>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/SecondPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/SecondPage.xaml
@@ -22,12 +22,9 @@
 				</AppBarButton>
 			</utu:NavigationBar.MainCommand>
 		</utu:NavigationBar>
-		<TextBlock Grid.Row="1" Text="{Binding Entity.Name}"
-				HorizontalAlignment="Center"
-				VerticalAlignment="Center"
-				Margin="8" />
 <!--#else-->
 		<TextBlock Text="Second Page" HorizontalAlignment="Center" />
+<!--#endif-->
 		<StackPanel Grid.Row="1"
 					HorizontalAlignment="Center"
 					VerticalAlignment="Center">
@@ -35,13 +32,14 @@
 				HorizontalAlignment="Center"
 				VerticalAlignment="Center"
 				Margin="8" />
-
+<!--#if (!useToolkit)-->
 			<Button Content="Back to Main Page"
 				HorizontalAlignment="Left"
 				VerticalAlignment="Top"
 				AutomationProperties.AutomationId="BackButton"
 				uen:Navigation.Request="-"/>
+<!--#endif-->	
 		</StackPanel>
-<!--#endif-->
+
 	</Grid>
 </Page>


### PR DESCRIPTION
[Template] Provide Back Navigation when not using Toolkit https://github.com/unoplatform/uno.templates/issues/5

GitHub Issue (If applicable): closes #5 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

When we are not using the  using Uno.Toolkit.UI we can not use the to utu:NavigationBar.
So we do not have the some back options on the Second Page.

## What is the new behavior?

Now we have add the option to back on the second page.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Internal Issue (If applicable):
#5 