### PR TITLE
fix: Setting background of shell

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/Shell.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/Shell.xaml
@@ -7,36 +7,37 @@
 	mc:Ignorable="d"
 	d:DesignHeight="300"
 	d:DesignWidth="400">
-
+	<Border Background="{ThemeResource $themeBackgroundBrush$}">
 <!--#if (useToolkit)-->
-	<utu:ExtendedSplashScreen x:Name="Splash"
-							  HorizontalAlignment="Stretch"
-							  VerticalAlignment="Stretch"
-							  HorizontalContentAlignment="Stretch"
-							  VerticalContentAlignment="Stretch">
-		<utu:ExtendedSplashScreen.LoadingContentTemplate>
-			<DataTemplate>
-				<Grid>
-					<Grid.RowDefinitions>
-						<RowDefinition Height="2*" />
-						<RowDefinition />
-					</Grid.RowDefinitions>
+		<utu:ExtendedSplashScreen x:Name="Splash"
+								HorizontalAlignment="Stretch"
+								VerticalAlignment="Stretch"
+								HorizontalContentAlignment="Stretch"
+								VerticalContentAlignment="Stretch">
+			<utu:ExtendedSplashScreen.LoadingContentTemplate>
+				<DataTemplate>
+					<Grid>
+						<Grid.RowDefinitions>
+							<RowDefinition Height="2*" />
+							<RowDefinition />
+						</Grid.RowDefinitions>
 
-					<ProgressRing IsActive="True"
-								  Grid.Row="1"
-								  VerticalAlignment="Center"
-								  HorizontalAlignment="Center"
-								  Height="100"
-								  Width="100" />
-				</Grid>
-			</DataTemplate>
-		</utu:ExtendedSplashScreen.LoadingContentTemplate>
-	</utu:ExtendedSplashScreen>
+						<ProgressRing IsActive="True"
+									Grid.Row="1"
+									VerticalAlignment="Center"
+									HorizontalAlignment="Center"
+									Height="100"
+									Width="100" />
+					</Grid>
+				</DataTemplate>
+			</utu:ExtendedSplashScreen.LoadingContentTemplate>
+		</utu:ExtendedSplashScreen>
 <!--#else-->
-	<ContentControl x:Name="Splash"
-							  HorizontalAlignment="Stretch"
-							  VerticalAlignment="Stretch"
-							  HorizontalContentAlignment="Stretch"
-							  VerticalContentAlignment="Stretch" />
+		<ContentControl x:Name="Splash"
+								HorizontalAlignment="Stretch"
+								VerticalAlignment="Stretch"
+								HorizontalContentAlignment="Stretch"
+								VerticalContentAlignment="Stretch" />
 <!--#endif-->
+	</Border>
 </UserControl>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/Shell.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/Shell.xaml.cs
@@ -7,33 +7,34 @@ public sealed partial class Shell : UserControl, IContentControlProvider
 //+:cnd:noEmit
 #if useCsharpMarkup
 		this.Content(
-
+			new Border(
 #if useToolkit
-			new ExtendedSplashScreen()
-				.Assign(out var splash)
-				.HorizontalAlignment(HorizontalAlignment.Stretch)
-				.VerticalAlignment(VerticalAlignment.Stretch)
-				.HorizontalContentAlignment(HorizontalAlignment.Stretch)
-				.VerticalContentAlignment(VerticalAlignment.Stretch)
-				.LoadingContentTemplate<object>(_ => new Grid()
-					.RowDefinitions(new GridLength(2, GridUnitType.Star), new GridLength(1, GridUnitType.Star))
-					.Children(
-						new ProgressRing()
-							.Grid(row: 1)
-							.VerticalAlignment(VerticalAlignment.Center)
-							.HorizontalAlignment(HorizontalAlignment.Center)
-							.Height(100)
-							.Width(100)
+				new ExtendedSplashScreen()
+					.Assign(out var splash)
+					.HorizontalAlignment(HorizontalAlignment.Stretch)
+					.VerticalAlignment(VerticalAlignment.Stretch)
+					.HorizontalContentAlignment(HorizontalAlignment.Stretch)
+					.VerticalContentAlignment(VerticalAlignment.Stretch)
+					.LoadingContentTemplate<object>(_ => new Grid()
+						.RowDefinitions(new GridLength(2, GridUnitType.Star), new GridLength(1, GridUnitType.Star))
+						.Children(
+							new ProgressRing()
+								.Grid(row: 1)
+								.VerticalAlignment(VerticalAlignment.Center)
+								.HorizontalAlignment(HorizontalAlignment.Center)
+								.Height(100)
+								.Width(100)
+						)
 					)
-				)
 #else
-			new ContentControl()
-				.Assign(out var splash)
-				.HorizontalAlignment(HorizontalAlignment.Stretch)
-				.VerticalAlignment(VerticalAlignment.Stretch)
-				.HorizontalContentAlignment(HorizontalAlignment.Stretch)
-				.VerticalContentAlignment(VerticalAlignment.Stretch)
+				new ContentControl()
+					.Assign(out var splash)
+					.HorizontalAlignment(HorizontalAlignment.Stretch)
+					.VerticalAlignment(VerticalAlignment.Stretch)
+					.HorizontalContentAlignment(HorizontalAlignment.Stretch)
+					.VerticalContentAlignment(VerticalAlignment.Stretch)
 #endif
+				).Background(Theme.Brushes.Background.Default)
 			);
 		Splash = splash;
 #else


### PR DESCRIPTION
GitHub Issue (If applicable): #60

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Splashscreen background is always white, even when browser set to dark theme (ie no theme background color set)

## What is the new behavior?

Uses the themed background brush

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
