### PR TITLE
fix: Enabling unit and uitests for blank preset

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -623,7 +623,7 @@
     "useTestSolutionFolder": {
       "type": "computed",
       "datatype": "bool",
-      "value": "(testsEvaluator == 'ui' || testsEvaluator == 'unit' || testsEvaluator == 'unit|ui' || testsEvaluator == 'ui|unit')"
+      "value": "(testsEvaluator != '')"
     },
     "useCsharpMarkup": {
       "type": "computed",
@@ -906,14 +906,22 @@
       "value": "((useDependencyInjection && useHttp) || (server && useRecommendedAppTemplate))"
     },
     "useUnitTests": {
-      "type": "computed",
+      "type": "generated",
+      "generator": "regexMatch",
       "dataType": "bool",
-      "value": "(testsEvaluator == 'unit' || testsEvaluator == 'unit|ui' || testsEvaluator == 'ui|unit')"
+      "parameters": {
+      "source": "testsEvaluator",
+      "pattern": ".*unit.*"
+      }
     },
     "useUITests": {
-      "type": "computed",
+      "type": "generated",
+      "generator": "regexMatch",
       "dataType": "bool",
-      "value": "(testsEvaluator == 'ui' || testsEvaluator == 'unit|ui' || testsEvaluator == 'ui|unit')"
+      "parameters": {
+      "source": "testsEvaluator",
+      "pattern": ".*ui.*"
+      }
     },
     "useSkia": {
       "type": "computed",

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -598,7 +598,7 @@
     "useTestSolutionFolder": {
       "type": "computed",
       "datatype": "bool",
-      "value": "preset == 'recommended' && (tests == 'ui' || tests == 'unit')"
+      "value": "(tests == 'ui' || tests == 'unit')"
     },
     "useCsharpMarkup": {
       "type": "computed",

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -227,8 +227,33 @@
           "description": "Include a project for authoring UI tests using the Uno.UITest framework",
           "displayName": "UI Tests"
         }
-      ],
-      "defaultValue": "unit|ui"
+      ]
+    },
+    "presetTestsDefault": {
+      "type": "generated",
+      "generator": "switch",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "(preset == 'recommended')",
+            "value": "unit|ui"
+          },
+          {
+            "condition": "(preset == 'blank')",
+            "value": ""
+          }
+        ]
+      }
+    },
+    "testsEvaluator": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "tests",
+        "fallbackVariableName": "presetTestsDefault"
+      }
     },
     "server": {
       "displayName": "Server",
@@ -598,7 +623,7 @@
     "useTestSolutionFolder": {
       "type": "computed",
       "datatype": "bool",
-      "value": "(tests == 'ui' || tests == 'unit')"
+      "value": "(testsEvaluator == 'ui' || testsEvaluator == 'unit' || testsEvaluator == 'unit|ui' || testsEvaluator == 'ui|unit')"
     },
     "useCsharpMarkup": {
       "type": "computed",
@@ -883,12 +908,12 @@
     "useUnitTests": {
       "type": "computed",
       "dataType": "bool",
-      "value": "(tests == unit)"
+      "value": "(testsEvaluator == 'unit' || testsEvaluator == 'unit|ui' || testsEvaluator == 'ui|unit')"
     },
     "useUITests": {
       "type": "computed",
       "dataType": "bool",
-      "value": "(tests == ui)"
+      "value": "(testsEvaluator == 'ui' || testsEvaluator == 'unit|ui' || testsEvaluator == 'ui|unit')"
     },
     "useSkia": {
       "type": "computed",

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -883,12 +883,12 @@
     "useUnitTests": {
       "type": "computed",
       "dataType": "bool",
-      "value": "(preset == 'recommended' &&  tests == unit)"
+      "value": "(tests == unit)"
     },
     "useUITests": {
       "type": "computed",
       "dataType": "bool",
-      "value": "(preset == 'recommended' && tests == ui)"
+      "value": "(tests == ui)"
     },
     "useSkia": {
       "type": "computed",

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/Given_MainPage.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/Given_MainPage.cs
@@ -12,6 +12,9 @@ public class Given_MainPage : TestBase
 
 //+:cnd:noEmit
 #if (useExtensionsNavigation)
+		// Add delay to allow for the splash screen to disappear
+		await Task.Delay(5000);
+
 		// Query for the SecondPageButton and then tap it
 		Query xamlButton = q => q.All().Marked("SecondPageButton");
 		App.WaitForElement(xamlButton);
@@ -21,7 +24,7 @@ public class Given_MainPage : TestBase
 		TakeScreenshot("After tapped");
 #else
 		// Query for the MainPage Text Block
-		Query textBlock = q => q.All().Marked("Hello Uno Platform");
+		Query textBlock = q => q.All().Marked("HelloTextBlock");
 		App.WaitForElement(textBlock);
 
 		// Take a screenshot and add it to the test results

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/Given_MainPage.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/Given_MainPage.cs
@@ -3,17 +3,18 @@
 public class Given_MainPage : TestBase
 {
 	[Test]
-	public void When_SmokeTest()
+	public async Task When_SmokeTest()
 	{
 		// NOTICE
 		// To run UITests, Run the WASM target without debugger. Note
 		// the port that is being used and update the Constants.cs file
 		// in the UITests project with the correct port number.
 
-//+:cnd:noEmit
-#if (useExtensionsNavigation)
 		// Add delay to allow for the splash screen to disappear
 		await Task.Delay(5000);
+
+//+:cnd:noEmit
+#if (useExtensionsNavigation)
 
 		// Query for the SecondPageButton and then tap it
 		Query xamlButton = q => q.All().Marked("SecondPageButton");

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MainPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MainPage.xaml
@@ -9,6 +9,7 @@
 
 	<StackPanel HorizontalAlignment="Center"
 				VerticalAlignment="Center">
-		<TextBlock Text="Hello Uno Platform" />
+		<TextBlock AutomationProperties.AutomationId="HelloTextBlock"
+				   Text="Hello Uno Platform" />
 	</StackPanel>
 </Page>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #83

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

No test projects created when using blank preset and specifying tests=ui|unit

## What is the new behavior?

Test projects are created

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
