### PR TITLE
fix: Remove blank/recommended conditions

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -585,16 +585,6 @@
       "datatype": "bool",
       "value": "cpm"
     },
-    "useBlankAppTemplate": {
-      "type": "computed",
-      "datatype": "bool",
-      "value": "preset == 'blank'"
-    },
-    "useRecommendedAppTemplate": {
-      "type": "computed",
-      "datatype": "bool",
-      "value": "preset == 'recommended'"
-    },
     "useTestSolutionFolder": {
       "type": "computed",
       "datatype": "bool",
@@ -878,7 +868,7 @@
     "useDataContracts": {
       "type": "computed",
       "dataType": "bool",
-      "value": "((useDependencyInjection && useHttp) || (server && useRecommendedAppTemplate))"
+      "value": "(useDependencyInjection && useHttp)"
     },
     "useUnitTests": {
       "type": "computed",

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.DataContracts/WeatherForecast.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.DataContracts/WeatherForecast.cs
@@ -15,7 +15,7 @@ public class WeatherForecast
 	/// <summary>
 	/// Gets the Forecast Temperature in Celsius.
 	/// </summary>
-	public int TemperatureC { get; set; }
+	public double TemperatureC { get; set; }
 
 	/// <summary>
 	/// Get a description of how the weather will feel.
@@ -25,7 +25,7 @@ public class WeatherForecast
 	/// <summary>
 	/// Gets the Forecast Temperature in Fahrenheit
 	/// </summary>
-	public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+	public double TemperatureF => 32 + (TemperatureC * 9 / 5);
 }
 #else
 /// <summary>
@@ -34,11 +34,11 @@ public class WeatherForecast
 /// <param name="Date">Gets the Date of the Forecast.</param>
 /// <param name="TemperatureC">Gets the Forecast Temperature in Celsius.</param>
 /// <param name="Summary">Get a description of how the weather will feel.</param>
-public record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+public record WeatherForecast(DateOnly Date, double TemperatureC, string? Summary)
 {
 	/// <summary>
 	/// Gets the Forecast Temperature in Fahrenheit
 	/// </summary>
-	public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+	public double TemperatureF => 32 + (TemperatureC * 9 / 5);
 }
 #endif


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

A couple of places where template is still using blank or recommende conditions outside of evaluators

## What is the new behavior?

blank/recommended preset only used in default evaluators
(needs https://github.com/unoplatform/uno.templates/pull/85 to be closed to pick up on cases used for test projects)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
