### PR TITLE
fix: Setting AssemblyName to ensure correct formating of dll (eg no spaces)

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.DataContracts/MyExtensionsApp._1.DataContracts.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.DataContracts/MyExtensionsApp._1.DataContracts.csproj
@@ -4,6 +4,7 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<!-- Suppress Compiler warnings for elements without XML Docs -->
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
+		<AssemblyName>MyExtensionsApp._1.DataContracts</AssemblyName>
 	</PropertyGroup>
 	<!--#if (includeIsExternalInit)-->
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
@@ -23,6 +23,7 @@
 		<!-- Required for C# Hot Reload -->
 		<UseInterpreter Condition="'$(Configuration)' == 'Debug' and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'maccatalyst'">True</UseInterpreter>
 		<IsUnoHead>true</IsUnoHead>
+		<AssemblyName>MyExtensionsApp._1.Mobile</AssemblyName>
 	</PropertyGroup>
 
 	<!--#if (useCPM)-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/MyExtensionsApp._1.Server.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/MyExtensionsApp._1.Server.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>$baseTargetFramework$</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
+		<AssemblyName>MyExtensionsApp._1.Server</AssemblyName>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
@@ -4,6 +4,7 @@
 		<OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
 		<TargetFramework>$baseTargetFramework$</TargetFramework>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
+		<AssemblyName>MyExtensionsApp._1.Skia.Gtk</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
 		<EmbeddedResource Include="Package.appxmanifest" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
@@ -3,6 +3,7 @@
 		<OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
 		<OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
 		<TargetFramework>$baseTargetFramework$</TargetFramework>
+		<AssemblyName>MyExtensionsApp._1.Skia.Linux.FrameBuffer</AssemblyName>		
 	</PropertyGroup>
 	<ItemGroup>
 		<EmbeddedResource Include="Package.appxmanifest" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
@@ -5,6 +5,7 @@
 		<TargetFramework>$baseTargetFramework$-windows</TargetFramework>
 		<UseWPF>true</UseWPF>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
+		<AssemblyName>MyExtensionsApp._1.Skia.WPF</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup Label="AssemblyInfo">
 		<AssemblyAttribute Include="System.Runtime.InteropServices.ComVisibleAttribute">

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>$baseTargetFramework$</TargetFramework>
 		<IsPackable>false</IsPackable>
+		<AssemblyName>MyExtensionsApp._1.Tests</AssemblyName>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/MyExtensionsApp._1.UITests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/MyExtensionsApp._1.UITests.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>$baseTargetFramework$</TargetFramework>
+		<AssemblyName>MyExtensionsApp._1.UITests</AssemblyName>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
@@ -9,6 +9,7 @@
 		<WasmPWAManifestFile>manifest.webmanifest</WasmPWAManifestFile>
 		<!--#endif -->
 		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<AssemblyName>MyExtensionsApp._1.Wasm</AssemblyName>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
 		<MonoRuntimeDebuggerEnabled>true</MonoRuntimeDebuggerEnabled>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
@@ -10,6 +10,7 @@
 		<PublishProfile>win10-$(Platform).pubxml</PublishProfile>
 		<UseWinUI>true</UseWinUI>
 		<EnableMsixTooling>true</EnableMsixTooling>
+		<AssemblyName>MyExtensionsApp._1.Windows</AssemblyName>
 	</PropertyGroup>
 	<PropertyGroup>
 		<!-- Bundles the WinAppSDK binaries (Uncomment for unpackaged builds) -->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -13,6 +13,7 @@
 
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
+		<AssemblyName>MyExtensionsApp._1</AssemblyName>
 	</PropertyGroup>
 
 	<!--#if (useCPM)-->


### PR DESCRIPTION
GitHub Issue (If applicable): closes #64

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Using a project name with spaces causes issues due to dlls containing spaces

## What is the new behavior?

Set assembly name to be "namespace" formatted (see https://github.com/dotnet/templating/wiki/Naming-and-default-value-forms)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
