### PR TITLE
chore: add note on why we remove the usings

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Build.targets
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.targets
@@ -1,5 +1,6 @@
 <Project>
-    <ItemGroup>
-        <Using Remove="@(Using->HasMetadata('Platform'))" />
-    </ItemGroup>
+	<ItemGroup>
+		<!-- Removes native usings to avoid Ambiguous reference -->
+		<Using Remove="@(Using->HasMetadata('Platform'))" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Other: Adds note to targets to indicate why we are removing global usings