### PR TITLE
Don't be evil: WarningsAsErrors sets people up for failure from the beginning

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -14,7 +14,6 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 		<!--#endif-->
 
-		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 		<NoWarn>$(NoWarn);CA1416;NU1507</NoWarn>
 
 		<DefaultLanguage>en</DefaultLanguage>


### PR DESCRIPTION
This default setting is just plain evil. When you start a new project, you're bound to have unused fields, a few null annotation issues etc as you get started. `TreatWarningsAsErrors` considerable reduces developer productivity and slows down the inner dev-loop.
I'm not saying it is a bad setting to have at some point, but it's almost never the right setting to have when you're starting up on a new project - and even then you might only set it in release builds or CI builds to keep the dev-loop fast.

I'm suggesting you remove this setting from the starter template. It's even hidden in a global directory.build.props file so it wasn't even immediately obvious why all these build errors kept happening.

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Template settings

-->

## What is the current behavior?

I almost never get to run my app because I'm not using a variable yet, or a null annotation hasn't completely been done right.


## What is the new behavior?

Look at me! I'm productive again!

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
