### PR TITLE
fix: Correct windows tooling options

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -20,6 +20,8 @@
     <!--#if (useWinAppSdk)-->
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <!-- Use previous version for unpackaged apps due to build issue https://github.com/microsoft/WindowsAppSDK/issues/3591 -->
+    <!-- <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.230313.1" /> -->    
     <!--#endif-->
     <!--#if (useAspNetCoreSerilogPackage)-->
     <PackageVersion Include="Serilog.AspNetCore" Version="6.1.0" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
@@ -12,6 +12,7 @@
 		<EnableMsixTooling>true</EnableMsixTooling>
 		<!-- Uncomment for Unpackaged builds -->
 		<!-- <WindowsPackageType>None</WindowsPackageType> -->
+    	<!-- For Unpackaged builds, change version of SDK to previous stable release https://github.com/microsoft/WindowsAppSDK/issues/3591 -->
 	</PropertyGroup>
 	<PropertyGroup>
 		<!-- Bundles the WinAppSDK binaries (Uncomment for unpackaged builds) -->
@@ -112,6 +113,8 @@
 		<PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
 		<PackageReference Include="Uno.WinUI" Version="$UnoWinUIPackageVersion$" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+		<!-- Use previous version for unpackaged apps due to build issue https://github.com/microsoft/WindowsAppSDK/issues/3591 -->
+		<!-- <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.230313.1" /> -->    
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
@@ -10,12 +10,13 @@
 		<PublishProfile>win10-$(Platform).pubxml</PublishProfile>
 		<UseWinUI>true</UseWinUI>
 		<EnableMsixTooling>true</EnableMsixTooling>
+		<!-- Uncomment for Unpackaged builds -->
+		<!-- <WindowsPackageType>None</WindowsPackageType> -->
 	</PropertyGroup>
 	<PropertyGroup>
 		<!-- Bundles the WinAppSDK binaries (Uncomment for unpackaged builds) -->
 		<!-- <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained> -->
-		<!-- This bundles the .NET Core libraries (Uncomment for packaged builds)  -->
-		<SelfContained>true</SelfContained>
+		<!-- <SelfContained>true</SelfContained> -->
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -213,6 +214,24 @@
 		<ProjectReference Include="..\MyExtensionsApp._1.DataContracts\MyExtensionsApp._1.DataContracts.csproj" />
 		<!--#endif-->
 	</ItemGroup>
+
+	<!-- 
+		Defining the "Msix" ProjectCapability here allows the Single-project MSIX Packaging
+		Tools extension to be activated for this project even if the Windows App SDK Nuget
+		package has not yet been restored.
+	-->
+	<ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
+		<ProjectCapability Include="Msix"/>
+	</ItemGroup>
+
+	<!-- 
+		Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution 
+		Explorer "Package and Publish" context menu entry to be enabled for this project even if 
+		the Windows App SDK Nuget package has not yet been restored.
+	-->
+	<PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
+		<HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
+	</PropertyGroup>
 
 	<Import Project="..\MyExtensionsApp._1.Base\base.props" />
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -197,6 +197,8 @@
 				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
 				<!--#else-->
 				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+				<!-- Use previous version for unpackaged apps due to build issue https://github.com/microsoft/WindowsAppSDK/issues/3591 -->
+				<!-- <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.230313.1" /> -->    
 				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
 				<!--#endif-->
 			</ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #102

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

VS complains if you try to run the Windows target without previously building it

## What is the new behavior?

VS already knows about running the MSIX, so no error on first run

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
