### PR TITLE
fix: Remove launch storyboard name

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/iOS/Info.plist
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/iOS/Info.plist
@@ -9,8 +9,6 @@
 			<integer>1</integer>
 			<integer>2</integer>
 		</array>
-		<key>UILaunchStoryboardName</key>
-		<string>LaunchScreen</string>
 		<key>UIRequiredDeviceCapabilities</key>
 		<array>
 			<string>armv7</string>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Storyboard referenced that doesn't exist

## What is the new behavior?

Should use Resizetizer generated storyboard

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
