### PR TITLE
fix: Icon not set on WinUI window

### DIFF
--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -15,7 +15,7 @@
 		<IsPackable Condition="'$(UNO_UWP_BUILD)'=='false'">false</IsPackable>
 		<NoWarn>$(NoWarn);NU5128</NoWarn>
 		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">2.4.0-dev.297</UnoExtensionsVersion>
-		<UnoVersion Condition="'$(UnoVersion)' == ''">4.9.0-dev.1029</UnoVersion>
+		<UnoVersion Condition="'$(UnoVersion)' == ''">4.9.0-dev.1113</UnoVersion>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -551,7 +551,7 @@
     "unoResizetizerVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "1.1.0-dev.92",
+      "defaultValue": "1.1.0-dev.98",
       "replaces": "$UnoResizetizerVersion$"
     },
     "unoUniversalImageLoaderVersion": {

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/AppHead.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/AppHead.xaml.cs
@@ -2,12 +2,9 @@
 #if (useLoggingFallback)
 using System;
 using Microsoft.Extensions.Logging;
-using Microsoft.UI.Xaml;
-
-#elif (useCsharpMarkup)
-using Microsoft.UI.Xaml;
-
 #endif
+using Microsoft.UI.Xaml;
+
 namespace MyExtensionsApp._1;
 
 public sealed partial class AppHead : App
@@ -25,7 +22,6 @@ public sealed partial class AppHead : App
 	{
 		this.InitializeComponent();
 	}
-#if useCsharpMarkup
 
 	/// <summary>
 	/// Invoked when the application is launched normally by the end user.  Other entry points
@@ -34,12 +30,15 @@ public sealed partial class AppHead : App
 	/// <param name="args">Details about the launch request and process.</param>
 	protected override void OnLaunched(LaunchActivatedEventArgs args)
 	{
+#if useCsharpMarkup
 		Resources.Build(r => r.Merged(
 			new AppResources()));
 
-		base.OnLaunched(args);
-	}
 #endif
+		base.OnLaunched(args);
+
+		SetWindowsIcon();
+	}
 #if (useLoggingFallback)
 
 	/// <summary>
@@ -113,4 +112,23 @@ public sealed partial class AppHead : App
 //+:cnd:noEmit
 	}
 #endif
+
+	private void SetWindowsIcon()
+	{
+//-:cnd:noEmit
+#if WINDOWS
+		var hWnd =
+			WinRT.Interop.WindowNative.GetWindowHandle(MainWindow);
+
+		// Retrieve the WindowId that corresponds to hWnd.
+		Microsoft.UI.WindowId windowId =
+        Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hWnd);
+
+		// Lastly, retrieve the AppWindow for the current (XAML) WinUI 3 window.
+		Microsoft.UI.Windowing.AppWindow appWindow =
+			Microsoft.UI.Windowing.AppWindow.GetFromWindowId(windowId);
+		appWindow.SetIcon("iconapp.ico");
+#endif
+//+:cnd:noEmit
+	}
 }

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/AppHead.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/AppHead.xaml.cs
@@ -117,17 +117,7 @@ public sealed partial class AppHead : App
 	{
 //-:cnd:noEmit
 #if WINDOWS
-		var hWnd =
-			WinRT.Interop.WindowNative.GetWindowHandle(MainWindow);
-
-		// Retrieve the WindowId that corresponds to hWnd.
-		Microsoft.UI.WindowId windowId =
-        Microsoft.UI.Win32Interop.GetWindowIdFromWindow(hWnd);
-
-		// Lastly, retrieve the AppWindow for the current (XAML) WinUI 3 window.
-		Microsoft.UI.Windowing.AppWindow appWindow =
-			Microsoft.UI.Windowing.AppWindow.GetFromWindowId(windowId);
-		appWindow.SetIcon("iconapp.ico");
+		Uno.Resizetizer.WindowExtensions.SetWindowIcon(MainWindow);
 #endif
 //+:cnd:noEmit
 	}

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/AppHead.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/AppHead.xaml.cs
@@ -4,6 +4,7 @@ using System;
 using Microsoft.Extensions.Logging;
 #endif
 using Microsoft.UI.Xaml;
+using Uno.Resizetizer;
 
 namespace MyExtensionsApp._1;
 
@@ -37,7 +38,7 @@ public sealed partial class AppHead : App
 #endif
 		base.OnLaunched(args);
 
-		SetWindowsIcon();
+		MainWindow.SetWindowIcon();
 	}
 #if (useLoggingFallback)
 
@@ -112,13 +113,4 @@ public sealed partial class AppHead : App
 //+:cnd:noEmit
 	}
 #endif
-
-	private void SetWindowsIcon()
-	{
-//-:cnd:noEmit
-#if WINDOWS
-		Uno.Resizetizer.WindowExtensions.SetWindowIcon(MainWindow);
-#endif
-//+:cnd:noEmit
-	}
 }

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -6,7 +6,7 @@ param(
     [string]$ExtensionsVersion = "2.4.0-dev.297",
 
     # Version of published Uno.WinUI packages
-    [string]$UnoVersion = "4.9.0-dev.1029"
+    [string]$UnoVersion = "4.9.0-dev.1113"
 )
 
 function RemoveNuGetPackage {


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.resizetizer#129

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Icon not set for WinUI

## What is the new behavior?

Icon set

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
