### PR TITLE
Enable Windows Targeting

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -23,6 +23,9 @@
 		<IsMac>false</IsMac>
 		<IsMacCatalyst>false</IsMacCatalyst>
 		<IsWinAppSdk>false</IsWinAppSdk>
+
+		<!-- This allows dotnet restore to work on macOS -->
+		<EnableWindowsTargeting>true</EnableWindowsTargeting>
 	</PropertyGroup>
 
 	<Choose>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<!--#if (useWinAppSdk) -->
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$baseTargetFramework$-windows10.0.19041</TargetFrameworks>
-		<TargetFrameworks>$(TargetFrameworks);$libraryBaseTargetFramework$;$mobileTargetFrameworks$</TargetFrameworks>
+		<TargetFrameworks>$baseTargetFramework$-windows10.0.19041;$libraryBaseTargetFramework$;$mobileTargetFrameworks$</TargetFrameworks>
 		<!--#else -->
 		<TargetFrameworks>$libraryBaseTargetFramework$;$mobileTargetFrameworks$</TargetFrameworks>
 		<!--#endif -->


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #111 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When creating a new project on macOS the solution will fail to restore because the property EnableWindowsTargeting is not set to true

## What is the new behavior?

The conditional arguments are removed from the common class library and we set EnableWindowsTargeting to true in the Directory.Build.props.