### PR TITLE
Opt out of tests with Recommended preset

### DIFF
--- a/build/.azure-pipelines.TemplateValidation.yml
+++ b/build/.azure-pipelines.TemplateValidation.yml
@@ -41,13 +41,15 @@ jobs:
         templateArgs: '-server false'
       NoServerNoHttp:
         templateArgs: '-server false -http false'
+      NoTests:
+        templateArgs: '-tests none'
       FrameNavigation:
         templateArgs: '--navigation blank'
       Net6:
         templateArgs: '-tfm net6.0'
       # https://github.com/unoplatform/uno.templates/issues/22
       Issue22:
-        templateArgs: '-preset blank -tfm net7.0 -platforms android -platforms ios -platforms maccatalyst -platforms macos -platforms windows -platforms wasm -platforms gtk -platforms wpf -platforms linux-fb -presentation mvvm -server false -tests `"`" -vscode false -pwa false -di true -nav regions -log none -theme material'
+        templateArgs: '-preset blank -tfm net7.0 -platforms android -platforms ios -platforms maccatalyst -platforms macos -platforms windows -platforms wasm -platforms gtk -platforms wpf -platforms linux-fb -presentation mvvm -server false -tests none -vscode false -pwa false -di true -nav regions -log none -theme material'
       CustomAuthMvux:
         templateArgs: '-preset=recommended -auth=custom'
       CustomAuthMvvm:

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -218,6 +218,11 @@
       "enableQuotelessLiterals": true,
       "choices": [
         {
+          "choice": "none",
+          "description": "Disable testing",
+          "displayName": "None"
+        },
+        {
           "choice": "unit",
           "description": "Include a project for authoring traditional unit tests",
           "displayName": "Unit Tests"
@@ -242,7 +247,7 @@
           },
           {
             "condition": "(preset == 'blank')",
-            "value": ""
+            "value": "none"
           }
         ]
       }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #88

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When passing `-tests ''` with the recommended preset the ui and unit test projects are still created


## What is the new behavior?

We are adding an explicit none option so that the fallback does not get confused by an empty string.

`-tests none` to disable tests