### PR TITLE
Dev/ds/mac windowshead restore

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1536,7 +1536,7 @@
     },
     "canWindowsRestore": {
       "type": "computed",
-      "value": "(HostIdentifier == \"dotnetcli\" && OS == \"Windows\")",
+      "value": "(OS == \"Windows\")",
       "datatype": "bool"
     }
   },

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1529,11 +1529,20 @@
     "HostIdentifier": {
       "type": "bind",
       "binding": "HostIdentifier"
+    },
+    "OS": {
+      "type": "bind",
+      "binding": "OS"
+    },
+    "canWindowsRestore": {
+      "type": "computed",
+      "value": "(HostIdentifier == \"dotnetcli\" && OS == \"Windows\")",
+      "datatype": "bool"
     }
   },
   "primaryOutputs": [
     {
-      "condition": "!isVsix",
+      "condition": "!isVsix && canWindowsRestore",
       "path": "MyExtensionsApp._1.sln"
     },
     {
@@ -1564,7 +1573,7 @@
       "path": "MyExtensionsApp._1.Mobile\\MyExtensionsApp._1.Mobile.csproj"
     },
     {
-      "condition": "useWinAppSdk",
+      "condition": "useWinAppSdk && canWindowsRestore",
       "path": "MyExtensionsApp._1.Windows\\MyExtensionsApp._1.Windows.csproj"
     },
     {

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -34,5 +34,7 @@ if($LASTEXITCODE -ne 0) {
     Write-Error "Building NuGet Package failed."
     exit $LASTEXITCODE
 }
-dotnet new install $PSScriptRoot\bin\Release\Uno.Templates.$TemplatesVersion.nupkg
+
+$nugetPath = Join-Path -Path $PSScriptRoot -ChildPath 'bin' -AdditionalChildPath @('Release',"Uno.Templates.$TemplatesVersion.nupkg") 
+dotnet new install $nugetPath
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- replaces #112 
- closes #111 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When creating a solution on macOS the automatic restore attempts to restore the Windows head if created and results in an error

## What is the new behavior?

When creating a solution on macOS the automatic restore will ignore the solution file and Windows head to avoid the restore error.
