### PR TITLE
chore: update from deprecated FrameworkReference Update

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -186,24 +186,7 @@
 	<!--#if (useWinAppSdk) -->
 	<Choose>
 		<When Condition="$(IsWinAppSdk)">
-			<!--#if (useMsalAuthentication)-->
 			<PropertyGroup>
-				<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
-			</PropertyGroup>
-			<!--#endif-->
-			<ItemGroup>
-				<!--#if (useCPM)-->
-				<PackageReference Include="Microsoft.WindowsAppSDK" />
-				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
-				<!--#else-->
-				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
-				<!-- Use previous version for unpackaged apps due to build issue https://github.com/microsoft/WindowsAppSDK/issues/3591 -->
-				<!-- <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.230313.1" /> -->    
-				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
-				<!--#endif-->
-			</ItemGroup>
-
-			<ItemGroup>
 				<!--
 				If you encounter this error message:
 
@@ -214,8 +197,21 @@
 				the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
 				must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
 				-->
-				<!-- <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" />
-				<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" /> -->
+				<!-- <WindowsSdkPackageVersion>10.0.22621.28</WindowsSdkPackageVersion> -->
+				<!--#if (useMsalAuthentication)-->
+				<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+				<!--#endif-->
+			</PropertyGroup>
+			<ItemGroup>
+				<!--#if (useCPM)-->
+				<PackageReference Include="Microsoft.WindowsAppSDK" />
+				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
+				<!--#else-->
+				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+				<!-- Use previous version for unpackaged apps due to build issue https://github.com/microsoft/WindowsAppSDK/issues/3591 -->
+				<!-- <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.230313.1" /> -->    
+				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
+				<!--#endif-->
 			</ItemGroup>
 		</When>
 		<Otherwise>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #72

## PR Type

What kind of change does this PR introduce?

- Refactoring

## What is the current behavior?

We provide a commented out block with a FrameworkReference Update should a developer encounter an error due to the version of the WinAppSdk that a dependency was built against create the need to specify it.


## What is the new behavior?

This has been replaced by the updated WindowsSdkPackageVersion property. This is also commented out and we are maintaining the same code comment block to indicate when developers may need it.

https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/5.0/override-windows-sdk-package-version#previous-behavior