### PR TITLE
Rename Window as public property

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.blank.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.blank.cs
@@ -3,7 +3,7 @@ namespace MyExtensionsApp._1;
 
 public class App : Application
 {
-	public static Window? MainWindow { get; private set; }
+	protected Window? MainWindow { get; private set; }
 
 	protected override void OnLaunched(LaunchActivatedEventArgs args)
 	{

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.blank.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.blank.cs
@@ -3,25 +3,25 @@ namespace MyExtensionsApp._1;
 
 public class App : Application
 {
-	public static Window? AppWindow { get; private set; }
+	public static Window? MainWindow { get; private set; }
 
 	protected override void OnLaunched(LaunchActivatedEventArgs args)
 	{
 #if NET6_0_OR_GREATER && WINDOWS && !HAS_UNO
-		AppWindow = new Window();
+		MainWindow = new Window();
 #else
-		AppWindow = Microsoft.UI.Xaml.Window.Current;
+		MainWindow = Microsoft.UI.Xaml.Window.Current;
 #endif
 
 		// Do not repeat app initialization when the Window already has content,
 		// just ensure that the window is active
-		if (AppWindow.Content is not Frame rootFrame)
+		if (MainWindow.Content is not Frame rootFrame)
 		{
 			// Create a Frame to act as the navigation context and navigate to the first page
 			rootFrame = new Frame();
 
 			// Place the frame in the current Window
-			AppWindow.Content = rootFrame;
+			MainWindow.Content = rootFrame;
 
 			rootFrame.NavigationFailed += OnNavigationFailed;
 		}
@@ -35,7 +35,7 @@ public class App : Application
 		}
 
 		// Ensure the current window is active
-		AppWindow.Activate();
+		MainWindow.Activate();
 	}
 
 	/// <summary>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.blank.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.blank.cs
@@ -3,25 +3,25 @@ namespace MyExtensionsApp._1;
 
 public class App : Application
 {
-	public static Window? _window;
+	public static Window? AppWindow { get; private set; }
 
 	protected override void OnLaunched(LaunchActivatedEventArgs args)
 	{
 #if NET6_0_OR_GREATER && WINDOWS && !HAS_UNO
-		_window = new Window();
+		AppWindow = new Window();
 #else
-		_window = Microsoft.UI.Xaml.Window.Current;
+		AppWindow = Microsoft.UI.Xaml.Window.Current;
 #endif
 
 		// Do not repeat app initialization when the Window already has content,
 		// just ensure that the window is active
-		if (_window.Content is not Frame rootFrame)
+		if (AppWindow.Content is not Frame rootFrame)
 		{
 			// Create a Frame to act as the navigation context and navigate to the first page
 			rootFrame = new Frame();
 
 			// Place the frame in the current Window
-			_window.Content = rootFrame;
+			AppWindow.Content = rootFrame;
 
 			rootFrame.NavigationFailed += OnNavigationFailed;
 		}
@@ -35,7 +35,7 @@ public class App : Application
 		}
 
 		// Ensure the current window is active
-		_window.Activate();
+		AppWindow.Activate();
 	}
 
 	/// <summary>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.recommended.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.recommended.cs
@@ -3,7 +3,7 @@ namespace MyExtensionsApp._1;
 
 public class App : Application
 {
-	public static Window? AppWindow { get; private set; }
+	public static Window? MainWindow { get; private set; }
 	public static IHost? Host { get; private set; }
 
 //+:cnd:noEmit
@@ -125,7 +125,7 @@ public class App : Application
 				.UseNavigation(RegisterRoutes)
 #endif
 			);
-		AppWindow = builder.Window;
+		MainWindow = builder.Window;
 
 #if useFrameNav
 //-:cnd:noEmit
@@ -133,13 +133,13 @@ public class App : Application
 
 		// Do not repeat app initialization when the Window already has content,
 		// just ensure that the window is active
-		if (AppWindow.Content is not Frame rootFrame)
+		if (MainWindow.Content is not Frame rootFrame)
 		{
 			// Create a Frame to act as the navigation context and navigate to the first page
 			rootFrame = new Frame();
 
 			// Place the frame in the current Window
-			AppWindow.Content = rootFrame;
+			MainWindow.Content = rootFrame;
 		}
 
 		if (rootFrame.Content == null)
@@ -150,7 +150,7 @@ public class App : Application
 			rootFrame.Navigate(typeof(MainPage), args.Arguments);
 		}
 		// Ensure the current window is active
-		AppWindow.Activate();
+		MainWindow.Activate();
 //+:cnd:noEmit
 #elif (!useAuthentication)
 		Host = await builder.NavigateAsync<Shell>();

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.recommended.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.recommended.cs
@@ -3,8 +3,8 @@ namespace MyExtensionsApp._1;
 
 public class App : Application
 {
-	public static Window? MainWindow { get; private set; }
-	public static IHost? Host { get; private set; }
+	protected Window? MainWindow { get; private set; }
+	protected IHost? Host { get; private set; }
 
 //+:cnd:noEmit
 #if useFrameNav

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.recommended.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.recommended.cs
@@ -3,7 +3,7 @@ namespace MyExtensionsApp._1;
 
 public class App : Application
 {
-	private static Window? _window;
+	public static Window? AppWindow { get; private set; }
 	public static IHost? Host { get; private set; }
 
 //+:cnd:noEmit
@@ -125,7 +125,7 @@ public class App : Application
 				.UseNavigation(RegisterRoutes)
 #endif
 			);
-		_window = builder.Window;
+		AppWindow = builder.Window;
 
 #if useFrameNav
 //-:cnd:noEmit
@@ -133,13 +133,13 @@ public class App : Application
 
 		// Do not repeat app initialization when the Window already has content,
 		// just ensure that the window is active
-		if (_window.Content is not Frame rootFrame)
+		if (AppWindow.Content is not Frame rootFrame)
 		{
 			// Create a Frame to act as the navigation context and navigate to the first page
 			rootFrame = new Frame();
 
 			// Place the frame in the current Window
-			_window.Content = rootFrame;
+			AppWindow.Content = rootFrame;
 		}
 
 		if (rootFrame.Content == null)
@@ -150,7 +150,7 @@ public class App : Application
 			rootFrame.Navigate(typeof(MainPage), args.Arguments);
 		}
 		// Ensure the current window is active
-		_window.Activate();
+		AppWindow.Activate();
 //+:cnd:noEmit
 #elif (!useAuthentication)
 		Host = await builder.NavigateAsync<Shell>();


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #120

## PR Type

What kind of change does this PR introduce?

- Refactoring 

## What is the current behavior?

The visibility of the `_window` property is inconsistent depending on whether you are creating a blank or recommended app.

## What is the new behavior?

The visibility is normalized as public with a private setter and the property has been renamed to be consistent with coding standard for a public property.