### PR TITLE
Remove nowarn for xml comments

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.DataContracts/MyExtensionsApp._1.DataContracts.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.DataContracts/MyExtensionsApp._1.DataContracts.csproj
@@ -2,8 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>$libraryBaseTargetFramework$</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<!-- Suppress Compiler warnings for elements without XML Docs -->
-		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 	<!--#if (includeIsExternalInit)-->
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.DataContracts/Serialization/WeatherForecastContext.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.DataContracts/Serialization/WeatherForecastContext.cs
@@ -3,13 +3,16 @@ using System.Text.Json.Serialization;
 
 namespace MyExtensionsApp._1.DataContracts.Serialization;
 
-/*
- * When using the JsonSerializerContext you must add the JsonSerializableAttribute
- * for each type that you may need to serialize / deserialize including both the
- * concrete type and any interface that the concrete type implements.
- * For more information on the JsonSerializerContext see:
- * https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation?WT.mc_id=DT-MVP-5002924
- */
+/// <summary>
+/// Generated class for System.Text.Json Serialization
+/// </summary>
+/// <remarks>
+/// When using the JsonSerializerContext you must add the JsonSerializableAttribute
+/// for each type that you may need to serialize / deserialize including both the
+/// concrete type and any interface that the concrete type implements.
+/// For more information on the JsonSerializerContext see:
+/// https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation?WT.mc_id=DT-MVP-5002924
+/// </remarks>
 [JsonSerializable(typeof(WeatherForecast))]
 [JsonSerializable(typeof(WeatherForecast[]))]
 [JsonSerializable(typeof(IEnumerable<WeatherForecast>))]

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/Apis/WeatherForecastApi.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/Apis/WeatherForecastApi.cs
@@ -1,6 +1,6 @@
 namespace MyExtensionsApp._1.Server.Apis;
 
-public static class WeatherForecastApi
+internal static class WeatherForecastApi
 {
 	private const string Tag = "Weather";
 	private static readonly string[] Summaries = new[]
@@ -8,7 +8,7 @@ public static class WeatherForecastApi
 		"Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
 	};
 
-	public static WebApplication MapWeatherApi(this WebApplication app)
+	internal static WebApplication MapWeatherApi(this WebApplication app)
 	{
 		app.MapGet("/api/weatherforecast", GetForecast)
 			.WithTags(Tag)

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/MyExtensionsApp._1.Server.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/MyExtensionsApp._1.Server.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<TargetFramework>$baseTargetFramework$</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #38 

## PR Type

What kind of change does this PR introduce?

- Refactoring

## What is the current behavior?

We disable CS1591 in the DataContracts and Server so that we do not annoy developers who are not adding XML docs to everything while enabling full swagger docs from the generated template

## What is the new behavior?

Making the minimal API extensions internal to avoid issues with requiring XML docs, and adding a comment to the Serialization Context in the DataContracts. The NoWarn has been removed from both projects.