### PR TITLE
Move runtime identifier to the Mobile head only

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -36,21 +36,18 @@
 			<PropertyGroup>
 				<IsIOS>true</IsIOS>
 				<SupportedOSPlatformVersion>14.2</SupportedOSPlatformVersion>
-				<RuntimeIdentifier Condition="'$(RuntimeIdentifier)'==''">iossimulator-x64</RuntimeIdentifier>
 			</PropertyGroup>
 		</When>
 		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'">
 			<PropertyGroup>
 				<IsMac>true</IsMac>
 				<SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
-				<RuntimeIdentifier Condition="'$(RuntimeIdentifier)'==''">osx-x64</RuntimeIdentifier>
 			</PropertyGroup>
 		</When>
 		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
 			<PropertyGroup>
 				<IsMacCatalyst>true</IsMacCatalyst>
 				<SupportedOSPlatformVersion>14.0</SupportedOSPlatformVersion>
-				<RuntimeIdentifier Condition="'$(RuntimeIdentifier)'==''">maccatalyst-x64</RuntimeIdentifier>
 			</PropertyGroup>
 		</When>
 		<When Condition="$(TargetFramework.Contains('windows10'))">

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
@@ -214,6 +214,7 @@
 				<MtouchExtraArgs>$(MtouchExtraArgs) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
 				<!-- See https://github.com/unoplatform/uno/issues/9430 for more details. -->
 				<MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
+				<RuntimeIdentifier Condition="'$(RuntimeIdentifier)'==''">iossimulator-x64</RuntimeIdentifier>
 			</PropertyGroup>
 			<PropertyGroup Condition="'$(Configuration)'=='Release'">
 				<!-- https://github.com/xamarin/xamarin-macios/issues/14812 -->
@@ -230,6 +231,7 @@
 				<MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
 				<!-- Full globalization is required for Uno -->
 				<InvariantGlobalization>false</InvariantGlobalization>
+				<RuntimeIdentifier Condition="'$(RuntimeIdentifier)'==''">maccatalyst-x64</RuntimeIdentifier>
 			</PropertyGroup>
 			<PropertyGroup Condition="'$(Configuration)'=='Release'">
 				<!-- https://github.com/xamarin/xamarin-macios/issues/14812 -->
@@ -241,6 +243,7 @@
 		<When Condition="$(IsMac)">
 			<PropertyGroup>
 				<TrimMode Condition="'$(Configuration)'=='Release'">link</TrimMode>
+				<RuntimeIdentifier Condition="'$(RuntimeIdentifier)'==''">osx-x64</RuntimeIdentifier>
 			</PropertyGroup>
 		</When>
 		<!--#endif-->


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/12281

- n/a

## PR Type

What kind of change does this PR introduce?

- Refactoring

## What is the current behavior?

The Runtime Identifier is set at the Directory.Build.props if not set, which will affect the common library as well

## What is the new behavior?

We now only set this on the Mobile head.
