### PR TITLE
Remove unnecessary property

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -8,7 +8,6 @@
 
 		<DebugType>portable</DebugType>
 		<DebugSymbols>True</DebugSymbols>
-		<SynthesizeLinkMetadata>true</SynthesizeLinkMetadata>
 		<!--#if (cpm)-->
 
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #126 

## PR Type

What kind of change does this PR introduce?

- Refactoring

## What is the current behavior?

We add the value for SynthizeLinks in the Directory.Build.props which was necessary for the Shared Projects which we no longer use.

## What is the new behavior?

Because the property is no longer needed we are removing it from the Directory.Build.props

verified ok to remove with @jeromelaban 