### PR TITLE
Cannot add mvvm with blank template

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -210,6 +210,11 @@
       "datatype": "choice",
       "choices": [
         {
+          "choice": "none",
+          "description": "No additional presentation framework",
+          "displayName": "None"
+        },
+        {
           "choice": "mvvm",
           "description": "Use the Model-View-ViewModel (MVVM) design pattern",
           "displayName": "MVVM"
@@ -923,7 +928,7 @@
           },
           {
             "condition": "(preset == 'blank')",
-            "value": "mvvm"
+            "value": "none"
           }
         ]
       }
@@ -944,7 +949,7 @@
     "useMvvm": {
       "type": "computed",
       "datatype": "bool",
-      "value": "architectureEvaluator == 'mvvm' && useExtensionsNavigation"
+      "value": "architectureEvaluator == 'mvvm' || (architectureEvaluator == 'none' && useExtensionsNavigation)"
     },
     "useGtk": {
       "type": "computed",


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- #136 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When creating a blank template CommunityToolkit.Mvvm is not added even when it is specifically specified as an argument

## What is the new behavior?

When creating a blank template neither CommunityToolkit.Mvvm or Uno.Extensions.Reactive will be automatically added. You can now specify `mvvm` to get CommunityToolkit.Mvvm with the blank preset. You can also now specify `none` from the recommended preset if you do not have Extensions Navigation enabled. If you do have Extensions Navigation then it will default back to Mvvm.