### PR TITLE
feat: Adding script files for launching

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1751,19 +1751,22 @@
         {
           "condition": "(!useMobile)",
           "exclude": [
-            "MyExtensionsApp._1.Mobile/**/*"
+            "MyExtensionsApp._1.Mobile/**/*",
+            "MyExtensionsApp._1-mobile.slnf"
           ]
         },
         {
           "condition": "(!useWasm)",
           "exclude": [
-            "MyExtensionsApp._1.Wasm**/*"
+            "MyExtensionsApp._1.Wasm**/*",
+            "MyExtensionsApp._1-wasm.slnf"
           ]
         },
         {
           "condition": "(!useGtk)",
           "exclude": [
-            "MyExtensionsApp._1.Skia.Gtk/**/*"
+            "MyExtensionsApp._1.Skia.Gtk/**/*",
+            "MyExtensionsApp._1-gtk.slnf"
           ]
         },
         {
@@ -1781,7 +1784,9 @@
         {
           "condition": "(!useWinAppSdk)",
           "exclude": [
-            "MyExtensionsApp._1.Windows/**/*"
+            "MyExtensionsApp._1.Windows/**/*",
+            "MyExtensionsApp._1-windows.slnf",
+            "debug-windows.bat"
           ]
         },
         {

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1-gtk.slnf
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1-gtk.slnf
@@ -1,0 +1,18 @@
+{
+  "solution": {
+    "path": "MyExtensionsApp._1.sln",
+    "projects": [
+#//#if (useUnitTests)
+      "MyExtensionsApp._1.Tests\\MyExtensionsApp._1.Tests.csproj",
+#//#endif
+#//#if (useUITests)
+      "MyExtensionsApp._1.UITests\\MyExtensionsApp._1.UITests.csproj",
+#//#endif
+      "MyExtensionsApp._1.Skia.Gtk\\MyExtensionsApp._1.Skia.Gtk.csproj",
+#//#if (useDataContracts)
+      "MyExtensionsApp._1.DataContracts\\MyExtensionsApp._1.DataContracts.csproj",
+#//#endif
+      "MyExtensionsApp._1\\MyExtensionsApp._1.csproj"
+    ]
+  }
+}

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1-mobile.slnf
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1-mobile.slnf
@@ -1,0 +1,18 @@
+{
+  "solution": {
+    "path": "MyExtensionsApp._1.sln",
+    "projects": [
+#//#if (useUnitTests)
+      "MyExtensionsApp._1.Tests\\MyExtensionsApp._1.Tests.csproj",
+#//#endif
+#//#if (useUITests)
+      "MyExtensionsApp._1.UITests\\MyExtensionsApp._1.UITests.csproj",
+#//#endif
+      "MyExtensionsApp._1.Mobile\\MyExtensionsApp._1.Mobile.csproj",
+#//#if (useDataContracts)
+      "MyExtensionsApp._1.DataContracts\\MyExtensionsApp._1.DataContracts.csproj",
+#//#endif
+      "MyExtensionsApp._1\\MyExtensionsApp._1.csproj"
+    ]
+  }
+}

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1-wasm.slnf
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1-wasm.slnf
@@ -1,0 +1,21 @@
+{
+  "solution": {
+    "path": "MyExtensionsApp._1.sln",
+    "projects": [
+#//#if (useUnitTests)
+      "MyExtensionsApp._1.Tests\\MyExtensionsApp._1.Tests.csproj",
+#//#endif
+#//#if (useUITests)
+      "MyExtensionsApp._1.UITests\\MyExtensionsApp._1.UITests.csproj",
+#//#endif
+      "MyExtensionsApp._1.Wasm\\MyExtensionsApp._1.Wasm.csproj",
+#//#if (server)
+      "MyExtensionsApp._1.Server\\MyExtensionsApp._1.Server.csproj",
+#//#endif
+#//#if (useDataContracts)
+      "MyExtensionsApp._1.DataContracts\\MyExtensionsApp._1.DataContracts.csproj",
+#//#endif
+      "MyExtensionsApp._1\\MyExtensionsApp._1.csproj"
+    ]
+  }
+}

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1-windows.slnf
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1-windows.slnf
@@ -1,0 +1,18 @@
+{
+  "solution": {
+    "path": "MyExtensionsApp._1.sln",
+    "projects": [
+#//#if (useUnitTests)
+      "MyExtensionsApp._1.Tests\\MyExtensionsApp._1.Tests.csproj",
+#//#endif
+#//#if (useUITests)
+      "MyExtensionsApp._1.UITests\\MyExtensionsApp._1.UITests.csproj",
+#//#endif
+      "MyExtensionsApp._1.Windows\\MyExtensionsApp._1.Windows.csproj",
+#//#if (useDataContracts)
+      "MyExtensionsApp._1.DataContracts\\MyExtensionsApp._1.DataContracts.csproj",
+#//#endif
+      "MyExtensionsApp._1\\MyExtensionsApp._1.csproj"
+    ]
+  }
+}

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>$mobileTargetFrameworks$</TargetFrameworks>
+		<TargetFrameworks Condition="'$(MobileOverrideTargetFrameworks)'!=''">$(MobileOverrideTargetFrameworks)</TargetFrameworks>
+		<TargetFrameworks Condition="'$(MobileOverrideTargetFrameworks)'==''">$mobileTargetFrameworks$</TargetFrameworks>
 		<!--#if (useMacOS)-->
 		<!-- Disabled because of https://github.com/xamarin/xamarin-macios/issues/16401-->
 		<!-- <TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$-macos</TargetFrameworks> -->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
+		<TargetFrameworks Condition="'$(OverrideTargetFrameworks)'!=''">$(OverrideTargetFrameworks)</TargetFrameworks>
 		<!--#if (useWinAppSdk) -->
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$baseTargetFramework$-windows10.0.19041</TargetFrameworks>
-		<TargetFrameworks>$(TargetFrameworks);$libraryBaseTargetFramework$;$mobileTargetFrameworks$</TargetFrameworks>
+		<TargetFrameworks Condition="'$(OverrideTargetFrameworks)'=='' and $([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$baseTargetFramework$-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks Condition="'$(OverrideTargetFrameworks)'==''">$(TargetFrameworks);$libraryBaseTargetFramework$;$mobileTargetFrameworks$</TargetFrameworks>
 		<!--#else -->
-		<TargetFrameworks>$libraryBaseTargetFramework$;$mobileTargetFrameworks$</TargetFrameworks>
+		<TargetFrameworks Condition="'$(OverrideTargetFrameworks)'==''">$libraryBaseTargetFramework$;$mobileTargetFrameworks$</TargetFrameworks>
 		<!--#endif -->
 		<!--#if (useMacOS)-->
 		<!-- Disabled because of https://github.com/xamarin/xamarin-macios/issues/16401-->

--- a/src/Uno.Templates/content/unoapp/debug-android.bat
+++ b/src/Uno.Templates/content/unoapp/debug-android.bat
@@ -1,0 +1,17 @@
+@echo off
+
+echo Setting target framework
+Set OverrideTargetFrameworks=$baseTargetFramework$;$baseTargetFramework$-android
+Set MobileOverrideTargetFrameworks=$baseTargetFramework$-android
+
+echo Cleaning up obj and bin folders
+for /f %%i in ('dir /s /b obj') do ( rmdir /s /q "%%i" )
+for /f %%i in ('dir /s /b bin') do ( rmdir /s /q "%%i" )
+
+echo Restoring packages
+dotnet restore MyExtensionsApp._1-mobile.slnf -v q
+
+if (%1) == () (
+    echo No arguments passed, launching solution
+    MyExtensionsApp._1-mobile.slnf
+) 

--- a/src/Uno.Templates/content/unoapp/debug-gtk.bat
+++ b/src/Uno.Templates/content/unoapp/debug-gtk.bat
@@ -1,0 +1,16 @@
+@echo off
+
+echo Setting target framework
+Set OverrideTargetFrameworks=$baseTargetFramework$
+
+echo Cleaning up obj and bin folders
+for /f %%i in ('dir /s /b obj') do ( rmdir /s /q "%%i" )
+for /f %%i in ('dir /s /b bin') do ( rmdir /s /q "%%i" )
+
+echo Restoring packages
+dotnet restore MyExtensionsApp._1-gtk.slnf -v q
+
+if (%1) == () (
+    echo No arguments passed, launching solution
+    MyExtensionsApp._1-gtk.slnf
+) 

--- a/src/Uno.Templates/content/unoapp/debug-ios.bat
+++ b/src/Uno.Templates/content/unoapp/debug-ios.bat
@@ -1,0 +1,17 @@
+@echo off
+
+echo Setting target framework
+Set OverrideTargetFrameworks=$baseTargetFramework$;$baseTargetFramework$-ios
+Set MobileOverrideTargetFrameworks=$baseTargetFramework$-ios
+
+echo Cleaning up obj and bin folders
+for /f %%i in ('dir /s /b obj') do ( rmdir /s /q "%%i" )
+for /f %%i in ('dir /s /b bin') do ( rmdir /s /q "%%i" )
+
+echo Restoring packages
+dotnet restore MyExtensionsApp._1-mobile.slnf -v q
+
+if (%1) == () (
+    echo No arguments passed, launching solution
+    MyExtensionsApp._1-mobile.slnf
+) 

--- a/src/Uno.Templates/content/unoapp/debug-wasm.bat
+++ b/src/Uno.Templates/content/unoapp/debug-wasm.bat
@@ -1,0 +1,16 @@
+@echo off
+
+echo Setting target framework
+Set OverrideTargetFrameworks=$baseTargetFramework$
+
+echo Cleaning up obj and bin folders
+for /f %%i in ('dir /s /b obj') do ( rmdir /s /q "%%i" )
+for /f %%i in ('dir /s /b bin') do ( rmdir /s /q "%%i" )
+
+echo Restoring packages
+dotnet restore MyExtensionsApp._1-wasm.slnf -v q
+
+if (%1) == () (
+    echo No arguments passed, launching solution
+    MyExtensionsApp._1-wasm.slnf
+) 

--- a/src/Uno.Templates/content/unoapp/debug-windows.bat
+++ b/src/Uno.Templates/content/unoapp/debug-windows.bat
@@ -1,0 +1,16 @@
+@echo off
+
+echo Setting target framework
+Set OverrideTargetFrameworks=$baseTargetFramework$;$baseTargetFramework$-windows10.0.19041.0
+
+echo Cleaning up obj and bin folders
+for /f %%i in ('dir /s /b obj') do ( rmdir /s /q "%%i" )
+for /f %%i in ('dir /s /b bin') do ( rmdir /s /q "%%i" )
+
+echo Restoring packages
+dotnet restore MyExtensionsApp._1-windows.slnf -v q
+
+if (%1) == () (
+    echo No arguments passed, launching solution
+    MyExtensionsApp._1-windows.slnf
+) 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

No way to restrict which tfms are loaded and built when opening solution

## What is the new behavior?

Solution filters for Mobile, Wasm, Gtk and Windows
OverrideTargetFrameworks can be specified as environmental (or msbuild) value to limit which targets are built for the class library
MobileOverrideTargetFrameworks is required to limit the tfms for the mobile project
debug-xxxx.bat script files are available for setting environmental variables, clearing obj/bin folders, doing a restore and launching the appropriate solution filter.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
