### PR TITLE
Enable single target builds

### DIFF
--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -47,6 +47,15 @@
 
 		<RemoveDir Directories="$(TemplateContentFolder)" />
 
+		<!-- Ensure we keep the .gitignore up to date with the latest changes to the official VisualStudio.gitignore -->
+		<DownloadFile
+			DestinationFolder="$(TemplateContentFolder)/unoapp" 
+			DestinationFileName=".gitignore" 
+			SourceUrl="https://raw.githubusercontent.com/github/gitignore/main/VisualStudio.gitignore" />
+
+		<!-- Add our custom ignore for Single TFM targeting -->
+		<AppendSingleTargetIgnore Filename="$(TemplateContentFolder)/unoapp/.gitignore" />
+
 		<Copy SourceFiles="@(TemplateFile)" DestinationFiles="$(TemplateContentFolder)/%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="false" />
 		<Copy SourceFiles="content/unoapp/MyExtensionsApp._1.DataContracts/WeatherForecast.cs" DestinationFiles="$(TemplateContentFolder)/unoapp/MyExtensionsApp._1.Server/WeatherForecast.cs" SkipUnchangedFiles="false" />
 		<Copy SourceFiles="content/unoapp/MyExtensionsApp._1.Windows/Package.appxmanifest" DestinationFiles="$(TemplateContentFolder)/unoapp/MyExtensionsApp._1.Skia.Gtk/Package.appxmanifest" SkipUnchangedFiles="false" />
@@ -117,6 +126,24 @@
 			<TemplateFile Include="$(TemplateUnzipFolder)/content/**/*" Exclude="@(_ExternalTemplateExcludes)" />
 		</ItemGroup>
 	</Target>
+
+	<UsingTask TaskName="AppendSingleTargetIgnore" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+		<ParameterGroup>
+			<Filename ParameterType="System.String" Required="true" />
+		</ParameterGroup>
+		<Task>
+			<Using Namespace="System" />
+			<Using Namespace="System.IO" />
+			<Code Type="Fragment" Language="cs">
+				<![CDATA[
+					File.AppendAllText(
+						Filename,
+						Environment.NewLine + "# Single Target Config" + Environment.NewLine + "solution-config.props"
+						);
+				]]>
+			</Code>
+		</Task>
+	</UsingTask>
 
 	<!-- Using Regex Replace prevents XmlPoke from replacing Tabs with Spaces -->
 	<UsingTask TaskName="ReplaceFileText" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -138,7 +138,8 @@
 				<![CDATA[
 					File.AppendAllText(
 						Filename,
-						Environment.NewLine + "# Single Target Config" + Environment.NewLine + "solution-config.props"
+						Environment.NewLine + "# Single Target Config" + Environment.NewLine + "solution-config.props" +
+						Environment.NewLine + "# Windows Publish Profiles" + Environment.NewLine + "!**/*.Windows/Properties/PublishProfiles/*.pubxml" 
 						);
 				]]>
 			</Code>

--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -1,4 +1,17 @@
 <Project>
+
+	<!--
+		If working on a single target framework, uncomment the following line to
+		adjust an Uno Solution for a faster build with Visual Studio 2022. Be sure to remove the 
+		`.sample` extension from `solution-config.props.sample`, and update the file with the Target
+		Framework you want to target. See the following article for more information:
+
+		https://platform.uno/docs/articles/guides/solution-building-single-targetframework.html 
+	-->
+	<!--
+	<Import Project="solution-config.props" Condition="exists('solution-config.props')" />
+	-->
+
 	<PropertyGroup>
 		<!--#if (useLangVersion)-->
 		<LangVersion>10</LangVersion>
@@ -57,4 +70,5 @@
 			</PropertyGroup>
 		</When>
 	</Choose>
+
 </Project>

--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -1,16 +1,13 @@
 <Project>
 
 	<!--
-		If working on a single target framework, uncomment the following line to
-		adjust an Uno Solution for a faster build with Visual Studio 2022. Be sure to remove the 
-		`.sample` extension from `solution-config.props.sample`, and update the file with the Target
-		Framework you want to target. See the following article for more information:
+		If working on a single target framework, copy solution-config.props.sample to solution-config.props
+		and uncomment the appropriate lines in solution-config.props to build for the desired platforms only.
 
 		https://platform.uno/docs/articles/guides/solution-building-single-targetframework.html 
 	-->
-	<!--
 	<Import Project="solution-config.props" Condition="exists('solution-config.props')" />
-	-->
+	
 
 	<PropertyGroup>
 		<!--#if (useLangVersion)-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
@@ -5,6 +5,7 @@
 		<!-- Disabled because of https://github.com/xamarin/xamarin-macios/issues/16401-->
 		<!-- <TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$-macos</TargetFrameworks> -->
 		<!--#endif-->
+		<TargetFrameworks Condition="'$(OverrideTargetFrameworks)'!=''">$(OverrideTargetFrameworks)</TargetFrameworks>
 		<SingleProject>true</SingleProject>
 		<OutputType>Exe</OutputType>
 		<!-- Display name -->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.sln
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.sln
@@ -61,6 +61,8 @@ EndProject
 
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BADA71DC-7FFD-4EDC-9F28-FB74AEADC713}"
 	ProjectSection(SolutionItems) = preProject
+		solution-config.props.sample = solution-config.props.sample
+		.gitignore = .gitignore
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 #//#if (cpm)

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -10,6 +10,7 @@
 		<!-- Disabled because of https://github.com/xamarin/xamarin-macios/issues/16401-->
 		<!--<TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$-macos</TargetFrameworks>-->
 		<!--#endif -->
+		<TargetFrameworks Condition="'$(OverrideTargetFrameworks)'!=''">$(OverrideTargetFrameworks)</TargetFrameworks>
 
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>

--- a/src/Uno.Templates/content/unoapp/solution-config.props.sample
+++ b/src/Uno.Templates/content/unoapp/solution-config.props.sample
@@ -1,0 +1,7 @@
+<Project>
+
+    <PropertyGroup>
+        <OverrideTargetFrameworks>$baseTargetFramework$-ios</OverrideTargetFrameworks>
+    </PropertyGroup>
+
+</Project>

--- a/src/Uno.Templates/content/unoapp/solution-config.props.sample
+++ b/src/Uno.Templates/content/unoapp/solution-config.props.sample
@@ -1,7 +1,22 @@
 <Project>
+	<!--
+		This file is used to control the platforms compiled by visual studio, and
+			allow for a faster build when testing for a single platform.
+
+			Instructions:
+			1) Copy this file and remove the ".sample" name
+			2) Uncomment and adjust the properties below
+			3) Make sure to do a Rebuild, so that nuget restores the proper packages for the new target
+	-->
 
     <PropertyGroup>
-        <OverrideTargetFrameworks>$baseTargetFramework$-ios</OverrideTargetFrameworks>
+		<!-- Uncomment each line for each platform that you want to build: -->
+		
+		<!-- <OverrideTargetFrameworks Condition="''!='hint: Windows App Sdk (WinUI)'">$(OverrideTargetFrameworks);$baseTargetFramework$-windows10.0.18362</OverrideTargetFrameworks> -->
+		<!-- <OverrideTargetFrameworks Condition="''!='hint: WASM, Skia'">$(OverrideTargetFrameworks);$baseTargetFramework$</OverrideTargetFrameworks> -->
+		<!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 iOS'">$(OverrideTargetFrameworks);$baseTargetFramework$-ios</OverrideTargetFrameworks> -->
+		<!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 Android'">$(OverrideTargetFrameworks);$baseTargetFramework$-android</OverrideTargetFrameworks> -->
+		<!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 macOS Catalyst'">$(OverrideTargetFrameworks);$baseTargetFramework$-maccatalyst</OverrideTargetFrameworks> -->
     </PropertyGroup>
 
 </Project>

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -3,10 +3,10 @@ param(
     [string]$TemplatesVersion = "255.255.255.255",
 
     # Version of published Uno.Extensions packages
-    [string]$ExtensionsVersion = "2.4.0-dev.297",
+    [string]$ExtensionsVersion = "2.4.1",
 
     # Version of published Uno.WinUI packages
-    [string]$UnoVersion = "4.9.0-dev.1113"
+    [string]$UnoVersion = "4.9.17"
 )
 
 function RemoveNuGetPackage {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- Replaces #141

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

The projects core "shared" project and the mobile project will multi-target as necessary.

## What is the new behavior?

Developers may now optionally uncomment an import line in the Directory.Build.props and rename the sample file to single target. This is an opt in feature. We additionally have added the official VisualStudio .gitignore with the addition of a line to ignore the solution-config.props so that if a developer chooses to use this they will not accidently check the file into source control.

It will be up to the developer to create any solution filters that they may want. The linked docs explain this process in more detail.