### PR TITLE
fix: Change OS to look for both windows and windows_nt

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1640,9 +1640,17 @@
       "type": "bind",
       "binding": "OS"
     },
+    "osLower":{
+      "type": "generated",
+      "generator": "casing",
+      "parameters": {
+        "source":"OS",
+        "toLower": true
+      }
+    },
     "canWindowsRestore": {
       "type": "computed",
-      "value": "(OS == \"Windows\")",
+      "value": "(osLower == 'windows' || osLower == 'windows_nt')",
       "datatype": "bool"
     }
   },


### PR DESCRIPTION
GitHub Issue (If applicable): closes #143 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Fails to add Windows project to the generated solution in Windows because the Windows csproj isn't listed as an output. This is because the OS value is returning Windows_NT when run inside Visual Studio instead of just Windows

## What is the new behavior?

Checks for windows and windows_nt


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
