### PR TITLE
fix: WinAppSdk version bump to fix "PrecompiledHeaderFile" error when building Windows target

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -22,9 +22,7 @@
     <!--#endif-->
     <!--#if (useWinAppSdk)-->
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
-    <!-- Use previous version for unpackaged apps due to build issue https://github.com/microsoft/WindowsAppSDK/issues/3591 -->
-    <!-- <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.230313.1" /> -->    
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.3.230602002" />
     <!--#endif-->
     <!--#if (useAspNetCoreSerilogPackage)-->
     <PackageVersion Include="Serilog.AspNetCore" Version="7.0.0" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
@@ -112,9 +112,7 @@
 	<ItemGroup>
 		<PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
 		<PackageReference Include="Uno.WinUI" Version="$UnoWinUIPackageVersion$" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
-		<!-- Use previous version for unpackaged apps due to build issue https://github.com/microsoft/WindowsAppSDK/issues/3591 -->
-		<!-- <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.230313.1" /> -->    
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230602002" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -208,9 +208,7 @@
 				<PackageReference Include="Microsoft.WindowsAppSDK" />
 				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
 				<!--#else-->
-				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
-				<!-- Use previous version for unpackaged apps due to build issue https://github.com/microsoft/WindowsAppSDK/issues/3591 -->
-				<!-- <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.230313.1" /> -->    
+				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230602002" />
 				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
 				<!--#endif-->
 			</ItemGroup>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Building windows target often resulted in build error: https://github.com/microsoft/WindowsAppSDK/issues/3554

## What is the new behavior?

This type of build error has been resolved in latest winappsdk

