### PR TITLE
fix: Reference Http.WinUI from template

### DIFF
--- a/build/templates/canary-updater.yml
+++ b/build/templates/canary-updater.yml
@@ -17,6 +17,6 @@ steps:
       usePrivateFeed: false
       mergeBranch: ${{ parameters.MergeBranch }}
       branchToMerge: main
-      nugetUpdaterVersion: 2.3.0-alpha.42
+      nugetUpdaterVersion: 2.3.0-alpha.46
       packageAuthor: 'nventive,Uno Platform'
       summaryFile: '$(Build.ArtifactStagingDirectory)/Canary.md'

--- a/build/templates/package-validation.yml
+++ b/build/templates/package-validation.yml
@@ -65,7 +65,7 @@ steps:
 
       cd UnoApp1
 
-      & $env:msbuildpath /r /m UnoApp1.sln
+      & $env:msbuildpath /r /m UnoApp1.sln /bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog
       if ($LASTEXITCODE -ne 0)
       {
           throw "Exit code must be zero."
@@ -73,3 +73,11 @@ steps:
       cd ..
 
   displayName: Build template app
+
+- task: PublishBuildArtifacts@1
+  condition: always()
+  retryCountOnTaskFailure: 3
+  inputs:
+    PathtoPublish: $(build.artifactstagingdirectory)
+    ArtifactName: logs
+    ArtifactType: Container

--- a/build/templates/package-validation.yml
+++ b/build/templates/package-validation.yml
@@ -65,7 +65,7 @@ steps:
 
       cd UnoApp1
 
-      & $env:msbuildpath /r /m UnoApp1.sln /bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog
+      & $env:msbuildpath /r /m UnoApp1.sln "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
       if ($LASTEXITCODE -ne 0)
       {
           throw "Exit code must be zero."

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -14,7 +14,7 @@
 		<!-- Disable package generation for WinUI converted build -->
 		<IsPackable Condition="'$(UNO_UWP_BUILD)'=='false'">false</IsPackable>
 		<NoWarn>$(NoWarn);NU5128</NoWarn>
-		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">2.4.1</UnoExtensionsVersion>
+		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">2.5.0-dev.132</UnoExtensionsVersion>
 		<UnoVersion Condition="'$(UnoVersion)' == ''">4.9.17</UnoVersion>
 	</PropertyGroup>
 

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -15,7 +15,7 @@
 		<IsPackable Condition="'$(UNO_UWP_BUILD)'=='false'">false</IsPackable>
 		<NoWarn>$(NoWarn);NU5128</NoWarn>
 		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">2.5.0-dev.132</UnoExtensionsVersion>
-		<UnoVersion Condition="'$(UnoVersion)' == ''">4.9.17</UnoVersion>
+		<UnoVersion Condition="'$(UnoVersion)' == ''">4.9.20</UnoVersion>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -14,7 +14,7 @@
 		<!-- Disable package generation for WinUI converted build -->
 		<IsPackable Condition="'$(UNO_UWP_BUILD)'=='false'">false</IsPackable>
 		<NoWarn>$(NoWarn);NU5128</NoWarn>
-		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">2.5.0-dev.132</UnoExtensionsVersion>
+		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">2.5.0-dev.148</UnoExtensionsVersion>
 		<UnoVersion Condition="'$(UnoVersion)' == ''">4.9.20</UnoVersion>
 	</PropertyGroup>
 

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -663,7 +663,7 @@
     "unoThemesVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "2.6.0-dev.17",
+      "defaultValue": "2.6.1",
       "replaces": "$UnoThemesVersion$"
     },
     "unoDspTasksVersion": {
@@ -675,7 +675,7 @@
     "unoToolkitVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "2.6.0-dev.40",
+      "defaultValue": "3.0.4",
       "replaces": "$UnoToolkitVersion$"
     },
     "unoResizetizerVersion": {

--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -143,6 +143,8 @@
     <!--#endif-->
     <!--#if (useAndroid)-->
     <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.9.0.1" />
+    <!-- Required to avoid warnings in 1.9.0.1 of Android.Material - https://github.com/xamarin/AndroidX/issues/727 -->
+    <PackageVersion Include="Xamarin.AndroidX.Annotation" Version="1.6.0.3" />
     <!--#endif-->
     <!--#if (useUITests)-->
     <PackageVersion Include="Uno.UITest.Helpers" Version="$UnoUITestHelpersVersion$" />

--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -55,6 +55,7 @@
     <!--#endif-->
     <!--#if (useHttp)-->
     <PackageVersion Include="Uno.Extensions.Http" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Http.WinUI" Version="$UnoExtensionsPackageVersion$" />
     <PackageVersion Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsPackageVersion$" />
     <!--#endif-->
     <!--#if (useLocalization)-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
@@ -198,9 +198,13 @@
 			<ItemGroup>
 				<!--#if (useCPM)-->
 				<PackageReference Include="Xamarin.Google.Android.Material" />
+				<!-- Required to avoid warnings in 1.9.0.1 of Android.Material - https://github.com/xamarin/AndroidX/issues/727 -->
+				<PackageReference Include="Xamarin.AndroidX.Annotation" />
 				<PackageReference Include="Uno.UniversalImageLoader" />
 				<!--#else-->
 				<PackageReference Include="Xamarin.Google.Android.Material" Version="1.9.0.1" />
+				<!-- Required to avoid warnings in 1.9.0.1 of Android.Material - https://github.com/xamarin/AndroidX/issues/727 -->
+				<PackageReference Include="Xamarin.AndroidX.Annotation" Version="1.6.0.3" />
 				<PackageReference Include="Uno.UniversalImageLoader" Version="$UnoUniversalImageLoaderVersion$" />
 				<!--#endif-->
 			</ItemGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/Program.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/Program.cs
@@ -14,7 +14,7 @@ public class Program
 			expArgs.ExitApplication = true;
 		};
 
-		var host = new GtkHost(() => new AppHead(), args);
+		var host = new GtkHost(() => new AppHead());
 
 		host.Run();
 	}

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/GlobalUsings.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/GlobalUsings.cs
@@ -46,9 +46,6 @@ global using Uno.Extensions.Serialization;
 #if (useExtensionsNavigation)
 global using Uno.Extensions.Navigation;
 #endif
-#if (useHttp)
-global using Refit;
-#endif
 #if (useDependencyInjection)
 global using Uno.Extensions;
 #endif

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/GlobalUsings.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/GlobalUsings.cs
@@ -40,29 +40,6 @@ global using MyExtensionsApp._1.DataContracts;
 global using MyExtensionsApp._1.DataContracts.Serialization;
 global using MyExtensionsApp._1.Services.Caching;
 global using MyExtensionsApp._1.Services.Endpoints;
-global using Uno.Extensions.Http;
-global using Uno.Extensions.Serialization;
-#endif
-#if (useExtensionsNavigation)
-global using Uno.Extensions.Navigation;
-#endif
-#if (useDependencyInjection)
-global using Uno.Extensions;
-#endif
-#if (useAuthentication)
-global using Uno.Extensions.Authentication;
-#endif
-#if (useConfiguration)
-global using Uno.Extensions.Configuration;
-#endif
-#if (useDependencyInjection)
-global using Uno.Extensions.Hosting;
-#endif
-#if (useLocalization)
-global using Uno.Extensions.Localization;
-#endif
-#if (useLogging)
-global using Uno.Extensions.Logging;
 #endif
 #if (useCsharpMarkup)
 global using Uno.Extensions.Markup;
@@ -81,9 +58,6 @@ global using Windows.ApplicationModel;
 global using ApplicationExecutionState = Windows.ApplicationModel.Activation.ApplicationExecutionState;
 #if (useCsharpMarkup)
 global using Color = Windows.UI.Color;
-#endif
-#if (useMvux)
-global using Uno.Extensions.Reactive;
 #endif
 #if (useMvvm)
 global using CommunityToolkit.Mvvm.ComponentModel;

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -121,6 +121,7 @@
 		<!--#endif-->
 		<!--#if (useHttp)-->
 		<PackageReference Include="Uno.Extensions.Http" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Http.WinUI" Version="$UnoExtensionsPackageVersion$" />
 		<PackageReference Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsPackageVersion$" />
 		<!--#endif-->
 		<!--#if (useLogging)-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -48,6 +48,7 @@
 		<!--#endif-->
 		<!--#if (useHttp)-->
 		<PackageReference Include="Uno.Extensions.Serialization.Http" />
+		<PackageReference Include="Uno.Extensions.Http.WinUI" />
 		<PackageReference Include="Uno.Extensions.Serialization.Refit" />
 		<!--#endif-->
 		<!--#if (useMaterial)-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Services/Endpoints/IApiClient.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Services/Endpoints/IApiClient.cs
@@ -1,4 +1,6 @@
 //-:cnd:noEmit
+using Refit;
+
 namespace MyExtensionsApp._1.Services.Endpoints;
 
 [Headers("Content-Type: application/json")]

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -6,7 +6,7 @@ param(
     [string]$ExtensionsVersion = "2.5.0-dev.132",
 
     # Version of published Uno.WinUI packages
-    [string]$UnoVersion = "4.9.17"
+    [string]$UnoVersion = "4.9.20"
 )
 
 function RemoveNuGetPackage {

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -3,7 +3,7 @@ param(
     [string]$TemplatesVersion = "255.255.255.255",
 
     # Version of published Uno.Extensions packages
-    [string]$ExtensionsVersion = "2.5.0-dev.132",
+    [string]$ExtensionsVersion = "2.5.0-dev.148",
 
     # Version of published Uno.WinUI packages
     [string]$UnoVersion = "4.9.20"

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -3,7 +3,7 @@ param(
     [string]$TemplatesVersion = "255.255.255.255",
 
     # Version of published Uno.Extensions packages
-    [string]$ExtensionsVersion = "2.4.1",
+    [string]$ExtensionsVersion = "2.5.0-dev.132",
 
     # Version of published Uno.WinUI packages
     [string]$UnoVersion = "4.9.17"


### PR DESCRIPTION
GitHub Issue (If applicable): closes: #160, fixes: #162

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Missing http.winui reference
Warnings when building for android (see #162)

## What is the new behavior?

Http.winui is referenced
No warnings building for android
Global usings for uno.extensions have been removed

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [N/A] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [N/A] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [N/A] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [N/A ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
