### PR TITLE
Update uno versions

### DIFF
--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -14,8 +14,8 @@
 		<!-- Disable package generation for WinUI converted build -->
 		<IsPackable Condition="'$(UNO_UWP_BUILD)'=='false'">false</IsPackable>
 		<NoWarn>$(NoWarn);NU5128</NoWarn>
-		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">2.5.0-dev.177</UnoExtensionsVersion>
-		<UnoVersion Condition="'$(UnoVersion)' == ''">5.0.0-dev.1160</UnoVersion>
+		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">3.0.0-dev.1936</UnoExtensionsVersion>
+		<UnoVersion Condition="'$(UnoVersion)' == ''">5.0.0-dev.1223</UnoVersion>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -658,7 +658,7 @@
     "unoThemesVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "3.0.0-dev.252",
+      "defaultValue": "3.0.0-dev.254",
       "replaces": "$UnoThemesVersion$"
     },
     "unoDspTasksVersion": {
@@ -670,7 +670,7 @@
     "unoToolkitVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "3.1.0-dev.24",
+      "defaultValue": "4.0.0-dev.27",
       "replaces": "$UnoToolkitVersion$"
     },
     "unoResizetizerVersion": {
@@ -699,7 +699,7 @@
         "cases": [
           {
             "condition": "(tfm == 'net7.0')",
-            "value": "7.0.23"
+            "value": "7.0.24"
           },
           {
             "condition": "(tfm == 'net8.0')",
@@ -720,13 +720,13 @@
     "unoMarkupVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "4.8.0-dev.30",
+      "defaultValue": "4.8.0-dev.43",
       "replaces": "$UnoMarkupVersion$"
     },
     "unoUITestHelpersVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "1.1.0-dev.55",
+      "defaultValue": "1.1.0-dev.59",
       "replaces": "$UnoUITestHelpersVersion$"
     },
     "isVsix": {

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -664,7 +664,7 @@
     "unoDspTasksVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "1.0.1",
+      "defaultValue": "1.1.0",
       "replaces": "$UnoDspTasksVersion$"
     },
     "unoToolkitVersion": {
@@ -676,7 +676,7 @@
     "unoResizetizerVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "1.1.0",
+      "defaultValue": "1.2.0-dev.19",
       "replaces": "$UnoResizetizerVersion$"
     },
     "unoUniversalImageLoaderVersion": {

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -3,10 +3,10 @@ param(
     [string]$TemplatesVersion = "255.255.255.255",
 
     # Version of published Uno.Extensions packages
-    [string]$ExtensionsVersion = "2.5.0-dev.177",
+    [string]$ExtensionsVersion = "3.0.0-dev.1936",
 
     # Version of published Uno.WinUI packages
-    [string]$UnoVersion = "5.0.0-dev.1160"
+    [string]$UnoVersion = "5.0.0-dev.1223"
 )
 
 function RemoveNuGetPackage {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The current version do not work for Markp

## What is the new behavior?

Now the new version works for Markup, but still disabled.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
