### PR TITLE
fix: Removing deprecated Uno.Extensions.Toolkit package

### DIFF
--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -14,8 +14,8 @@
 		<!-- Disable package generation for WinUI converted build -->
 		<IsPackable Condition="'$(UNO_UWP_BUILD)'=='false'">false</IsPackable>
 		<NoWarn>$(NoWarn);NU5128</NoWarn>
-		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">3.0.0-dev.1936</UnoExtensionsVersion>
-		<UnoVersion Condition="'$(UnoVersion)' == ''">5.0.0-dev.1223</UnoVersion>
+		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">3.0.0-dev.1984</UnoExtensionsVersion>
+		<UnoVersion Condition="'$(UnoVersion)' == ''">5.0.0-dev.1610</UnoVersion>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -98,7 +98,6 @@
     <!--#endif-->
     <!--#if (useToolkit)-->
     <PackageVersion Include="Uno.Toolkit.WinUI" Version="$UnoToolkitVersion$" />
-    <PackageVersion Include="Uno.Extensions.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
     <!--#if (useMaterial)-->
     <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="$UnoToolkitVersion$" />
     <!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
@@ -65,7 +65,6 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" />
 		<!--#endif-->
 		<!--#if (useToolkit)-->
-		<PackageReference Include="Uno.Extensions.Toolkit.WinUI"/>
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Markup" />
 		<!--#else-->
@@ -148,7 +147,6 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" Version="$UnoThemesVersion$" />
 		<!--#endif-->
 		<!--#if (useToolkit)-->
-		<PackageReference Include="Uno.Extensions.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Markup" Version="$UnoToolkitMarkupVersion$" />
 		<!--#else-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
@@ -49,7 +49,6 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" />
 		<!--#endif-->
 		<!--#if (useToolkit)-->
-		<PackageReference Include="Uno.Extensions.Toolkit.WinUI" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Markup" />
 		<!--#else-->
@@ -133,7 +132,6 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" Version="$UnoThemesVersion$" />
 		<!--#endif-->
 		<!--#if (useToolkit)-->
-		<PackageReference Include="Uno.Extensions.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Markup" Version="$UnoToolkitMarkupVersion$" />
 		<!--#else-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
@@ -47,7 +47,6 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" />
 		<!--#endif-->
 		<!--#if (useToolkit)-->
-		<PackageReference Include="Uno.Extensions.Toolkit.WinUI" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Markup" />
 		<!--#else-->
@@ -131,7 +130,6 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" Version="$UnoThemesVersion$" />
 		<!--#endif-->
 		<!--#if (useToolkit)-->
-		<PackageReference Include="Uno.Extensions.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Markup" Version="$UnoToolkitMarkupVersion$" />
 		<!--#else-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
@@ -61,7 +61,6 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" />
 		<!--#endif-->
 		<!--#if (useToolkit)-->
-		<PackageReference Include="Uno.Extensions.Toolkit.WinUI" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Markup" />
 		<!--#else-->
@@ -145,7 +144,6 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" Version="$UnoThemesVersion$" />
 		<!--#endif-->
 		<!--#if (useToolkit)-->
-		<PackageReference Include="Uno.Extensions.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Markup" Version="$UnoToolkitMarkupVersion$" />
 		<!--#else-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
@@ -109,7 +109,6 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" />
 		<!--#endif-->
 		<!--#if (useToolkit)-->
-		<PackageReference Include="Uno.Extensions.Toolkit.WinUI" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Markup" />
 		<!--#else-->
@@ -195,7 +194,6 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" Version="$UnoThemesVersion$" />
 		<!--#endif-->
 		<!--#if (useToolkit)-->
-		<PackageReference Include="Uno.Extensions.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Markup" Version="$UnoToolkitMarkupVersion$" />
 		<!--#else-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
@@ -66,7 +66,6 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" />
 		<!--#endif-->
 		<!--#if (useToolkit)-->
-		<PackageReference Include="Uno.Extensions.Toolkit.WinUI" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Markup" />
 		<!--#else-->
@@ -150,7 +149,6 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" Version="$UnoThemesVersion$" />
 		<!--#endif-->
 		<!--#if (useToolkit)-->
-		<PackageReference Include="Uno.Extensions.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Markup" Version="$UnoToolkitMarkupVersion$" />
 		<!--#else-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -60,7 +60,6 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" />
 		<!--#endif-->
 		<!--#if (useToolkit)-->
-		<PackageReference Include="Uno.Extensions.Toolkit.WinUI" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Markup" />
 		<!--#else-->
@@ -144,7 +143,6 @@
 		<PackageReference Include="Uno.Cupertino.WinUI" Version="$UnoThemesVersion$" />
 		<!--#endif-->
 		<!--#if (useToolkit)-->
-		<PackageReference Include="Uno.Extensions.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Markup" Version="$UnoToolkitMarkupVersion$" />
 		<!--#else-->


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Template references deprecated uno.extensions.toolkit package

## What is the new behavior?

Deprecated reference removed

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
