### PR TITLE
feat: Extracting package versions to csproj so updater will work

### DIFF
--- a/build/templates/canary-updater.yml
+++ b/build/templates/canary-updater.yml
@@ -17,6 +17,7 @@ steps:
       usePrivateFeed: false
       mergeBranch: ${{ parameters.MergeBranch }}
       branchToMerge: main
-      nugetUpdaterVersion: 2.3.0-alpha.46
+      nugetUpdaterVersion: 2.3.0-alpha.55
       packageAuthor: 'nventive,unoplatform,uno platform'
       summaryFile: '$(Build.ArtifactStagingDirectory)/Canary.md'
+      projectProperties: 'propertiesToUpdate.json'

--- a/build/templates/propertiesToUpdate.json
+++ b/build/templates/propertiesToUpdate.json
@@ -1,0 +1,17 @@
+﻿[
+  { "PropertyName": "UnoExtensionsVersion", "PackageId": "Uno.Extensions.Core" },
+  { "PropertyName": "UnoVersion", "PackageId": "Uno.WinUI" },  
+  { "PropertyName": "UnoExtensionsLoggingVersion", "PackageId": "Uno.Extensions.Logging.WebAssembly.Console" }, 
+  { "PropertyName": "SkiaSharpVersion", "PackageId": "SkiaSharp.Skottie" }, 
+  { "PropertyName": "UnoCoreExtensionsLoggingVersion", "PackageId": "Uno.Core.Extensions.Logging" }, 
+  { "PropertyName": "UnoThemesVersion", "PackageId": "Uno.Material.WinUI" }, 
+  { "PropertyName": "UnoDspTasksVersion", "PackageId": "Uno.Dsp.Tasks" }, 
+  { "PropertyName": "UnoToolkitVersion", "PackageId": "Uno.Toolkit.WinUI" }, 
+  { "PropertyName": "UnoToolkitMarkupVersion", "PackageId": "Uno.Toolkit.WinUI.Markup" }, 
+  { "PropertyName": "UnoResizetizerVersion", "PackageId": "Uno.Resizetizer" }, 
+  { "PropertyName": "UnoUniversalImageLoaderVersion", "PackageId": "Uno.UniversalImageLoader" }, 
+  { "PropertyName": "UnoWasmBootstrapVersionNet7", "PackageId": "Uno.Wasm.Bootstrap" }, 
+  { "PropertyName": "UnoWasmBootstrapVersionNet8", "PackageId": "Uno.Wasm.Bootstrap" }, 
+  { "PropertyName": "UnoMarkupVersion", "PackageId": "Uno.WinUI.Markup" }, 
+  { "PropertyName": "UnoUITestHelpersVersion", "PackageId": "Uno.UITest.Helpers" }
+]

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -22,7 +22,7 @@
 		<UnoExtensionsLoggingVersion Condition="'$(UnoExtensionsLoggingVersion)' == ''">1.4.0</UnoExtensionsLoggingVersion>
 		<SkiaSharpVersion Condition="'$(SkiaSharpVersion)' == ''">2.88.3</SkiaSharpVersion>
 		<UnoCoreExtensionsLoggingVersion Condition="'$(UnoCoreExtensionsLoggingVersion)' == ''">4.0.1</UnoCoreExtensionsLoggingVersion>
-		<UnoThemesVersion Condition="'$(UnoThemesVersion)' == ''">3.0.0>-dev.254</UnoThemesVersion>
+		<UnoThemesVersion Condition="'$(UnoThemesVersion)' == ''">3.0.0-dev.254</UnoThemesVersion>
 		<UnoDspTasksVersion Condition="'$(UnoDspTasksVersion)' == ''">1.1.0</UnoDspTasksVersion>
 		<UnoToolkitVersion Condition="'$(UnoToolkitVersion)' == ''">4.0.0-dev.27</UnoToolkitVersion>
 		<UnoToolkitMarkupVersion Condition="'$(UnoToolkitMarkupVersion)' == ''">2.6.0-dev.58</UnoToolkitMarkupVersion>
@@ -85,8 +85,8 @@
 		<ItemGroup>
 			<_TemplateJson Include="$(IntermediateOutputPath)/content/**/template.json" />
 		</ItemGroup>
-		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoExtensionsPackageVersion" ReplacementText="$(UnoExtensionsVersion)" />
-		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoWinUIPackageVersion" ReplacementText="$(UnoVersion)" />
+		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoExtensionsVersion" ReplacementText="$(UnoExtensionsVersion)" />
+		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoWinUIVersion" ReplacementText="$(UnoVersion)" />
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoExtensionsLoggingVersion" ReplacementText="$(UnoExtensionsLoggingVersion)" />
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultSkiaSharpVersion" ReplacementText="$(SkiaSharpVersion)" />
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoCoreExtensionsLoggingVersion" ReplacementText="$(UnoCoreExtensionsLoggingVersion)" />

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -14,10 +14,25 @@
 		<!-- Disable package generation for WinUI converted build -->
 		<IsPackable Condition="'$(UNO_UWP_BUILD)'=='false'">false</IsPackable>
 		<NoWarn>$(NoWarn);NU5128</NoWarn>
-		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">3.0.0-dev.1984</UnoExtensionsVersion>
-		<UnoVersion Condition="'$(UnoVersion)' == ''">5.0.0-dev.1728</UnoVersion>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">3.0.0-dev.1984</UnoExtensionsVersion>
+		<UnoVersion Condition="'$(UnoVersion)' == ''">5.0.0-dev.1728</UnoVersion>
+		<UnoExtensionsLoggingVersion Condition="'$(UnoExtensionsLoggingVersion)' == ''">1.4.0</UnoExtensionsLoggingVersion>
+		<SkiaSharpVersion Condition="'$(SkiaSharpVersion)' == ''">2.88.3</SkiaSharpVersion>
+		<UnoCoreExtensionsLoggingVersion Condition="'$(UnoCoreExtensionsLoggingVersion)' == ''">4.0.1</UnoCoreExtensionsLoggingVersion>
+		<UnoThemesVersion Condition="'$(UnoThemesVersion)' == ''">3.0.0>-dev.254</UnoThemesVersion>
+		<UnoDspTasksVersion Condition="'$(UnoDspTasksVersion)' == ''">1.1.0</UnoDspTasksVersion>
+		<UnoToolkitVersion Condition="'$(UnoToolkitVersion)' == ''">4.0.0-dev.27</UnoToolkitVersion>
+		<UnoToolkitMarkupVersion Condition="'$(UnoToolkitMarkupVersion)' == ''">2.6.0-dev.58</UnoToolkitMarkupVersion>
+		<UnoResizetizerVersion Condition="'$(UnoResizetizerVersion)' == ''">1.2.0-dev.19</UnoResizetizerVersion>
+		<UnoUniversalImageLoaderVersion Condition="'$(UnoUniversalImageLoaderVersion)' == ''">1.9.36</UnoUniversalImageLoaderVersion>
+		<UnoWasmBootstrapVersionNet7 Condition="'$(UnoWasmBootstrapVersionNet7)' == ''">7.0.24</UnoWasmBootstrapVersionNet7>
+		<UnoWasmBootstrapVersionNet8 Condition="'$(UnoWasmBootstrapVersionNet8)' == ''">8.0.0-dev.218</UnoWasmBootstrapVersionNet8>
+		<UnoMarkupVersion Condition="'$(UnoMarkupVersion)' == ''">4.8.0-dev.43</UnoMarkupVersion>
+		<UnoUITestHelpersVersion Condition="'$(UnoUITestHelpersVersion)' == ''">1.1.0-dev.59</UnoUITestHelpersVersion>
+	</PropertyGroup>
 	<PropertyGroup>
 		<PackageTags>dotnet-new;templates;uno-platform</PackageTags>
 		<PackageProjectUrl>https://github.com/unoplatform/uno.templates</PackageProjectUrl>
@@ -32,12 +47,12 @@
 		<MergeTemplatePackage Include="Uno.ProjectTemplates.Dotnet" Version="$(UnoVersion)">
 			<FileExists>false</FileExists>
 		</MergeTemplatePackage>
-		
+
 		<!-- Workaround for NU5017-->
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Folder Include="content\" />
+		<Folder Include="content\" />
 	</ItemGroup>
 
 	<Target Name="PrepareTemplateFiles" BeforeTargets="ReplaceVersions" AfterTargets="DownloadTemplatePackages;ExtractPackages">
@@ -49,8 +64,8 @@
 
 		<!-- Ensure we keep the .gitignore up to date with the latest changes to the official VisualStudio.gitignore -->
 		<DownloadFile
-			DestinationFolder="$(TemplateContentFolder)/unoapp" 
-			DestinationFileName=".gitignore" 
+			DestinationFolder="$(TemplateContentFolder)/unoapp"
+			DestinationFileName=".gitignore"
 			SourceUrl="https://raw.githubusercontent.com/github/gitignore/main/VisualStudio.gitignore" />
 
 		<!-- Add our custom ignore for Single TFM targeting -->
@@ -72,6 +87,19 @@
 		</ItemGroup>
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoExtensionsPackageVersion" ReplacementText="$(UnoExtensionsVersion)" />
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoWinUIPackageVersion" ReplacementText="$(UnoVersion)" />
+		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoExtensionsLoggingVersion" ReplacementText="$(UnoExtensionsLoggingVersion)" />
+		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultSkiaSharpVersion" ReplacementText="$(SkiaSharpVersion)" />
+		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoCoreExtensionsLoggingVersion" ReplacementText="$(UnoCoreExtensionsLoggingVersion)" />
+		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoThemesVersion" ReplacementText="$(UnoThemesVersion)"/>
+		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoDspTasksVersion" ReplacementText="$(UnoDspTasksVersion)" />
+		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoToolkitVersion" ReplacementText="$(UnoToolkitVersion)"/>
+		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoToolkitMarkupVersion" ReplacementText="$(UnoToolkitMarkupVersion)"/>
+		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoResizetizerVersion" ReplacementText="$(UnoResizetizerVersion)"/>
+		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoUniversalImageLoaderVersion" ReplacementText="$(UnoUniversalImageLoaderVersion)" />
+		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoWasmBootstrapVersionNet7" ReplacementText="$(UnoWasmBootstrapVersionNet7)" />
+		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoWasmBootstrapVersionNet8" ReplacementText="$(UnoWasmBootstrapVersionNet8)"/>
+		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoMarkupVersion" ReplacementText="$(UnoMarkupVersion)"/>
+		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoUITestHelpersVersion" ReplacementText="$(UnoUITestHelpersVersion)"/>
 	</Target>
 
 	<Target Name="DownloadTemplatePackages" BeforeTargets="BeforeBuild;PrepareTemplateFiles">
@@ -96,9 +124,9 @@
 
 		<!-- Create an ItemGroup containing the file names of the downloaded packages -->
 		<ItemGroup>
-		<_TemplatePackages Include="$(TemplateDownloadFolder)/%(MergeTemplatePackage.Identity).%(MergeTemplatePackage.Version).nupkg">
-			<FileExists>%(MergeTemplatePackage.FileExists)</FileExists>
-		</_TemplatePackages>
+			<_TemplatePackages Include="$(TemplateDownloadFolder)/%(MergeTemplatePackage.Identity).%(MergeTemplatePackage.Version).nupkg">
+				<FileExists>%(MergeTemplatePackage.FileExists)</FileExists>
+			</_TemplatePackages>
 		</ItemGroup>
 
 	</Target>

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -648,55 +648,55 @@
     "unoExtensionsLoggingVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "1.4.0",
+      "defaultValue": "DefaultUnoExtensionsLoggingVersion",
       "replaces": "$UnoExtensionsLoggingPackageVersion$"
     },
     "skiaSharpVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "2.88.3",
+      "defaultValue": "DefaultSkiaSharpVersion",
       "replaces": "$SkiaSharpPackageVersion$"
     },
     "unoCoreExtensionsLoggingVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "4.0.1",
+      "defaultValue": "DefaultUnoCoreExtensionsLoggingVersion",
       "replaces": "$UnoCoreExtensionsLoggingVersion$"
     },
     "unoThemesVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "3.0.0-dev.254",
+      "defaultValue": "DefaultUnoThemesVersion",
       "replaces": "$UnoThemesVersion$"
     },
     "unoDspTasksVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "1.1.0",
+      "defaultValue": "DefaultUnoDspTasksVersion",
       "replaces": "$UnoDspTasksVersion$"
     },
     "unoToolkitVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "4.0.0-dev.27",
+      "defaultValue": "DefaultUnoToolkitVersion",
       "replaces": "$UnoToolkitVersion$"
     },
     "unoToolkitMarkupVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "2.6.0-dev.58",
+      "defaultValue": "DefaultUnoToolkitMarkupVersion",
       "replaces": "$UnoToolkitMarkupVersion$"
-    },   
+    },
     "unoResizetizerVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "1.2.0-dev.19",
+      "defaultValue": "DefaultUnoResizetizerVersion",
       "replaces": "$UnoResizetizerVersion$"
     },
     "unoUniversalImageLoaderVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "1.9.36",
+      "defaultValue": "DefaultUnoUniversalImageLoaderVersion",
       "replaces": "$UnoUniversalImageLoaderVersion$"
     },
     "unoWasmBootstrapVersion": {
@@ -713,11 +713,11 @@
         "cases": [
           {
             "condition": "(tfm == 'net7.0')",
-            "value": "7.0.24"
+            "value": "DefaultUnoWasmBootstrapVersionNet7"
           },
           {
             "condition": "(tfm == 'net8.0')",
-            "value": "8.0.0-dev.218"
+            "value": "DefaultUnoWasmBootstrapVersionNet8"
           }
         ]
       }
@@ -734,13 +734,13 @@
     "unoMarkupVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "4.8.0-dev.43",
+      "defaultValue": "DefaultUnoMarkupVersion",
       "replaces": "$UnoMarkupVersion$"
     },
     "unoUITestHelpersVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "1.1.0-dev.59",
+      "defaultValue": "DefaultUnoUITestHelpersVersion",
       "replaces": "$UnoUITestHelpersVersion$"
     },
     "isVsix": {

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -636,26 +636,26 @@
     "unoWinUIVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "DefaultUnoWinUIPackageVersion",
-      "replaces": "$UnoWinUIPackageVersion$"
+      "defaultValue": "DefaultUnoWinUIVersion",
+      "replaces": "$UnoWinUIVersion$"
     },
     "unoExtensionsVersion": {
       "type": "parameter",
       "datatype": "text",
-      "defaultValue": "DefaultUnoExtensionsPackageVersion",
-      "replaces": "$UnoExtensionsPackageVersion$"
+      "defaultValue": "DefaultUnoExtensionsVersion",
+      "replaces": "$UnoExtensionsVersion$"
     },
     "unoExtensionsLoggingVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "DefaultUnoExtensionsLoggingVersion",
-      "replaces": "$UnoExtensionsLoggingPackageVersion$"
+      "replaces": "$UnoExtensionsLoggingVersion$"
     },
     "skiaSharpVersion": {
       "type": "parameter",
       "datatype": "text",
       "defaultValue": "DefaultSkiaSharpVersion",
-      "replaces": "$SkiaSharpPackageVersion$"
+      "replaces": "$SkiaSharpVersion$"
     },
     "unoCoreExtensionsLoggingVersion": {
       "type": "parameter",

--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -28,67 +28,67 @@
     <PackageVersion Include="Serilog.AspNetCore" Version="7.0.0" />
     <!--#endif-->
     <!--#if (useSkia)-->
-    <PackageVersion Include="SkiaSharp.Skottie" Version="$SkiaSharpPackageVersion$" />
-    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="$SkiaSharpPackageVersion$" />
+    <PackageVersion Include="SkiaSharp.Skottie" Version="$SkiaSharpVersion$" />
+    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="$SkiaSharpVersion$" />
     <!--#endif-->
     <!--#if (server)-->
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <!--#endif-->
     <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="$UnoCoreExtensionsLoggingVersion$" />
     <!--#if (useAuthentication)-->
-    <PackageVersion Include="Uno.Extensions.Authentication" Version="$UnoExtensionsPackageVersion$" />
-    <PackageVersion Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Authentication" Version="$UnoExtensionsVersion$" />
+    <PackageVersion Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsVersion$" />
     <!--#if (useOidcAuthentication)-->
-    <PackageVersion Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useMsalAuthentication)-->
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.54.1" />
-    <PackageVersion Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#endif-->
     <!--#if (useConfiguration)-->
-    <PackageVersion Include="Uno.Extensions.Configuration" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Configuration" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useDependencyInjection)-->
-    <PackageVersion Include="Uno.Extensions.Hosting" Version="$UnoExtensionsPackageVersion$" />
-    <PackageVersion Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Hosting" Version="$UnoExtensionsVersion$" />
+    <PackageVersion Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useHttp)-->
-    <PackageVersion Include="Uno.Extensions.Http" Version="$UnoExtensionsPackageVersion$" />
-    <PackageVersion Include="Uno.Extensions.Http.WinUI" Version="$UnoExtensionsPackageVersion$" />
-    <PackageVersion Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Http" Version="$UnoExtensionsVersion$" />
+    <PackageVersion Include="Uno.Extensions.Http.WinUI" Version="$UnoExtensionsVersion$" />
+    <PackageVersion Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useLocalization)-->
-    <PackageVersion Include="Uno.Extensions.Localization" Version="$UnoExtensionsPackageVersion$" />
-    <PackageVersion Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Localization" Version="$UnoExtensionsVersion$" />
+    <PackageVersion Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useMobile)-->
-    <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="$UnoExtensionsLoggingPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="$UnoExtensionsLoggingVersion$" />
     <!--#endif-->
     <!--#if (useWasm)-->
-    <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="$UnoExtensionsLoggingPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="$UnoExtensionsLoggingVersion$" />
     <!--#endif-->
     <!--#if (useSerilog)-->
-    <PackageVersion Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useLogging)-->
-    <PackageVersion Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useExtensionsNavigation)-->
-    <PackageVersion Include="Uno.Extensions.Navigation" Version="$UnoExtensionsPackageVersion$" />
-    <PackageVersion Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Navigation" Version="$UnoExtensionsVersion$" />
+    <PackageVersion Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useNavigationToolkit)-->
-    <PackageVersion Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useMvux)-->
-    <PackageVersion Include="Uno.Extensions.Reactive" Version="$UnoExtensionsPackageVersion$" />
-    <PackageVersion Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Reactive" Version="$UnoExtensionsVersion$" />
+    <PackageVersion Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useHttp)-->
-    <PackageVersion Include="Uno.Extensions.Serialization" Version="$UnoExtensionsPackageVersion$" />
-    <PackageVersion Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsPackageVersion$" />
-    <PackageVersion Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Serialization" Version="$UnoExtensionsVersion$" />
+    <PackageVersion Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsVersion$" />
+    <PackageVersion Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useMaterial)-->
     <PackageVersion Include="Uno.Material.WinUI" Version="$UnoThemesVersion$" />
@@ -103,42 +103,42 @@
     <!--#endif-->
     <!--#endif-->
     <PackageVersion Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIPackageVersion$" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
     <PackageVersion Include="Uno.UniversalImageLoader" Version="$UnoUniversalImageLoaderVersion$" />
     <!--#if (useWasm)-->
     <PackageVersion Include="Uno.Wasm.Bootstrap" Version="$UnoWasmBootstrapVersion$" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="$UnoWasmBootstrapVersion$" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.Server" Version="$UnoWasmBootstrapVersion$" />
     <!--#endif-->
-    <PackageVersion Include="Uno.WinUI" Version="$UnoWinUIPackageVersion$" />
+    <PackageVersion Include="Uno.WinUI" Version="$UnoWinUIVersion$" />
     <!--#if (useCsharpMarkup)-->
     <PackageVersion Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
     <!--#if (useToolkit)-->
     <PackageVersion Include="Uno.Toolkit.WinUI.Markup" Version="$UnoToolkitMarkupVersion$" />
     <!--#endif-->
     <!--#if (useExtensionsNavigation)-->
-    <PackageVersion Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useMvux)-->
-    <PackageVersion Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+    <PackageVersion Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useMaterial)-->
     <PackageVersion Include="Uno.Material.WinUI.Markup" Version="$UnoThemesVersion$" />
     <!--#endif-->
     <PackageVersion Include="Uno.Themes.WinUI.Markup" Version="$UnoThemesVersion$" />
     <!--#endif-->
-    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIPackageVersion$" />
+    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIVersion$" />
     <!--#if (useGtk)-->
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="$UnoWinUIPackageVersion$" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="$UnoWinUIVersion$" />
     <!--#endif-->
     <!--#if (useLinuxFb)-->
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="$UnoWinUIPackageVersion$" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="$UnoWinUIVersion$" />
     <!--#endif-->
     <!--#if (useWpf)-->
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="$UnoWinUIPackageVersion$" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="$UnoWinUIVersion$" />
     <!--#endif-->
     <!--#if (useWasm)-->
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="$UnoWinUIPackageVersion$" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="$UnoWinUIVersion$" />
     <!--#endif-->
     <!--#if (useAndroid)-->
     <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.9.0.2" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
@@ -110,7 +110,7 @@
 	<!--#else-->
 	<ItemGroup>
 		<PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
-		<PackageReference Include="Uno.WinUI" Version="$UnoWinUIPackageVersion$" />
+		<PackageReference Include="Uno.WinUI" Version="$UnoWinUIVersion$" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
 		<!--#if (useMaterial)-->
@@ -122,21 +122,21 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
 		<!--#endif -->
 		<!--#if (useConfiguration)-->
-		<PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useHttp)-->
-		<PackageReference Include="Uno.Extensions.Http" Version="$UnoExtensionsPackageVersion$" />
-		<PackageReference Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Http" Version="$UnoExtensionsVersion$" />
+		<PackageReference Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useLogging)-->
-		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->
-		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useHttp)-->
-		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsPackageVersion$" />
-		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsVersion$" />
+		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="$UnoThemesVersion$" />
@@ -154,40 +154,40 @@
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useAuthentication)-->
-		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useOidcAuthentication)-->
-		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
-		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useDependencyInjection)-->
-		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useLocalization)-->
-		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useExtensionsNavigation)-->
 		<!--#if (useNavigationToolkit)-->
-		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
-		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useCsharpMarkup)-->
-		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useMvux)-->
-		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useCsharpMarkup)-->
-		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
-		<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="$UnoExtensionsLoggingPackageVersion$" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIPackageVersion$" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIPackageVersion$" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="$UnoExtensionsLoggingVersion$" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
 	</ItemGroup>
 	<!--#endif-->
 	<Choose>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
@@ -95,7 +95,7 @@
 	<!--#else-->
 	<ItemGroup>
 		<PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="$UnoWinUIPackageVersion$" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="$UnoWinUIVersion$" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
 		<!--#if (useMaterial)-->
@@ -107,21 +107,21 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
 		<!--#endif -->
 		<!--#if (useConfiguration)-->
-		<PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useHttp)-->
-		<PackageReference Include="Uno.Extensions.Http" Version="$UnoExtensionsPackageVersion$" />
-		<PackageReference Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Http" Version="$UnoExtensionsVersion$" />
+		<PackageReference Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useLogging)-->
-		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->
-		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useHttp)-->
-		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsPackageVersion$" />
-		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsVersion$" />
+		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="$UnoThemesVersion$" />
@@ -139,41 +139,41 @@
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useAuthentication)-->
-		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useOidcAuthentication)-->
-		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
-		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useDependencyInjection)-->
-		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useLocalization)-->
-		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useExtensionsNavigation)-->
 		<!--#if (useNavigationToolkit)-->
-		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
-		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useCsharpMarkup)-->
-		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useMvux)-->
-		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useCsharpMarkup)-->
-		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
-		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="$SkiaSharpPackageVersion$" />
-		<PackageReference Include="SkiaSharp.Skottie" Version="$SkiaSharpPackageVersion$" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIPackageVersion$" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIPackageVersion$" />
+		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="$SkiaSharpVersion$" />
+		<PackageReference Include="SkiaSharp.Skottie" Version="$SkiaSharpVersion$" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
 	</ItemGroup>
 	<!--#endif-->
 	<ItemGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
@@ -93,7 +93,7 @@
 	<!--#else-->
 	<ItemGroup>
 		<PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
-		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="$UnoWinUIPackageVersion$" />
+		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="$UnoWinUIVersion$" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
 		<!--#if (useMaterial)-->
@@ -105,21 +105,21 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
 		<!--#endif -->
 		<!--#if (useConfiguration)-->
-		<PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useHttp)-->
-		<PackageReference Include="Uno.Extensions.Http" Version="$UnoExtensionsPackageVersion$" />
-		<PackageReference Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Http" Version="$UnoExtensionsVersion$" />
+		<PackageReference Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useLogging)-->
-		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->
-		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useHttp)-->
-		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsPackageVersion$" />
-		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsVersion$" />
+		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="$UnoThemesVersion$" />
@@ -137,41 +137,41 @@
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useAuthentication)-->
-		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useOidcAuthentication)-->
-		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
-		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useDependencyInjection)-->
-		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useLocalization)-->
-		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useExtensionsNavigation)-->
 		<!--#if (useNavigationToolkit)-->
-		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
-		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useCsharpMarkup)-->
-		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useMvux)-->
-		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useCsharpMarkup)-->
-		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
-		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="$SkiaSharpPackageVersion$" />
-		<PackageReference Include="SkiaSharp.Skottie" Version="$SkiaSharpPackageVersion$" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIPackageVersion$" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIPackageVersion$" />
+		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="$SkiaSharpVersion$" />
+		<PackageReference Include="SkiaSharp.Skottie" Version="$SkiaSharpVersion$" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
 	</ItemGroup>
 	<!--#endif-->
 	<ItemGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
@@ -107,7 +107,7 @@
 	<!--#else-->
 	<ItemGroup>
 		<PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="$UnoWinUIPackageVersion$" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="$UnoWinUIVersion$" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
 		<!--#if (useMaterial)-->
@@ -119,21 +119,21 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
 		<!--#endif -->
 		<!--#if (useConfiguration)-->
-		<PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useHttp)-->
-		<PackageReference Include="Uno.Extensions.Http" Version="$UnoExtensionsPackageVersion$" />
-		<PackageReference Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Http" Version="$UnoExtensionsVersion$" />
+		<PackageReference Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useLogging)-->
-		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->
-		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useHttp)-->
-		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsPackageVersion$" />
-		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsVersion$" />
+		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="$UnoThemesVersion$" />
@@ -151,41 +151,41 @@
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useAuthentication)-->
-		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useOidcAuthentication)-->
-		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
-		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useDependencyInjection)-->
-		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useLocalization)-->
-		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useExtensionsNavigation)-->
 		<!--#if (useNavigationToolkit)-->
-		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
-		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useCsharpMarkup)-->
-		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useMvux)-->
-		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useCsharpMarkup)-->
-		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
-		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="$SkiaSharpPackageVersion$" />
-		<PackageReference Include="SkiaSharp.Skottie" Version="$SkiaSharpPackageVersion$" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIPackageVersion$" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIPackageVersion$" />
+		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="$SkiaSharpVersion$" />
+		<PackageReference Include="SkiaSharp.Skottie" Version="$SkiaSharpVersion$" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
 	</ItemGroup>
 	<!--#endif-->
 	<ItemGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
@@ -154,9 +154,9 @@
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="$MsftWindowsCompatibilityVersion$" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="$UnoWasmBootstrapVersion$" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="$UnoWasmBootstrapVersion$" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="$UnoWinUIPackageVersion$" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIPackageVersion$" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIPackageVersion$" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="$UnoWinUIVersion$" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
 		<!--#if (useMaterial)-->
@@ -168,22 +168,22 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
 		<!--#endif -->
 		<!--#if (useConfiguration)-->
-		<PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useHttp)-->
-		<PackageReference Include="Uno.Extensions.Http" Version="$UnoExtensionsPackageVersion$" />
-		<PackageReference Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Http" Version="$UnoExtensionsVersion$" />
+		<PackageReference Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
-		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="$UnoExtensionsLoggingPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="$UnoExtensionsLoggingVersion$" />
 		<!--#if (useLogging)-->
-		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->
-		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useHttp)-->
-		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsPackageVersion$" />
-		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsVersion$" />
+		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="$UnoThemesVersion$" />
@@ -201,34 +201,34 @@
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useAuthentication)-->
-		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useOidcAuthentication)-->
-		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
-		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useDependencyInjection)-->
-		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useLocalization)-->
-		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useExtensionsNavigation)-->
 		<!--#if (useNavigationToolkit)-->
-		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
-		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useCsharpMarkup)-->
-		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useMvux)-->
-		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useCsharpMarkup)-->
-		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
@@ -110,7 +110,7 @@
 	<!--#else-->
 	<ItemGroup>
 		<PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
-		<PackageReference Include="Uno.WinUI" Version="$UnoWinUIPackageVersion$" />
+		<PackageReference Include="Uno.WinUI" Version="$UnoWinUIVersion$" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230602002" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
 		<!--#if (useCsharpMarkup)-->
@@ -124,21 +124,21 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
 		<!--#endif -->
 		<!--#if (useConfiguration)-->
-		<PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useHttp)-->
-		<PackageReference Include="Uno.Extensions.Http" Version="$UnoExtensionsPackageVersion$" />
-		<PackageReference Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Http" Version="$UnoExtensionsVersion$" />
+		<PackageReference Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useLogging)-->
-		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->
-		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useHttp)-->
-		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsPackageVersion$" />
-		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsVersion$" />
+		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="$UnoThemesVersion$" />
@@ -156,39 +156,39 @@
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useAuthentication)-->
-		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useOidcAuthentication)-->
-		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
-		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useDependencyInjection)-->
-		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useLocalization)-->
-		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useExtensionsNavigation)-->
 		<!--#if (useNavigationToolkit)-->
-		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
-		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useCsharpMarkup)-->
-		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useMvux)-->
-		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useCsharpMarkup)-->
-		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="$UnoCoreExtensionsLoggingVersion$" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIPackageVersion$" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
 	</ItemGroup>
 	<!--#endif-->
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -104,7 +104,7 @@
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Dsp.Tasks" Version="$UnoDspTasksVersion$" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI" Version="$UnoWinUIPackageVersion$" />
+		<PackageReference Include="Uno.WinUI" Version="$UnoWinUIVersion$" />
 		<PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
@@ -117,22 +117,22 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
 		<!--#endif -->
 		<!--#if (useConfiguration)-->
-		<PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useHttp)-->
-		<PackageReference Include="Uno.Extensions.Http" Version="$UnoExtensionsPackageVersion$" />
-		<PackageReference Include="Uno.Extensions.Http.WinUI" Version="$UnoExtensionsPackageVersion$" />
-		<PackageReference Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Http" Version="$UnoExtensionsVersion$" />
+		<PackageReference Include="Uno.Extensions.Http.WinUI" Version="$UnoExtensionsVersion$" />
+		<PackageReference Include="Uno.Extensions.Http.Refit" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useLogging)-->
-		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->
-		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useHttp)-->
-		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsPackageVersion$" />
-		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="$UnoExtensionsVersion$" />
+		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="$UnoThemesVersion$" />
@@ -150,34 +150,34 @@
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useAuthentication)-->
-		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useOidcAuthentication)-->
-		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
-		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useDependencyInjection)-->
-		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useLocalization)-->
-		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useExtensionsNavigation)-->
 		<!--#if (useNavigationToolkit)-->
-		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
-		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useCsharpMarkup)-->
-		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<!--#if (useMvux)-->
-		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#if (useCsharpMarkup)-->
-		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsPackageVersion$" />
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Only Uno.Extensions and Uno.WinUI versions are in the uno.templates.csproj file. This will prevent other packages from being updated by the canary updater

## What is the new behavior?
The other Uno packages and Skia have been added to the csproj file

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
