### PR TITLE
Show the base.props and icon files

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1705,6 +1705,9 @@
       "path": "MyExtensionsApp._1\\MyExtensionsApp._1.csproj"
     },
     {
+      "path": "MyExtensionsApp._1.Base\\MyExtensionsApp._1.Base.csproj"
+    },
+    {
       "condition": "useServer",
       "path": "MyExtensionsApp._1.Server\\MyExtensionsApp._1.Server.csproj"
     },

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1-vsmac.slnf
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1-vsmac.slnf
@@ -23,6 +23,7 @@
 #//#if (useDataContracts)
       "MyExtensionsApp._1.DataContracts\\MyExtensionsApp._1.DataContracts.csproj",
 #//#endif
+      "MyExtensionsApp._1.Base\\MyExtensionsApp._1.Base.csproj",
       "MyExtensionsApp._1\\MyExtensionsApp._1.csproj"
     ]
   }

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/MyExtensionsApp._1.Base.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/MyExtensionsApp._1.Base.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+	<PropertyGroup>
+		<!-- NOTE: The TargetFramework is required by MSBuild but not used as this project is not built. -->
+		<TargetFramework>$libraryBaseTargetFramework$</TargetFramework>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<!-- NOTE: The AppHead is accessible in the Platform heads -->
+		<None Remove="AppHead.*" />
+	</ItemGroup>
+</Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.sln
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.sln
@@ -18,6 +18,8 @@ EndProject
 
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyExtensionsApp._1", "MyExtensionsApp._1\MyExtensionsApp._1.csproj", "{BACDD33A-304C-46C4-9B00-AC166978D7E0}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyExtensionsApp._1.Base", "MyExtensionsApp._1.Base\MyExtensionsApp._1.Base.csproj", "{2189102C-8698-4760-A2C5-ADED686F84E2}"
+EndProject
 #//#if (useMobile)
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyExtensionsApp._1.Mobile", "MyExtensionsApp._1.Mobile\MyExtensionsApp._1.Mobile.csproj", "{24D56E12-2373-4CBD-9AD4-5C931D15FB0D}"
 EndProject
@@ -487,6 +489,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{BACDD33A-304C-46C4-9B00-AC166978D7E0} = {FAA2C1DE-F859-4053-9573-6245F7E832EF}
+		{2189102C-8698-4760-A2C5-ADED686F84E2} = {339C569C-EE23-445E-B908-743673EE5BC9}
 //#if (useDataContracts)
 		{5ED31500-DF01-462D-9436-EC2EDCAA1965} = {FAA2C1DE-F859-4053-9573-6245F7E832EF}
 //#endif


### PR DESCRIPTION
GitHub Issue (If applicable): 

- closes #176

## PR Type

- Feature

## What is the current behavior?

The base.props, app icon and splash screen resources are inaccessible while working in Visual Studio

## What is the new behavior?

A new csproj has been added to the solution that allows you to view these previously inaccessible files while still in Visual Studio. The solution uses the NoTargets SDK, is not referenced anywhere other than the Solution and does not affect the build at all.

NOTE: The AppHead.xaml/AppHead.xaml.cs are hidden from this project as they should be modified from the existing platform head projects where they are already linked in by the base.props