### PR TITLE
Link image assets to head projects

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/MyExtensionsApp._1.Base.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/MyExtensionsApp._1.Base.csproj
@@ -7,6 +7,6 @@
 
 	<ItemGroup>
 		<None Include="**\*" Exclude="obj\**;bin\**;*.csproj" />
-		<None Include="AppHead.xaml.cs" DependentUpon="AppHead.xaml" />
+		<None Update="AppHead.xaml.cs" DependentUpon="AppHead.xaml" />
 	</ItemGroup>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/MyExtensionsApp._1.Base.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/MyExtensionsApp._1.Base.csproj
@@ -2,10 +2,11 @@
 	<PropertyGroup>
 		<!-- NOTE: The TargetFramework is required by MSBuild but not used as this project is not built. -->
 		<TargetFramework>$libraryBaseTargetFramework$</TargetFramework>
+		<EnableDefaultItems>false</EnableDefaultItems>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<!-- NOTE: The AppHead is accessible in the Platform heads -->
-		<None Remove="AppHead.*" />
+		<None Include="**\*" Exclude="obj\**;bin\**;*.csproj" />
+		<None Include="AppHead.xaml.cs" DependentUpon="AppHead.xaml" />
 	</ItemGroup>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/base.props
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/base.props
@@ -24,5 +24,9 @@
 			Include="$(MSBuildThisFileDirectory)Splash\splash_screen.svg"
 			BaseSize="128,128"
 			Color="#086AD1" />
+		<!-- NOTE: Files explicitly linked to display in the head projects for clarity. -->
+		<None Include="$(MSBuildThisFileDirectory)Icons\iconapp.svg" Link="Icons\iconapp.svg" />
+		<None Include="$(MSBuildThisFileDirectory)Icons\appconfig.svg" Link="Icons\appconfig.svg" />
+		<None Include="$(MSBuildThisFileDirectory)Splash\splash_screen.svg" Link="Splash\splash_screen.svg" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #198


## PR Type

What kind of change does this PR introduce?

- Refactoring

## What is the current behavior?

Image Assets are only displayed in the Base project

## What is the new behavior?

Icon and Splash Screen assets are now added as linked files with the base.props. Note that LinkBase and wildcards were not working to link the files in for Visual Studio. As a result each file is explicitly added.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
