### PR TITLE
fix: Canary builds

### DIFF
--- a/build/templates/dotnet-install-windows.yml
+++ b/build/templates/dotnet-install-windows.yml
@@ -1,5 +1,5 @@
 parameters:
-  DotNetVersion: '7.0.x'
+  DotNetVersion: '7.0.306'
   UnoCheck_Version: '1.11.0-dev.2'
   UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/146b0b4b23d866bef455494a12ad7ffd2f6f2d20/manifests/uno.ui.manifest.json'
   InstallMauiWorkloads: false

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -28,7 +28,7 @@
 		<UnoToolkitMarkupVersion Condition="'$(UnoToolkitMarkupVersion)' == ''">2.6.0-dev.58</UnoToolkitMarkupVersion>
 		<UnoResizetizerVersion Condition="'$(UnoResizetizerVersion)' == ''">1.2.0-dev.19</UnoResizetizerVersion>
 		<UnoUniversalImageLoaderVersion Condition="'$(UnoUniversalImageLoaderVersion)' == ''">1.9.36</UnoUniversalImageLoaderVersion>
-		<UnoWasmBootstrapVersionNet7 Condition="'$(UnoWasmBootstrapVersionNet7)' == ''">7.0.24</UnoWasmBootstrapVersionNet7>
+		<UnoWasmBootstrapVersionNet7 Condition="'$(UnoWasmBootstrapVersionNet7)' == ''">7.0.27</UnoWasmBootstrapVersionNet7>
 		<UnoWasmBootstrapVersionNet8 Condition="'$(UnoWasmBootstrapVersionNet8)' == ''">8.0.0-dev.218</UnoWasmBootstrapVersionNet8>
 		<UnoMarkupVersion Condition="'$(UnoMarkupVersion)' == ''">4.8.0-dev.43</UnoMarkupVersion>
 		<UnoUITestHelpersVersion Condition="'$(UnoUITestHelpersVersion)' == ''">1.1.0-dev.59</UnoUITestHelpersVersion>

--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -14,7 +14,7 @@
     <!--#if (useTestSolutionFolder)-->
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.11.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <!--#if (useGitHubActions)-->
@@ -30,7 +30,7 @@
     <!--#if (!mauiEmbedding)-->
     <!--#if (useWinAppSdk)-->
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.3.230602002" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.3.230724000" />
     <!--#endif-->
     <!--#endif-->
     <!--#if (useAspNetCoreSerilogPackage)-->
@@ -51,7 +51,7 @@
     <PackageVersion Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useMsalAuthentication)-->
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.54.1" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.55.0" />
     <PackageVersion Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#endif-->
@@ -157,7 +157,7 @@
     <!--#endif-->
     <!--#if (useUITests)-->
     <PackageVersion Include="Uno.UITest.Helpers" Version="$UnoUITestHelpersVersion$" />
-    <PackageVersion Include="Xamarin.UITest" Version="4.1.4" />
+    <PackageVersion Include="Xamarin.UITest" Version="4.2.0" />
     <!--#endif-->
   </ItemGroup>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
@@ -77,7 +77,6 @@
 		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
-		<PackageReference Include="Microsoft.Identity.Client" />
 		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" />
 		<!--#endif-->
 		<!--#endif-->
@@ -163,7 +162,6 @@
 		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
 		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
@@ -61,7 +61,6 @@
 		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
-		<PackageReference Include="Microsoft.Identity.Client" />
 		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" />
 		<!--#endif-->
 		<!--#endif-->
@@ -144,7 +143,6 @@
 		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
 		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
@@ -59,7 +59,6 @@
 		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
-		<PackageReference Include="Microsoft.Identity.Client" />
 		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" />
 		<!--#endif-->
 		<!--#endif-->
@@ -142,7 +141,6 @@
 		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
 		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
@@ -73,7 +73,6 @@
 		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
-		<PackageReference Include="Microsoft.Identity.Client" />
 		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" />
 		<!--#endif-->
 		<!--#endif-->
@@ -156,7 +155,6 @@
 		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
 		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj
@@ -20,7 +20,7 @@
 		<!--#endif-->
 		<!--#else-->
 		<PackageReference Include="FluentAssertions" Version="6.11.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 		<PackageReference Include="coverlet.collector" Version="6.0.0" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/MyExtensionsApp._1.UITests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/MyExtensionsApp._1.UITests.csproj
@@ -21,12 +21,12 @@
 		<!--#endif-->
 		<!--#else-->
 		<PackageReference Include="FluentAssertions" Version="6.11.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 		<PackageReference Include="Uno.UITest.Helpers" Version="$UnoUITestHelpersVersion$" />
-		<PackageReference Include="Xamarin.UITest" Version="4.1.4" />
+		<PackageReference Include="Xamarin.UITest" Version="4.2.0" />
 		<!--#if (useGitHubActions)-->
 		<PackageReference Include="GitHubActionsTestLogger" Version="2.3.2">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
@@ -121,7 +121,6 @@
 		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
-		<PackageReference Include="Microsoft.Identity.Client" />
 		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" />
 		<!--#endif-->
 		<!--#endif-->
@@ -206,7 +205,6 @@
 		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
 		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
@@ -120,7 +120,7 @@
 		<PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
 		<PackageReference Include="Uno.WinUI" Version="$UnoWinUIVersion$" />
 		<!--#if (!mauiEmbedding)-->
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230602002" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230724000" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
 		<!--#endif-->
 		<!--#if (useCsharpMarkup)-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
@@ -83,7 +83,6 @@
 		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
-		<PackageReference Include="Microsoft.Identity.Client" />
 		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" />
 		<!--#endif-->
 		<!--#endif-->
@@ -172,7 +171,6 @@
 		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
 		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -168,7 +168,7 @@
 		<PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#if (useMsalAuthentication)-->
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.55.0" />
 		<PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
 		<!--#endif-->
 		<!--#endif-->
@@ -229,7 +229,7 @@
 				<PackageReference Include="Microsoft.WindowsAppSDK" />
 				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
 				<!--#else-->
-				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230602002" />
+				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230724000" />
 				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
 				<!--#endif-->
 			</ItemGroup>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Canaries break due to mismatch of versions for Microsoft.Identity.Client library

## What is the new behavior?

Updated version of library used by template and removed unnecessary references in head projects

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [N/A] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [N/A] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [N/A] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [N/A] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
