### PR TITLE
fix net8 build errors on windows

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -61,6 +61,7 @@
 				<IsWinAppSdk>true</IsWinAppSdk>
 				<SupportedOSPlatformVersion>10.0.18362.0</SupportedOSPlatformVersion>
 				<TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
+				<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
 			</PropertyGroup>
 		</When>
 	</Choose>

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -35,6 +35,8 @@ if($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE
 }
 
-$nugetPath = Join-Path -Path $PSScriptRoot -ChildPath 'bin' -AdditionalChildPath @('Release',"Uno.Templates.$TemplatesVersion.nupkg") 
+$nugetPath = Join-Path -Path $PSScriptRoot -ChildPath 'bin'
+$nugetPath = Join-Path -Path $nugetPath -ChildPath 'Release'
+$nugetPath = Join-Path -Path $nugetPath -ChildPath ("Uno.Templates.$TemplatesVersion.nupkg")
 dotnet new install $nugetPath
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes [#183](https://github.com/unoplatform/uno.templates/issues/183)

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Build errors related to RuntimeIdentifiers with .Net8 on shared project

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
all platform now builds and run

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

