### PR TITLE
fix: Updating UITest version

### DIFF
--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
@@ -31,7 +31,7 @@
 		<UnoWasmBootstrapVersionNet7 Condition="'$(UnoWasmBootstrapVersionNet7)' == ''">7.0.27</UnoWasmBootstrapVersionNet7>
 		<UnoWasmBootstrapVersionNet8 Condition="'$(UnoWasmBootstrapVersionNet8)' == ''">8.0.0-dev.218</UnoWasmBootstrapVersionNet8>
 		<UnoMarkupVersion Condition="'$(UnoMarkupVersion)' == ''">4.8.0-dev.43</UnoMarkupVersion>
-		<UnoUITestHelpersVersion Condition="'$(UnoUITestHelpersVersion)' == ''">1.1.0-dev.59</UnoUITestHelpersVersion>
+		<UnoUITestHelpersVersion Condition="'$(UnoUITestHelpersVersion)' == ''">1.1.0-dev.70</UnoUITestHelpersVersion>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageTags>dotnet-new;templates;uno-platform</PackageTags>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/Constants.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/Constants.cs
@@ -9,4 +9,5 @@ public class Constants
 	public readonly static string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (3rd generation)";
 
 	public readonly static Platform CurrentPlatform = Platform.Browser;
+	public readonly static Browser WebAssemblyBrowser = Browser.Chrome;
 }

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/TestBase.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/TestBase.cs
@@ -14,6 +14,7 @@ public class TestBase
 		AppInitializer.TestEnvironment.AndroidAppName = Constants.AndroidAppName;
 		AppInitializer.TestEnvironment.iOSDeviceNameOrId = Constants.iOSDeviceNameOrId;
 		AppInitializer.TestEnvironment.CurrentPlatform = Constants.CurrentPlatform;
+		AppInitializer.TestEnvironment.WebAssemblyBrowser = Constants.WebAssemblyBrowser;
 
 #if DEBUG
 		AppInitializer.TestEnvironment.WebAssemblyHeadless = false;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #215

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

See #215 

## What is the new behavior?

Updates UITest to latest dev release which fixes the chromedriver download behavior
It also adds support for running UITests in Edge

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [N/A] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [N/A] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
