### PR TITLE
chore: move Maui registrations into MauiControls lib

### DIFF
--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">3.0.0-dev.2112</UnoExtensionsVersion>
+		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">3.0.0-dev.2142</UnoExtensionsVersion>
 		<UnoVersion Condition="'$(UnoVersion)' == ''">5.0.0-dev.1734</UnoVersion>
 		<UnoExtensionsLoggingVersion Condition="'$(UnoExtensionsLoggingVersion)' == ''">1.4.0</UnoExtensionsLoggingVersion>
 		<SkiaSharpVersion Condition="'$(SkiaSharpVersion)' == ''">2.88.4-preview.89</SkiaSharpVersion>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/AppBuilderExtensions.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/AppBuilderExtensions.cs
@@ -1,0 +1,11 @@
+//-:cnd:noEmit
+namespace MyExtensionsApp._1.MauiControls;
+
+public static class AppBuilderExtensions
+{
+    public static MauiAppBuilder UseMauiControls(this MauiAppBuilder builder)
+    {
+        builder.UseMauiCommunityToolkit();
+        return builder;
+    }
+}

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/AppBuilderExtensions.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/AppBuilderExtensions.cs
@@ -1,11 +1,13 @@
 //-:cnd:noEmit
-namespace MyExtensionsApp._1.MauiControls;
+using CommunityToolkit.Maui;
+
+namespace MyExtensionsApp._1;
 
 public static class AppBuilderExtensions
 {
-    public static MauiAppBuilder UseMauiControls(this MauiAppBuilder builder)
-    {
-        builder.UseMauiCommunityToolkit();
-        return builder;
-    }
+	public static MauiAppBuilder UseMauiControls(this MauiAppBuilder builder)
+	{
+		builder.UseMauiCommunityToolkit();
+		return builder;
+	}
 }

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/AppBuilderExtensions.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/AppBuilderExtensions.cs
@@ -5,9 +5,6 @@ namespace MyExtensionsApp._1;
 
 public static class AppBuilderExtensions
 {
-	public static MauiAppBuilder UseMauiControls(this MauiAppBuilder builder)
-	{
+	public static MauiAppBuilder UseMauiControls(this MauiAppBuilder builder) =>
 		builder.UseMauiCommunityToolkit();
-		return builder;
-	}
 }

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/Styles.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/Styles.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+					xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+					x:Class="MyExtensionsApp._1.MauiControls.Styles">
+
+	<!-- You can provide styles for Maui Controls here that will be shared 
+			 across all MAUI controls within the app -->
+	<Style TargetType="Label">
+		<Setter Property="TextColor" Value="Gray" />
+	</Style>
+</ResourceDictionary>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/Styles.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/Styles.xaml.cs
@@ -1,0 +1,10 @@
+//-:cnd:noEmit
+namespace MyExtensionsApp._1.MauiControls;
+
+public partial class Styles : ResourceDictionary
+{
+	public Styles()
+	{
+		InitializeComponent();
+	}
+}

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.blank.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.blank.cs
@@ -21,7 +21,8 @@ public class App : Application
 //+:cnd:noEmit
 #if mauiEmbedding
 		this.UseMauiEmbedding(maui => maui
-					.UseMauiCommunityToolkit());
+					.UseMauiControls()
+					.UseMauiEmbeddingResources<MauiControls.Styles>());
 #endif
 //-:cnd:noEmit
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.recommended.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.recommended.cs
@@ -143,8 +143,7 @@ public class App : Application
 				)
 #endif
 #if mauiEmbedding
-				.UseMauiEmbedding(this, maui => maui
-					.UseMauiCommunityToolkit())
+				.UseMauiEmbedding(this, maui => maui.UseMauiControls())
 #endif
 				.ConfigureServices((context, services) => {
 					// TODO: Register your services

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.recommended.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.recommended.cs
@@ -1,8 +1,3 @@
-//+:cnd:noEmit
-#if mauiEmbedding
-using CommunityToolkit.Maui;
-
-#endif
 //-:cnd:noEmit
 namespace MyExtensionsApp._1;
 
@@ -143,7 +138,8 @@ public class App : Application
 				)
 #endif
 #if mauiEmbedding
-				.UseMauiEmbedding(this, maui => maui.UseMauiControls())
+				.UseMauiEmbedding(this, maui => maui.UseMauiControls()
+					.UseMauiEmbeddingResources<MauiControls.Styles>())
 #endif
 				.ConfigureServices((context, services) => {
 					// TODO: Register your services

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.recommended.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.recommended.cs
@@ -138,7 +138,8 @@ public class App : Application
 				)
 #endif
 #if mauiEmbedding
-				.UseMauiEmbedding(this, maui => maui.UseMauiControls()
+				.UseMauiEmbedding(this, maui => maui
+					.UseMauiControls()
 					.UseMauiEmbeddingResources<MauiControls.Styles>())
 #endif
 				.ConfigureServices((context, services) => {

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -101,9 +101,6 @@
 		<!--#endif-->
 		<!--#endif-->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" />
-		<!--#if (mauiEmbedding)-->
-		<PackageReference Include="CommunityToolkit.Maui" />
-		<!--#endif-->
 		<!--#if (useMauiPackageReference)-->
 		<PackageReference Include="Microsoft.Maui.Controls" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
@@ -194,9 +191,6 @@
 		<!--#endif-->
 		<!--#endif-->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
-		<!--#if (mauiEmbedding)-->
-		<PackageReference Include="CommunityToolkit.Maui" Version="5.2.0" />
-		<!--#endif-->
 		<!--#if (useMauiPackageReference)-->
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -3,7 +3,7 @@ param(
     [string]$TemplatesVersion = "255.255.255.255",
 
     # Version of published Uno.Extensions packages
-    [string]$ExtensionsVersion = "3.0.0-dev.2112",
+    [string]$ExtensionsVersion = "3.0.0-dev.2142",
 
     # Version of published Uno.WinUI packages
     [string]$UnoVersion = "5.0.0-dev.1732"


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- implements unoplatform/uno.extensions#1749

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

There is no ability to provide Maui styles globally for the application which would normally go in the Maui Application.

## What is the new behavior?

We now use the new extension for Maui Embedding to provide a Resource Dictionary that will be provided in the parent resources so that styles are automatically applied and resources are available.
