### PR TITLE
chore: Revert removal of OverrideTargetFrameworks

### DIFF
--- a/src/Uno.Templates/content/unoapp/solution-config.props.sample
+++ b/src/Uno.Templates/content/unoapp/solution-config.props.sample
@@ -12,7 +12,7 @@
     <PropertyGroup>
 		<!-- Uncomment each line for each platform that you want to build: -->
 		
-		<!-- <OverrideTargetFrameworks Condition="''!='hint: Windows App Sdk (WinUI)'">$(OverrideTargetFrameworks);$baseTargetFramework$-windows10.0.18362</OverrideTargetFrameworks> -->
+		<!-- <OverrideTargetFrameworks Condition="''!='hint: Windows App Sdk (WinUI)'">$(OverrideTargetFrameworks);$baseTargetFramework$-windows10.0.19041.0</OverrideTargetFrameworks> -->
 		<!-- <OverrideTargetFrameworks Condition="''!='hint: WASM, Skia'">$(OverrideTargetFrameworks);$baseTargetFramework$</OverrideTargetFrameworks> -->
 		<!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 iOS'">$(OverrideTargetFrameworks);$baseTargetFramework$-ios</OverrideTargetFrameworks> -->
 		<!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 Android'">$(OverrideTargetFrameworks);$baseTargetFramework$-android</OverrideTargetFrameworks> -->

--- a/src/Uno.Templates/content/unoapp/solution-config.props.sample
+++ b/src/Uno.Templates/content/unoapp/solution-config.props.sample
@@ -9,7 +9,7 @@
 			3) Make sure to do a Rebuild, so that nuget restores the proper packages for the new target
 	-->
 
-    <PropertyGroup>
+	<PropertyGroup>
 		<!-- Uncomment each line for each platform that you want to build: -->
 		
 		<!-- <OverrideTargetFrameworks Condition="''!='hint: Windows App Sdk (WinUI)'">$(OverrideTargetFrameworks);$baseTargetFramework$-windows10.0.19041.0</OverrideTargetFrameworks> -->
@@ -17,6 +17,6 @@
 		<!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 iOS'">$(OverrideTargetFrameworks);$baseTargetFramework$-ios</OverrideTargetFrameworks> -->
 		<!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 Android'">$(OverrideTargetFrameworks);$baseTargetFramework$-android</OverrideTargetFrameworks> -->
 		<!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 macOS Catalyst'">$(OverrideTargetFrameworks);$baseTargetFramework$-maccatalyst</OverrideTargetFrameworks> -->
-    </PropertyGroup>
+	</PropertyGroup>
 
 </Project>

--- a/src/Uno.Templates/content/unoapp/solution-config.props.sample
+++ b/src/Uno.Templates/content/unoapp/solution-config.props.sample
@@ -9,14 +9,14 @@
 			3) Make sure to do a Rebuild, so that nuget restores the proper packages for the new target
 	-->
 
-	<PropertyGroup>
+    <PropertyGroup>
 		<!-- Uncomment each line for each platform that you want to build: -->
 		
-		<!-- <OverrideTargetFrameworks Condition="''!='hint: Windows App Sdk (WinUI)'">$baseTargetFramework$-windows10.0.19041.0</OverrideTargetFrameworks> -->
-		<!-- <OverrideTargetFrameworks Condition="''!='hint: WASM, Skia'">$baseTargetFramework$</OverrideTargetFrameworks> -->
-		<!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 iOS'">$baseTargetFramework$-ios</OverrideTargetFrameworks> -->
-		<!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 Android'">$baseTargetFramework$-android</OverrideTargetFrameworks> -->
-		<!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 macOS Catalyst'">$baseTargetFramework$-maccatalyst</OverrideTargetFrameworks> -->
-	</PropertyGroup>
+		<!-- <OverrideTargetFrameworks Condition="''!='hint: Windows App Sdk (WinUI)'">$(OverrideTargetFrameworks);$baseTargetFramework$-windows10.0.18362</OverrideTargetFrameworks> -->
+		<!-- <OverrideTargetFrameworks Condition="''!='hint: WASM, Skia'">$(OverrideTargetFrameworks);$baseTargetFramework$</OverrideTargetFrameworks> -->
+		<!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 iOS'">$(OverrideTargetFrameworks);$baseTargetFramework$-ios</OverrideTargetFrameworks> -->
+		<!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 Android'">$(OverrideTargetFrameworks);$baseTargetFramework$-android</OverrideTargetFrameworks> -->
+		<!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 macOS Catalyst'">$(OverrideTargetFrameworks);$baseTargetFramework$-maccatalyst</OverrideTargetFrameworks> -->
+    </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

When specifying the OverrideTargetFrameworks in the sample-config.props, if you uncomment multiple lines, only the last framework is included

## What is the new behavior?

As many lines as necessary can be uncommented and the tfms are cumulative

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
