### PR TITLE
fix: Force embedded control to expand to fill available space

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/EmbeddedControl.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/EmbeddedControl.xaml
@@ -2,7 +2,9 @@
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			 xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
-			 x:Class="MyExtensionsApp._1.MauiControls.EmbeddedControl">
+			 x:Class="MyExtensionsApp._1.MauiControls.EmbeddedControl"
+			 HorizontalOptions="Fill"
+			 VerticalOptions="Fill">
 	<VerticalStackLayout>
 		<toolkit:AvatarView HeightRequest="100"
 							WidthRequest="100">


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

maui controls don't render to fill available space when added to embedded control

## What is the new behavior?

EmbeddedControl fills to available space in the Uno app. Then Maui control will render correctly based on their horizontal/vertical alignment options.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
