### PR TITLE
fix: Adding reference to Uno.WinUI.Lottie

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -123,6 +123,7 @@
     <PackageVersion Include="Uno.Wasm.Bootstrap.Server" Version="$UnoWasmBootstrapVersion$" />
     <!--#endif-->
     <PackageVersion Include="Uno.WinUI" Version="$UnoWinUIVersion$" />
+    <PackageVersion Include="Uno.WinUI.Lottie" Version="$UnoWinUIVersion$" />
     <!--#if (useCsharpMarkup)-->
     <PackageVersion Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
     <!--#if (useToolkit)-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -231,6 +231,12 @@
 		</When>
 		<Otherwise>
 			<ItemGroup>
+				<!--#if (useCPM)-->
+				<PackageReference Include="Uno.WinUI.Lottie" />
+				<!--#else-->
+				<PackageReference Include="Uno.WinUI.Lottie" Version="$UnoWinUIVersion$" />
+				<!--#endif-->
+
 				<!-- Include all images by default - matches the __WindowsAppSdkDefaultImageIncludes property in the WindowsAppSDK -->
 				<Content Include="Assets\**;**/*.png;**/*.bmp;**/*.jpg;**/*.dds;**/*.tif;**/*.tga;**/*.gif" Exclude="bin\**;obj\**;**\*.svg" />
 				<Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
@@ -243,6 +249,12 @@
 	</Choose>
 	<!--#else-->
 	<ItemGroup>
+		<!--#if (useCPM)-->
+		<PackageReference Include="Uno.WinUI.Lottie" />
+		<!--#else-->
+		<PackageReference Include="Uno.WinUI.Lottie" Version="$UnoWinUIVersion$" />
+		<!--#endif-->
+
 		<!-- Include all images by default - matches the __WindowsAppSdkDefaultImageIncludes property in the WindowsAppSDK -->
 		<Content Include="Assets\**;**/*.png;**/*.bmp;**/*.jpg;**/*.dds;**/*.tif;**/*.tga;**/*.gif" Exclude="bin\**;obj\**" />
 		<Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Adding a ProgressRing to a blank application will display an error on all targets except Windows as it needs uno.winui.lottie reference

## What is the new behavior?

Adds Uno.WinUi.Lottie to non-winui targets

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
