### PR TITLE
chore: Tidyup

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -22,6 +22,9 @@
 		<PackageReference Include="Uno.Dsp.Tasks" />
 		<!--#endif-->
 		<PackageReference Include="Uno.WinUI" />
+		<!--#if (!useWinAppSdk) -->
+		<PackageReference Include="Uno.WinUI.Lottie" />
+		<!--#endif-->
 		<PackageReference Include="Uno.Resizetizer" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" />
@@ -112,6 +115,9 @@
 		<PackageReference Include="Uno.Dsp.Tasks" Version="$UnoDspTasksVersion$" />
 		<!--#endif-->
 		<PackageReference Include="Uno.WinUI" Version="$UnoWinUIVersion$" />
+		<!--#if (!useWinAppSdk) -->
+		<PackageReference Include="Uno.WinUI.Lottie" Version="$UnoWinUIVersion$" />
+		<!--#endif-->
 		<PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
@@ -249,12 +255,6 @@
 	</Choose>
 	<!--#else-->
 	<ItemGroup>
-		<!--#if (useCPM)-->
-		<PackageReference Include="Uno.WinUI.Lottie" />
-		<!--#else-->
-		<PackageReference Include="Uno.WinUI.Lottie" Version="$UnoWinUIVersion$" />
-		<!--#endif-->
-
 		<!-- Include all images by default - matches the __WindowsAppSdkDefaultImageIncludes property in the WindowsAppSDK -->
 		<Content Include="Assets\**;**/*.png;**/*.bmp;**/*.jpg;**/*.dds;**/*.tif;**/*.tga;**/*.gif" Exclude="bin\**;obj\**" />
 		<Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the current behavior?

https://github.com/unoplatform/uno.templates/pull/231 - leaves uno.winui.lottie package reference in separate block when not referencing winappsdk

## What is the new behavior?

Package reference is with all the other package reference when not targetting winappsdk

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
