### PR TITLE
feat: Adding image converter to template

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/App.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/App.xaml
@@ -1,6 +1,7 @@
 ﻿<?xml version = "1.0" encoding = "UTF-8" ?>
 <Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:MyExtensionsApp._1"
 			 x:Class="MyExtensionsApp._1.MauiControls.App">
     <Application.Resources>
         <ResourceDictionary>
@@ -8,6 +9,7 @@
                 <ResourceDictionary Source="Styles/Colors.xaml" />
                 <ResourceDictionary Source="Styles/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
+            <local:UnoImageConverter x:Key="UnoImageConverter" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/EmbeddedControl.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/EmbeddedControl.xaml
@@ -11,7 +11,8 @@
 		VerticalOptions="Center">
 
 		<Image
-			Source="MyExtensionsApp._1/Assets/Images/dotnet_bot.png"
+			BindingContext="MyExtensionsApp._1/Assets/Images/dotnet_bot.png"
+			Source="{Binding Converter={StaticResource UnoImageConverter}}"
 			SemanticProperties.Description="Cute dot net bot waving hi to you!"
 			HeightRequest="200"
 			HorizontalOptions="Center" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/UnoImageConverter.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/UnoImageConverter.cs
@@ -1,0 +1,21 @@
+//-:cnd:noEmit
+using System.Globalization;
+
+namespace MyExtensionsApp._1;
+
+public class UnoImageConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+#if ANDROID
+        return (value + "").Replace('/','_').Replace('\\','_');
+#else
+        return value;
+#endif
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Image isn't displaying on android

## What is the new behavior?

Template includes a converter that adjusts the path to the image for Android

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
