### PR TITLE
fix: Adding dispatcher to LoginAsync calls

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/LoginModel.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/LoginModel.cs
@@ -1,7 +1,7 @@
 //-:cnd:noEmit
 namespace MyExtensionsApp._1.Presentation;
 
-public partial record LoginModel(INavigator Navigator, IAuthenticationService Authentication)
+public partial record LoginModel(IDispatcher Dispatcher, INavigator Navigator, IAuthenticationService Authentication)
 {
 	public string Title { get; } = "Login";
 
@@ -18,9 +18,9 @@ public partial record LoginModel(INavigator Navigator, IAuthenticationService Au
         var username = await Username ?? string.Empty;
         var password = await Password ?? string.Empty;
 
-        var success = await Authentication.LoginAsync(new Dictionary<string, string> { { nameof(Username), username }, { nameof(Password), password } });
+        var success = await Authentication.LoginAsync(Dispatcher, new Dictionary<string, string> { { nameof(Username), username }, { nameof(Password), password } });
 #else
-        var success = await Authentication.LoginAsync();
+        var success = await Authentication.LoginAsync(Dispatcher);
 #endif
 //-:cnd:noEmit
         if (success)

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/LoginViewModel.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/LoginViewModel.cs
@@ -6,6 +6,8 @@ public partial class LoginViewModel : ObservableObject
 	private IAuthenticationService _authentication;
 
 	private INavigator _navigator;
+	
+	private IDispatcher _dispatcher;
 
  //+:cnd:noEmit
 #if useCustomAuthentication
@@ -17,9 +19,11 @@ public partial class LoginViewModel : ObservableObject
 #endif
 
 	public LoginViewModel(
+		IDispatcher dispatcher,
 		INavigator navigator,
 		IAuthenticationService authentication)
 	{
+		_dispatcher = dispatcher;
 		_navigator = navigator;
 		_authentication = authentication;
 		Login = new AsyncRelayCommand(DoLogin);
@@ -28,9 +32,9 @@ public partial class LoginViewModel : ObservableObject
 	private async Task DoLogin()
 	{
 #if useCustomAuthentication
-        var success = await _authentication.LoginAsync(new Dictionary<string, string> { { nameof(Username), Username ?? string.Empty }, { nameof(Password), Password ?? string.Empty } });
+        var success = await _authentication.LoginAsync(_dispatcher, new Dictionary<string, string> { { nameof(Username), Username ?? string.Empty }, { nameof(Password), Password ?? string.Empty } });
 #else
-        var success = await _authentication.LoginAsync();
+        var success = await _authentication.LoginAsync(_dispatcher);
 #endif
 //-:cnd:noEmit
         if (success)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #https://github.com/unoplatform/uno.templates/issues/209

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Dispatcher not passed into the LoginAsync method - throws exception and fails login

## What is the new behavior?

Dipatcher passed into LoginAsync method

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
