### PR TITLE
feat: Improving VSCode debugging experience

### DIFF
--- a/src/Uno.Templates/content/unoapp/.vscode/launch.json
+++ b/src/Uno.Templates/content/unoapp/.vscode/launch.json
@@ -5,6 +5,13 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Uno Platform Mobile",
+      "type": "Uno",
+      "request": "launch",
+      // any Uno* task will do, this is simply to satisfy vscode requirement when a launch.json is present
+      "preLaunchTask": "Uno: android | Debug | android-x64"
+    },
+    {
       // Use IntelliSense to find out which attributes exist for C# debugging
       // Use hover for the description of the existing attributes
       // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
@@ -41,13 +48,6 @@
       // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
       "console": "internalConsole",
       "stopAtEntry": false
-    },
-    {
-      "name": "Uno Platform Mobile",
-      "type": "Uno",
-      "request": "launch",
-      // any Uno* task will do, this is simply to satisfy vscode requirement when a launch.json is present
-      "preLaunchTask": "Uno: android | Debug | android-x64"
     },
   ]
 }

--- a/src/Uno.Templates/content/unoapp/.vscode/launch.json
+++ b/src/Uno.Templates/content/unoapp/.vscode/launch.json
@@ -4,6 +4,7 @@
   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
   "version": "0.2.0",
   "configurations": [
+//#if (useMobile)
     {
       "name": "Uno Platform Mobile",
       "type": "Uno",
@@ -11,6 +12,8 @@
       // any Uno* task will do, this is simply to satisfy vscode requirement when a launch.json is present
       "preLaunchTask": "Uno: android | Debug | android-x64"
     },
+//#endif
+//#if (useWasm)
     {
       // Use IntelliSense to find out which attributes exist for C# debugging
       // Use hover for the description of the existing attributes
@@ -30,6 +33,8 @@
         "cwd": "${workspaceFolder}/MyExtensionsApp._1.Wasm"
       }
     },
+//#endif
+//#if (useGtk)
     {
       // Use IntelliSense to find out which attributes exist for C# debugging
       // Use hover for the description of the existing attributes
@@ -49,5 +54,6 @@
       "console": "internalConsole",
       "stopAtEntry": false
     },
+//#endif
   ]
 }

--- a/src/Uno.Templates/content/unoapp/.vscode/tasks.json
+++ b/src/Uno.Templates/content/unoapp/.vscode/tasks.json
@@ -1,6 +1,7 @@
 {
   "version": "2.0.0",
   "tasks": [
+//#if (useWasm)
     {
       "label": "build-wasm",
       "command": "dotnet",
@@ -25,6 +26,8 @@
       ],
       "problemMatcher": "$msCompile"
     },
+//#endif
+//#if (useGtk)
     {
       "label": "build-skia-gtk",
       "command": "dotnet",
@@ -49,5 +52,6 @@
       ],
       "problemMatcher": "$msCompile"
     }
+//#endif
   ]
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix
- Feature

## What is the current behavior?

Launch.json and Task.json contains mobible, wasm and gtk entries, even if those platforms aren't selected
Launch.json has mobile target last, meaning that web debugging is selected by default

## What is the new behavior?

Launch.json now has mobile target first - makes it easier for developers migrating from vs mac
Launch.json and Task.json items are conditional based on targets selected

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
