### PR TITLE
Limit required VS components based on project selections

### DIFF
--- a/src/Uno.Templates/content/unoapp/.vsconfig
+++ b/src/Uno.Templates/content/unoapp/.vsconfig
@@ -5,10 +5,11 @@
     "Microsoft.VisualStudio.Workload.CoreEditor",
     "Microsoft.NetCore.Component.SDK",
     "Microsoft.NetCore.Component.DevelopmentTools",
-    "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions",
-    "Microsoft.NetCore.Component.Web",
     "Microsoft.Net.ComponentGroup.DevelopmentPrerequisites",
     "Microsoft.VisualStudio.Component.TextTemplating",
+#//#if (useWasm)
+    "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions",
+    "Microsoft.NetCore.Component.Web",
     "Microsoft.VisualStudio.Component.IISExpress",
     "Component.Microsoft.Web.LibraryManager",
     "Microsoft.VisualStudio.ComponentGroup.Web",
@@ -17,22 +18,32 @@
     "Microsoft.VisualStudio.Workload.NetWeb",
     "Microsoft.VisualStudio.ComponentGroup.Azure.Prerequisites",
     "Microsoft.VisualStudio.Workload.Azure",
+    "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.TemplateEngine",
+#//#endif
+#//#if (useWinAppSdk)
     "Microsoft.VisualStudio.Component.Windows10SDK.19041",
+    "Microsoft.VisualStudio.ComponentGroup.MSIX.Packaging",
+#//#endif
     "Microsoft.VisualStudio.Component.ManagedDesktop.Prerequisites",
     "Microsoft.VisualStudio.Component.Debugger.JustInTime",
-    "Microsoft.VisualStudio.ComponentGroup.MSIX.Packaging",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.Component.NetFX.Native",
     "Microsoft.VisualStudio.Component.Graphics",
-    "Component.OpenJDK",
-    "Microsoft.VisualStudio.Component.MonoDebugger",
     "Microsoft.VisualStudio.Component.Merq",
+#//#if (useIOS)
     "Component.Xamarin.RemotedSimulator",
-    "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.TemplateEngine",
+#//#endif
+#//#if (useMobile)
+    "Microsoft.VisualStudio.Component.MonoDebugger",
     "Component.Xamarin",
-    "Component.Android.SDK32",
+    "Microsoft.VisualStudio.ComponentGroup.Maui.All",
+#//#endif
+#//#if (useAndroid)
+    "Component.Android.SDK34",
+    "Component.Android.SDK33",
+    "Component.OpenJDK",
+#//#endif
     "Microsoft.VisualStudio.Workload.NetCrossPlat",
-    "Microsoft.VisualStudio.Workload.NetCoreTools",
-    "Microsoft.VisualStudio.ComponentGroup.Maui.All"
+    "Microsoft.VisualStudio.Workload.NetCoreTools"
   ]
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #227

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

all recommended VS components are added to the generated project's .vsconfig

## What is the new behavior?

this is now trimmed down based on the platforms selected
