### PR TITLE
fix: Pinning workload restore

### DIFF
--- a/build/templates/dotnet-install-windows.yml
+++ b/build/templates/dotnet-install-windows.yml
@@ -1,5 +1,5 @@
 parameters:
-  DotNetVersion: '7.0.306'
+  DotNetVersion: '7.0.400'
   DotNetWorkloads: 'android ios maccatalyst'
   UnoCheck_Version: '1.14.1'
   UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/c3b289d7bb16a2a2df7f7f7f848d76fe1e74036d/manifests/uno.ui.manifest.json'

--- a/build/templates/package-validation.yml
+++ b/build/templates/package-validation.yml
@@ -10,14 +10,18 @@ steps:
 - powershell: |
     $templateArgs = '${{ parameters.arguments }}'
     Write-Host "TemplateArgs = '$templateArgs'"
-    $dotnetVersion = '7.0.306'
+    $dotnetVersion = '7.0.400'
+    $workloadRestore = 'https://maui.blob.core.windows.net/metadata/rollbacks/7.0.92.json'
 
     if ($templateArgs.Contains('net8')) {
       $dotnetVersion = '8.0.100-preview.7.23376.3'
+      $workloadRestore = 'https://maui.blob.core.windows.net/metadata/rollbacks/8.0.0-preview.7.8842.json'
     }
 
     Write-Host "DotNetVersion = $dotnetVersion"
     Write-Output "##vso[task.setvariable variable=DotNetVersion]$dotnetVersion"
+    Write-Host "WorkloadRestore = $workloadRestore"
+    Write-Output "##vso[task.setvariable variable=WorkloadRestore]$workloadRestore"
   displayName: Evaluate Template Args
 
 - template: dotnet-install-windows.yml
@@ -43,7 +47,8 @@ steps:
 - powershell: |
       dotnet nuget add source -n nuget_local $(Build.SourcesDirectory)\src\PackageCache
       dotnet nuget add source -n uno_dev "https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json"
-
+      dotnet nuget add source -n net8 "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json"
+      dotnet nuget add source -n ApiLocal "https://api.nuget.org/v3/index.json"
       Set-PSDebug -Trace 1
       $ErrorActionPreference = 'Stop'
 
@@ -66,7 +71,7 @@ steps:
 
       cd UnoApp1
 
-      & dotnet workload restore
+      & dotnet workload restore --from-rollback-file $(WorkloadRestore) --skip-sign-check
       & dotnet build UnoApp1.sln "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
       if ($LASTEXITCODE -ne 0)
       {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Build broken because of MS update

## What is the new behavior?

Build fixed by pinning dotnet workload restore

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
