### PR TITLE
fix: removed toolkit xlmns

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/EmbeddedControl.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/EmbeddedControl.xaml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-			 xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
 			 x:Class="MyExtensionsApp._1.MauiControls.EmbeddedControl"
 			 HorizontalOptions="Fill"
 			 VerticalOptions="Fill">


### PR DESCRIPTION
Just a quick fix to remove the xmlns for CommunityToolkit.Maui from our template