### PR TITLE
Adding stand alone Maui Embedding class lib

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.json]
+indent_style = space
+indent_size = 2

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -43,6 +43,7 @@
 
 	<ItemGroup>
 		<TemplateFile Include="content/**/*" Exclude="**/obj/**;**/bin/**" />
+		<MauiControlsTemplateFile Include="content/unoapp/MyExtensionsApp._1.MauiControls/**/*" Exclude="**/obj/**;**/bin/**" />
 		<UpToDateCheckInput Include="@(TemplateFile)" />
 		<MergeTemplatePackage Include="Uno.ProjectTemplates.Dotnet" Version="$(UnoVersion)">
 			<FileExists>false</FileExists>
@@ -77,6 +78,7 @@
 		<Copy SourceFiles="content/unoapp/MyExtensionsApp._1.Windows/Package.appxmanifest" DestinationFiles="$(TemplateContentFolder)/unoapp/MyExtensionsApp._1.Skia.Gtk/Package.appxmanifest" SkipUnchangedFiles="false" />
 		<Copy SourceFiles="content/unoapp/MyExtensionsApp._1.Windows/Package.appxmanifest" DestinationFiles="$(TemplateContentFolder)/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/Package.appxmanifest" SkipUnchangedFiles="false" />
 		<Copy SourceFiles="content/unoapp/MyExtensionsApp._1.Windows/Package.appxmanifest" DestinationFiles="$(TemplateContentFolder)/unoapp/MyExtensionsApp._1.Skia.WPF/Package.appxmanifest" SkipUnchangedFiles="false" />
+		<Copy SourceFiles="@(MauiControlsTemplateFile)" DestinationFiles="$(TemplateContentFolder)/unomauilib/%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="false" />
 		<ItemGroup>
 			<_PackageFiles Include="$(TemplateContentFolder)/**/*" PackagePath="content" />
 		</ItemGroup>
@@ -85,6 +87,7 @@
 	<Target Name="ReplaceVersions" BeforeTargets="BeforeBuild" AfterTargets="PrepareTemplateFiles">
 		<ItemGroup>
 			<_TemplateJson Include="$(IntermediateOutputPath)/content/**/template.json" />
+			<_MauiLibTemplateFile Include="$(TemplateContentFolder)/unomauilib/**" />
 		</ItemGroup>
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoExtensionsVersion" ReplacementText="$(UnoExtensionsVersion)" />
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoWinUIVersion" ReplacementText="$(UnoVersion)" />
@@ -101,6 +104,7 @@
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoWasmBootstrapVersionNet8" ReplacementText="$(UnoWasmBootstrapVersionNet8)"/>
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoMarkupVersion" ReplacementText="$(UnoMarkupVersion)"/>
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoUITestHelpersVersion" ReplacementText="$(UnoUITestHelpersVersion)"/>
+		<ReplaceFileText Filename="%(_MauiLibTemplateFile.Identity)" MatchExpression="MyExtensionsApp\._1\.MauiControls" ReplacementText="MyExtensionsApp._1" />
 	</Target>
 
 	<Target Name="DownloadTemplatePackages" BeforeTargets="BeforeBuild;PrepareTemplateFiles">

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/MyExtensionsApp._1.MauiControls.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/MyExtensionsApp._1.MauiControls.csproj
@@ -12,12 +12,51 @@
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 	</PropertyGroup>
+	<!--#if (unoMauiClassLibrary)-->
+
+	<Choose>
+		<!--#if (useAndroid)-->
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+			<PropertyGroup>
+				<SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
+			</PropertyGroup>
+		</When>
+		<!--#endif-->
+		<!--#if (useiOS)-->
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+			<PropertyGroup>
+				<SupportedOSPlatformVersion>14.2</SupportedOSPlatformVersion>
+			</PropertyGroup>
+		</When>
+		<!--#endif-->
+		<!--#if (useMacCatalyst)-->
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+			<PropertyGroup>
+				<SupportedOSPlatformVersion>14.0</SupportedOSPlatformVersion>
+			</PropertyGroup>
+		</When>
+		<!--#endif-->
+		<!--#if (useWinAppSdk)-->
+		<When Condition="$(TargetFramework.Contains('windows10'))">
+			<PropertyGroup>
+				<SupportedOSPlatformVersion>10.0.18362.0</SupportedOSPlatformVersion>
+				<TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
+				<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+				<EnableCoreMrtTooling Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">false</EnableCoreMrtTooling>
+			</PropertyGroup>
+		</When>
+		<!--#endif-->
+	</Choose>
+	<!--#endif-->
 	<!--#if (useMauiPackageReference)-->
 
 	<ItemGroup>
 		<!--#if (useCPM)-->
 		<PackageReference Include="Microsoft.Maui.Controls" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
+		<!--#elif (useStandaloneCPM)-->
+		<PackageReference Include="Microsoft.Maui.Controls" VersionOverride="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" VersionOverride="$(MauiVersion)" />
 		<!--#else -->
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />

--- a/src/Uno.Templates/content/unomauilib/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unomauilib/.template.config/dotnetcli.host.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "tfm": {
+      "longName": "tfm",
+      "shortName": "tfm"
+    },
+    "cpm": {
+      "longName": "cpm",
+      "shortName": "cpm"
+    },
+    "useAndroid": {
+      "longName": "android",
+      "shortName": "android"
+    },
+    "useiOS": {
+      "longName": "ios",
+      "shortName": "ios"
+    },
+    "useMacCatalyst": {
+      "longName": "maccatalyst",
+      "shortName": "maccatalyst"
+    },
+    "useWinAppSdk": {
+      "longName": "winappsdk",
+      "shortName": "winappsdk"
+    }
+  }
+}

--- a/src/Uno.Templates/content/unomauilib/.template.config/ide.host.json
+++ b/src/Uno.Templates/content/unomauilib/.template.config/ide.host.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "unsupportedHosts": [
+    {
+      "id": "vs"
+    }
+  ]
+}

--- a/src/Uno.Templates/content/unomauilib/.template.config/template.json
+++ b/src/Uno.Templates/content/unomauilib/.template.config/template.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Uno Platform",
+  "classifications": [
+    "Uno Platform",
+    "Android",
+    "iOS",
+    "Mac Catalyst",
+    "Windows",
+    "WinUI"
+  ],
+  "name": "Uno Maui Embedding Class Library",
+  "identity": "Uno.Platform.UnoApp.WinUI.mauiembeddingclasslibrary.CSharp",
+  "groupIdentity": "Uno.Platform.UnoApp.WinUI.mauiembeddingclasslibrary",
+  "description": "Project template for creating .NET MAUI Controls to embed within your Uno Platform app.",
+  "precedence": "99",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "shortName": "unomauilib",
+  "sourceName": "MyExtensionsApp._1",
+  "defaultName": "UnoMauiLibrary",
+  "placeholderFilename": "template-ignore",
+  "preferNameDirectory": true,
+  "symbols": {
+    "tfm": {
+      "displayName": "Target Framework",
+      "type": "parameter",
+      "datatype": "choice",
+      "enableQuotelessLiterals": true,
+      "replaces": "$baseTargetFramework$",
+      "defaultValue": "net7.0",
+      "description": "Select the .NET version of your solution",
+      "choices": [
+        {
+          "choice": "net7.0",
+          "displayName": ".NET 7.0",
+          "description": "Target .NET 7.0 (Standard Term Support)"
+        },
+        {
+          "choice": "net8.0",
+          "displayName": ".NET 8.0",
+          "description": "Target .NET 8.0 (Preview)"
+        }
+      ]
+    },
+    "cpm": {
+      "displayName": "Central Package Management",
+      "description": "Use Central Package Management",
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true"
+    },
+    "useAndroid": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true",
+      "description": "Include Android as a target platform",
+      "displayName": "Android"
+    },
+    "useiOS": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true",
+      "description": "Include iOS as a target platform",
+      "displayName": "iOS"
+    },
+    "useMacCatalyst": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true",
+      "description": "Include MacCatalyst as a target platform",
+      "displayName": "MacCatalyst"
+    },
+    "useWinAppSdk": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true",
+      "description": "Include WinUI as a target platform",
+      "displayName": "WinUI"
+    },
+    "unoMauiClassLibrary": {
+      "type": "generated",
+      "generator": "switch",
+      "parameters": {
+        "datatype": "bool",
+        "evaluator": "C++",
+        "cases": [
+          {
+            "condition": "(1 == 1)",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    "useStandaloneCPM": {
+      "type": "generated",
+      "generator": "switch",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "bool",
+        "cases": [
+          {
+            "condition": "(cpm == true)",
+            "value": "true"
+          },
+          {
+            "condition": "(cpm == false)",
+            "value": "false"
+          }
+        ]
+      }
+    },
+    "libraryBaseTargetFramework": {
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "$libraryBaseTargetFramework$",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "(tfm == 'net7.0')",
+            "value": "net7.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0')",
+            "value": "net8.0"
+          }
+        ]
+      }
+    },
+    "mobileTargetFrameworks": {
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "$mobileTargetFrameworks$",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "(tfm == 'net7.0' && useAndroid && useiOS && useMacCatalyst)",
+            "value": "net7.0-ios;net7.0-android;net7.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useAndroid && useiOS && useMacCatalyst)",
+            "value": "net8.0-ios;net8.0-android;net8.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net7.0' && useAndroid && useiOS && !useMacCatalyst)",
+            "value": "net7.0-ios;net7.0-android"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useAndroid && useiOS && !useMacCatalyst)",
+            "value": "net8.0-ios;net8.0-android"
+          },
+          {
+            "condition": "(tfm == 'net7.0' && !useAndroid && useiOS && useMacCatalyst)",
+            "value": "net7.0-ios;net7.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && !useAndroid && useiOS && useMacCatalyst)",
+            "value": "net8.0-ios;net8.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net7.0' && useAndroid && !useiOS && useMacCatalyst)",
+            "value": "net7.0-android;net7.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useAndroid && !useiOS && useMacCatalyst)",
+            "value": "net8.0-android;net8.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net7.0' && useAndroid && !useiOS && !useMacCatalyst)",
+            "value": "net7.0-android"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useAndroid && !useiOS && !useMacCatalyst)",
+            "value": "net8.0-android"
+          },
+          {
+            "condition": "(tfm == 'net7.0' && !useAndroid && useiOS && !useMacCatalyst)",
+            "value": "net7.0-ios"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && !useAndroid && useiOS && !useMacCatalyst)",
+            "value": "net8.0-ios"
+          },
+          {
+            "condition": "(tfm == 'net7.0' && !useAndroid && !useiOS && useMacCatalyst)",
+            "value": "net7.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && !useAndroid && !useiOS && useMacCatalyst)",
+            "value": "net8.0-maccatalyst"
+          },
+          {
+            "condition": "(!useAndroid && !useiOS && !useMacCatalyst)",
+            "value": ""
+          }
+        ]
+      }
+    },
+    "useMauiPackageReference": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "(tfm != 'net7.0')"
+    }
+  }
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #293 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

You can only get a MAUI Class library for MAUI Embedding as part of the unoapp template

## What is the new behavior?

You can now create a stand alone MAUI Class library for MAUI Embedding without any additional projects. This will make it easier to add to existing projects.


