### PR TITLE
chore: update to use new DevServer package

### DIFF
--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -18,7 +18,7 @@
 
 	<PropertyGroup>
 		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">3.0.0-dev.2246</UnoExtensionsVersion>
-		<UnoVersion Condition="'$(UnoVersion)' == ''">5.0.0-dev.2352</UnoVersion>
+		<UnoVersion Condition="'$(UnoVersion)' == ''">5.0.0-dev.2647</UnoVersion>
 		<UnoExtensionsLoggingVersion Condition="'$(UnoExtensionsLoggingVersion)' == ''">1.4.0</UnoExtensionsLoggingVersion>
 		<SkiaSharpVersion Condition="'$(SkiaSharpVersion)' == ''">2.88.5</SkiaSharpVersion>
 		<UnoCoreExtensionsLoggingVersion Condition="'$(UnoCoreExtensionsLoggingVersion)' == ''">4.0.1</UnoCoreExtensionsLoggingVersion>

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -17,8 +17,8 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">3.0.0-dev.2246</UnoExtensionsVersion>
-		<UnoVersion Condition="'$(UnoVersion)' == ''">5.0.0-dev.2647</UnoVersion>
+		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">3.0.0-dev.2296</UnoExtensionsVersion>
+		<UnoVersion Condition="'$(UnoVersion)' == ''">5.0.0-dev.2740</UnoVersion>
 		<UnoExtensionsLoggingVersion Condition="'$(UnoExtensionsLoggingVersion)' == ''">1.4.0</UnoExtensionsLoggingVersion>
 		<SkiaSharpVersion Condition="'$(SkiaSharpVersion)' == ''">2.88.5</SkiaSharpVersion>
 		<UnoCoreExtensionsLoggingVersion Condition="'$(UnoCoreExtensionsLoggingVersion)' == ''">4.0.1</UnoCoreExtensionsLoggingVersion>

--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -137,7 +137,7 @@
     <!--#endif-->
     <PackageVersion Include="Uno.Themes.WinUI.Markup" Version="$UnoThemesVersion$" />
     <!--#endif-->
-    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIVersion$" />
+    <PackageVersion Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" />
     <!--#if (useGtk)-->
     <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="$UnoWinUIVersion$" />
     <!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/AppHead.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/AppHead.xaml.cs
@@ -98,7 +98,7 @@ public sealed partial class AppHead : App
 			// builder.AddFilter("Uno.UI.DataBinding.BinderReferenceHolder", LogLevel.Debug );
 
 			// DevServer and HotReload related
-			// builder.AddFilter("Uno.UI.DevServer", LogLevel.Information);
+			// builder.AddFilter("Uno.UI.RemoteControl", LogLevel.Information);
 
 			// Debug JS interop
 			// builder.AddFilter("Uno.Foundation.WebAssemblyRuntime", LogLevel.Debug );

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/AppHead.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/AppHead.xaml.cs
@@ -97,8 +97,8 @@ public sealed partial class AppHead : App
 			// Binder memory references tracking
 			// builder.AddFilter("Uno.UI.DataBinding.BinderReferenceHolder", LogLevel.Debug );
 
-			// RemoteControl and HotReload related
-			// builder.AddFilter("Uno.UI.RemoteControl", LogLevel.Information);
+			// DevServer and HotReload related
+			// builder.AddFilter("Uno.UI.DevServer", LogLevel.Information);
 
 			// Debug JS interop
 			// builder.AddFilter("Uno.Foundation.WebAssemblyRuntime", LogLevel.Debug );

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
@@ -104,7 +104,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" />
 		<PackageReference Include="Uno.Extensions.Logging.OSLog" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.DevServer" Condition="'$(Configuration)'=='Debug'" />
 		<!--#if (useMauiPackageReference)-->
 		<PackageReference Include="Microsoft.Maui.Controls" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
@@ -189,7 +189,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
 		<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="$UnoExtensionsLoggingVersion$" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
 		<!--#if (useMauiPackageReference)-->
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
@@ -88,7 +88,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" />
 		<PackageReference Include="SkiaSharp.Skottie" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.DevServer" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
 	</ItemGroup>
 	<!--#else-->
@@ -170,7 +170,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="$SkiaSharpVersion$" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="$SkiaSharpVersion$" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
 	</ItemGroup>
 	<!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
@@ -86,7 +86,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" />
 		<PackageReference Include="SkiaSharp.Skottie" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" />
+		<PackageReference Include="Uno.WinUI.DevServer" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
 	</ItemGroup>
 	<!--#else-->
@@ -168,7 +168,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="$SkiaSharpVersion$" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="$SkiaSharpVersion$" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
 	</ItemGroup>
 	<!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
@@ -100,7 +100,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" />
 		<PackageReference Include="SkiaSharp.Skottie" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" />
+		<PackageReference Include="Uno.WinUI.DevServer" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
 	</ItemGroup>
 	<!--#else-->
@@ -182,7 +182,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="$SkiaSharpVersion$" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="$SkiaSharpVersion$" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
 	</ItemGroup>
 	<!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
@@ -70,7 +70,7 @@
 		<PackageReference Include="Uno.Wasm.Bootstrap" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" />
 		<PackageReference Include="Uno.WinUI.WebAssembly" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.DevServer" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" />
@@ -154,7 +154,7 @@
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="$UnoWasmBootstrapVersion$" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="$UnoWasmBootstrapVersion$" />
 		<PackageReference Include="Uno.WinUI.WebAssembly" Version="$UnoWinUIVersion$" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.recommended.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/App.recommended.cs
@@ -65,7 +65,7 @@ public class App : Application
 					//logBuilder.XamlBindingLogLevel(LogLevel.Debug);
 					//// Binder memory references tracking
 					//logBuilder.BinderMemoryReferenceLogLevel(LogLevel.Debug);
-					//// RemoteControl and HotReload related
+					//// DevServer and HotReload related
 					//logBuilder.HotReloadCoreLogLevel(LogLevel.Information);
 					//// Debug JS interop
 					//logBuilder.WebAssemblyLogLevel(LogLevel.Debug);

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -6,7 +6,7 @@ param(
     [string]$ExtensionsVersion = "3.0.0-dev.2246",
 
     # Version of published Uno.WinUI packages
-    [string]$UnoVersion = "5.0.0-dev.2352"
+    [string]$UnoVersion = "5.0.0-dev.2647"
 )
 
 function RemoveNuGetPackage {

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -3,10 +3,10 @@ param(
     [string]$TemplatesVersion = "255.255.255.255",
 
     # Version of published Uno.Extensions packages
-    [string]$ExtensionsVersion = "3.0.0-dev.2246",
+    [string]$ExtensionsVersion = "3.0.0-dev.2296",
 
     # Version of published Uno.WinUI packages
-    [string]$UnoVersion = "5.0.0-dev.2647"
+    [string]$UnoVersion = "5.0.0-dev.2740"
 )
 
 function RemoveNuGetPackage {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #289 

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Head projects target Uno.WinUI.RemoteControl

## What is the new behavior?

Package reference updated to use new Uno.WinUI.DevServer package for Hot Reload. All heads have been updated as well so that they consistently only include the reference for Debug builds. This was missed for some heads when using CPM.
