### PR TITLE
Add xml encoding

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project>
 
 	<!--

--- a/src/Uno.Templates/content/unoapp/Directory.Build.targets
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.targets
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project>
 	<ItemGroup>
 		<!-- Removes native usings to avoid Ambiguous reference -->

--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -1,4 +1,5 @@
-<Project ToolsVersion="15.0">
+<?xml version="1.0" encoding="utf-8" ?>
+<Project>
   <ItemGroup>
     <!--#if (useMvvm)-->
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.1" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/AppHead.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/AppHead.xaml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <!--#if (useCsharpMarkup)-->
 <local:App x:Class="MyExtensionsApp._1.AppHead"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/MyExtensionsApp._1.Base.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/MyExtensionsApp._1.Base.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project Sdk="Microsoft.Build.NoTargets/3.7.0">
 	<PropertyGroup>
 		<!-- NOTE: The TargetFramework is required by MSBuild but not used as this project is not built. -->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/base.props
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/base.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project>
 	<!--#if (useCPM)-->
 	<ItemGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.DataContracts/MyExtensionsApp._1.DataContracts.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.DataContracts/MyExtensionsApp._1.DataContracts.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>$libraryBaseTargetFramework$</TargetFramework>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/MyExtensionsApp._1.MauiControls.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/MyExtensionsApp._1.MauiControls.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>$mobileTargetFrameworks$</TargetFrameworks>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/MyExtensionsApp._1.Server.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/MyExtensionsApp._1.Server.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/Wpf/App.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/Wpf/App.xaml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Application x:Class="MyExtensionsApp._1.WPF.App"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/MyExtensionsApp._1.UITests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/MyExtensionsApp._1.UITests.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/AppResources.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/AppResources.xaml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MainPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MainPage.xaml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Page x:Class="MyExtensionsApp._1.MainPage"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<!--#if (useWinAppSdk) -->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/LoginPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/LoginPage.xaml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Page x:Class="MyExtensionsApp._1.Presentation.LoginPage"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/MainPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/MainPage.xaml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Page x:Class="MyExtensionsApp._1.Presentation.MainPage"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/SecondPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/SecondPage.xaml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Page x:Class="MyExtensionsApp._1.Presentation.SecondPage"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/Shell.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/Shell.xaml
@@ -1,4 +1,5 @@
-﻿<UserControl x:Class="MyExtensionsApp._1.Presentation.Shell"
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<UserControl x:Class="MyExtensionsApp._1.Presentation.Shell"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:local="using:MyExtensionsApp._1.Presentation"

--- a/src/Uno.Templates/content/unoapp/solution-config.props.sample
+++ b/src/Uno.Templates/content/unoapp/solution-config.props.sample
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Project>
 	<!--
 		This file is used to control the platforms compiled by visual studio, and


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #263

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

CSProj, Props, Targets, & XAML files are not using the xml tag to specify the encoding at UTF-8

## What is the new behavior?

The affected files now have the proper xml tag to specify the file encoding
```xml
<?xml version="1.0" encoding="utf-8" ?>
```
