### PR TITLE
Remove use of deprecated API

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/Program.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/Program.cs
@@ -1,4 +1,7 @@
 //+:cnd:noEmit
+#if (useHttp)
+using System.Text.Json.Serialization.Metadata;
+#endif
 #if (useSerilog)
 using Serilog;
 #endif

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/Program.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/Program.cs
@@ -25,7 +25,9 @@ try
 #if (useHttp)
 	// Configure the JsonOptions to use the generated WeatherForecastContext
 	builder.Services.Configure<JsonOptions>(options =>
-		options.JsonSerializerOptions.AddContext<WeatherForecastContext>());
+		options.JsonSerializerOptions.TypeInfoResolver = JsonTypeInfoResolver.Combine(
+			WeatherForecastContext.Default
+		));
 #endif
 	// Configure the RouteOptions to use lowercase URLs
 	builder.Services.Configure<RouteOptions>(options =>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #299

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The JsonSerializationContext is added to the JsonSerializerOptions with the AddContext method.

## What is the new behavior?

The JsonSerializationContext is added to the JsonSerializationOptions with a JsonTypeInfoResolver using the TypeInfoResolver property. This is the new recommended way from the net8.0 release notes.
https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8#chain-source-generators

**NOTE**: Do not backport. The TypeInfoResolver property was introduced in net7.0 and is not available for net6.0.
