### PR TITLE
Making DSP an optional feature

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
@@ -97,6 +97,10 @@
       "longName": "skip-restore",
       "shortName": "skip"
     },
+    "dspGenerator": {
+      "longName": "dsp",
+      "shortName": "dsp"
+    },
     "continuousIntegration": {
       "longName": "continuous-integration",
       "shortName": "ci"

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -599,6 +599,38 @@
         }
       ]
     },
+    "dspGenerator": {
+      "displayName": "Use the DSP Generator",
+      "description": "When enabled this will include a DSP file and the DSP Generator NuGet package",
+      "type": "parameter",
+      "datatype": "bool"
+    },
+    "presetDspDefault": {
+      "type": "generated",
+      "generator": "switch",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "bool",
+        "cases": [
+          {
+            "condition": "(preset == 'recommended')",
+            "value": "true"
+          },
+          {
+            "condition": "(preset == 'blank')",
+            "value": "false"
+          }
+        ]
+      }
+    },
+    "useDspGenerator": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "dspGenerator",
+        "fallbackVariableName": "presetDspDefault"
+      }
+    },
     "continuousIntegration": {
       "displayName": "Continuous Integration",
       "description": "Configures continuous integration support for the solution",
@@ -2244,6 +2276,12 @@
             "MyExtensionsApp._1/Assets/Fonts/**",
             "MyExtensionsApp._1/Assets/Images/**",
             "MyExtensionsApp._1.MauiControls/**"
+          ]
+        },
+        {
+          "condition": "(!useDspGenerator)",
+          "exclude": [
+            "MyExtensionsApp._1/Styles/ColorPaletteOverride.zip"
           ]
         }
       ]

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -623,7 +623,7 @@
         ]
       }
     },
-    "useDspGenerator": {
+    "dspGeneratorEvaluator": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
@@ -912,6 +912,11 @@
         "sourceVariableName": "appTheme",
         "fallbackVariableName": "presetAppThemeDefault"
       }
+    },
+    "useDspGenerator":{
+      "type": "computed",
+      "datatype": "bool",
+      "value": "(dspGeneratorEvaluator && appThemeEvaluator == 'material')"
     },
     "useMaterial": {
       "type": "computed",

--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -101,7 +101,9 @@
     <!--#endif-->
     <!--#if (useMaterial)-->
     <PackageVersion Include="Uno.Material.WinUI" Version="$UnoThemesVersion$" />
+    <!--#if (useDspGenerator)-->
     <PackageVersion Include="Uno.Dsp.Tasks" Version="$UnoDspTasksVersion$" />
+    <!--#endif-->
     <!--#elif (useCupertino)-->
     <PackageVersion Include="Uno.Cupertino.WinUI" Version="$UnoThemesVersion$" />
     <!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -18,9 +18,6 @@
 
 	<!--#if (useCPM)-->
 	<ItemGroup>
-		<!--#if (useMaterial)-->
-		<PackageReference Include="Uno.Dsp.Tasks" />
-		<!--#endif-->
 		<PackageReference Include="Uno.WinUI" />
 		<!--#if (!useWinAppSdk) -->
 		<PackageReference Include="Uno.WinUI.Lottie" />
@@ -59,6 +56,9 @@
 		<!--#endif-->
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" />
+		<!--#if (useDspGenerator)-->
+		<PackageReference Include="Uno.Dsp.Tasks" />
+		<!--#endif-->
 		<!--#if (useToolkit)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" />
 		<!--#endif-->
@@ -115,9 +115,6 @@
 	</ItemGroup>
 	<!--#else-->
 	<ItemGroup>
-		<!--#if (useMaterial)-->
-		<PackageReference Include="Uno.Dsp.Tasks" Version="$UnoDspTasksVersion$" />
-		<!--#endif-->
 		<PackageReference Include="Uno.WinUI" Version="$UnoWinUIVersion$" />
 		<!--#if (!useWinAppSdk) -->
 		<PackageReference Include="Uno.WinUI.Lottie" Version="$UnoWinUIVersion$" />
@@ -156,6 +153,9 @@
 		<!--#endif-->
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="$UnoThemesVersion$" />
+		<!--#if (useDspGenerator)-->
+		<PackageReference Include="Uno.Dsp.Tasks" Version="$UnoDspTasksVersion$" />
+		<!--#endif-->
 		<!--#if (useToolkit)-->
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="$UnoToolkitVersion$" />
 		<!--#endif-->
@@ -292,7 +292,7 @@
 	<!--#endif-->
 
 	<ItemGroup>
-		<!--#if (useMaterial)-->
+		<!--#if (useDspGenerator)-->
 		<UnoDspImportColors Include="Styles\*.zip" Generator="$DspGenerator$" />
 		<!--#endif-->
 		<UnoImage Include="Assets\**\*.svg" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #319 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

DSP is enabled by default when Material is enabled

## What is the new behavior?

DSP is now a separate flag and is disabled by default for the blank preset and enabled by default for the recommended preset.
