### PR TITLE
chore: Update .editorconfig for best practices

### DIFF
--- a/src/Uno.Templates/content/unoapp/.editorconfig
+++ b/src/Uno.Templates/content/unoapp/.editorconfig
@@ -10,8 +10,6 @@ root = true
 
 [*]
 indent_style = space
-end_of_line = crlf
-trim_trailing_whitespace = true
 insert_final_newline = true
 charset = utf-8
 


### PR DESCRIPTION
Both of these options are discouraged.

- EOLs should be normalized by Git per the OS, then `end_of_line` shouldn't be specified.
- `trim_trailing_whitespace` can trim **significant** whitespaces which is annoying. By default, the formatter will remove all **insignificant** whitespaces.