### PR TITLE
fix: Correct Material namespace and safearea

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1545,7 +1545,7 @@
         "cases": [
           {
             "condition": "(useToolkit)",
-            "value": " utu:SafeArea.Insets=\"All\""
+            "value": " utu:SafeArea.Insets=\"VisibleBounds\""
           },
           {
             "condition": "(!useToolkit)",

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1526,7 +1526,7 @@
         "evaluator": "C++",
         "cases": [
           {
-            "condition": "(useMaterial)",
+            "condition": "(appThemeEvaluator == 'material')",
             "value": "\n\txmlns:um=\"using:Uno.Material\""
           },
           {

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MainPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MainPage.xaml
@@ -3,7 +3,8 @@
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
   xmlns:local="using:MyExtensionsApp._1"$toolkitNamespace$$materialNamespace$$mauiNamespaces$
   Background="{ThemeResource $themeBackgroundBrush$}">
-  <StackPanel HorizontalAlignment="Center"
+  <StackPanel$toolkitSafeArea$
+        HorizontalAlignment="Center"
         VerticalAlignment="Center">
     <TextBlock AutomationProperties.AutomationId="HelloTextBlock"
           Text="Hello Uno Platform"


### PR DESCRIPTION
GitHub Issue (If applicable): closes #328

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Material namespace not included
SafeArea not applied to MainPage in blank template

## What is the new behavior?

Material namespace is being include
SafeArea is applied to StackPanel inside MainPage
SafeArea changed to use VisibleBounds, not All (since SoftInput value (included in All) doesn't make sense on root element)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
