### PR TITLE
Use spaces for new xaml namespaces

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1161,11 +1161,11 @@
           {
             // This works.... don't try to optimize it!
             "condition": "(platforms == wpf && mauiEmbedding || platforms == wasm && mauiEmbedding || platforms == gtk  && mauiEmbedding || platforms == linux-fb  && mauiEmbedding || platforms == macos  && mauiEmbedding)",
-            "value": "\n\txmlns:d=\"http://schemas.microsoft.com/expression/blend/2008\"\n\txmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\"\n\txmlns:maui=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\"\n\txmlns:not_maui=\"http://notmaui\"\n\tmc:Ignorable=\"d not_maui\""
+            "value": "\n      xmlns:d=\"http://schemas.microsoft.com/expression/blend/2008\"\n      xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\"\n      xmlns:maui=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\"\n      xmlns:not_maui=\"http://notmaui\"\n      mc:Ignorable=\"d not_maui\""
           },
           {
-            "condition": "true", 
-            "value": "\n\txmlns:d=\"http://schemas.microsoft.com/expression/blend/2008\"\n\txmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\"\n\tmc:Ignorable=\"d\""
+            "condition": "true",
+            "value": "\n      xmlns:d=\"http://schemas.microsoft.com/expression/blend/2008\"\n      xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\"\n      mc:Ignorable=\"d\""
           }
         ]
       }
@@ -1509,7 +1509,7 @@
         "cases": [
           {
             "condition": "(useToolkit)",
-            "value": "\n\txmlns:utu=\"using:Uno.Toolkit.UI\""
+            "value": "\n      xmlns:utu=\"using:Uno.Toolkit.UI\""
           },
           {
             "condition": "true",
@@ -1527,7 +1527,7 @@
         "cases": [
           {
             "condition": "(appThemeEvaluator == 'material')",
-            "value": "\n\txmlns:um=\"using:Uno.Material\""
+            "value": "\n      xmlns:um=\"using:Uno.Material\""
           },
           {
             "condition": "true",
@@ -1699,7 +1699,7 @@
         "cases": [
           {
             "condition": "(navigationEvaluator == 'regions')",
-            "value": "\n\txmlns:uen=\"using:Uno.Extensions.Navigation.UI\""
+            "value": "\n      xmlns:uen=\"using:Uno.Extensions.Navigation.UI\""
           },
           {
             "condition": "true",
@@ -1733,7 +1733,7 @@
       "datatype": "bool",
       "value": "useAuthentication && authentication == 'web'"
     },
-    // MSAL causes an error when used with WinAppSdk when self-contained 
+    // MSAL causes an error when used with WinAppSdk when self-contained
     "useWinAppSdkSelfContained": {
       "type": "computed",
       "datatype": "bool",

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MainPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MainPage.xaml
@@ -1,8 +1,8 @@
-﻿<Page x:Class="MyExtensionsApp._1.MainPage"
-  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-  xmlns:local="using:MyExtensionsApp._1"$toolkitNamespace$$materialNamespace$$mauiNamespaces$
-  Background="{ThemeResource $themeBackgroundBrush$}">
+<Page x:Class="MyExtensionsApp._1.MainPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MyExtensionsApp._1"$toolkitNamespace$$materialNamespace$$mauiNamespaces$
+      Background="{ThemeResource $themeBackgroundBrush$}">
   <StackPanel$toolkitSafeArea$
         HorizontalAlignment="Center"
         VerticalAlignment="Center">


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a follow up for #324 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Inserted XAML Namespaces use tabs

## What is the new behavior?

Inserted XAML Namespaces use the same spacing that already exist in the XAML files.

