### PR TITLE
Remove MaterialFontsOverride.xaml

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1507,6 +1507,60 @@
         ]
       }
     },
+    "toolkitMaterialStyleNamespace": {
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "$toolkitMaterialStyleNamespace$",
+      "parameters": {
+        "evaluator": "C++",
+        "cases": [
+          {
+            "condition": "(useToolkit)",
+            "value": "\n      xmlns:utum=\"using:Uno.Toolkit.UI.Material\""
+          },
+          {
+            "condition": "true",
+            "value": ""
+          }
+        ]
+      }
+    },
+    "materialStyleNamespace": {
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "$materialStyleNamespace$",
+      "parameters": {
+        "evaluator": "C++",
+        "cases": [
+          {
+            "condition": "(useMaterial)",
+            "value": "\n                    xmlns:um=\"using:Uno.Material\""
+          },
+          {
+            "condition": "true",
+            "value": ""
+          }
+        ]
+      }
+    },
+    "cupertinoStyleNamespace": {
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "$cupertinoStyleNamespace$",
+      "parameters": {
+        "evaluator": "C++",
+        "cases": [
+          {
+            "condition": "(useMaterial)",
+            "value": "\n                    xmlns:uc=\"using:Uno.Cupertino\""
+          },
+          {
+            "condition": "true",
+            "value": ""
+          }
+        ]
+      }
+    },
     "toolkitSafeArea": {
       "type": "generated",
       "generator": "switch",

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1507,51 +1507,23 @@
         ]
       }
     },
-    "toolkitMaterialStyleNamespace": {
+    "resourceStyleThemeNamespace": {
       "type": "generated",
       "generator": "switch",
-      "replaces": "$toolkitMaterialStyleNamespace$",
+      "replaces": "$useThemesResourceNamespace$",
       "parameters": {
         "evaluator": "C++",
         "cases": [
           {
-            "condition": "(useToolkit)",
-            "value": "\n      xmlns:utum=\"using:Uno.Toolkit.UI.Material\""
+            "condition": "(appThemeEvaluator == 'material' && useToolkit == true)",
+            "value": "\n                    xmlns:utum=\"using:Uno.Toolkit.UI.Material\""
           },
           {
-            "condition": "true",
-            "value": ""
-          }
-        ]
-      }
-    },
-    "materialStyleNamespace": {
-      "type": "generated",
-      "generator": "switch",
-      "replaces": "$materialStyleNamespace$",
-      "parameters": {
-        "evaluator": "C++",
-        "cases": [
-          {
-            "condition": "(useMaterial)",
+            "condition": "(appThemeEvaluator == 'material')",
             "value": "\n                    xmlns:um=\"using:Uno.Material\""
           },
           {
-            "condition": "true",
-            "value": ""
-          }
-        ]
-      }
-    },
-    "cupertinoStyleNamespace": {
-      "type": "generated",
-      "generator": "switch",
-      "replaces": "$cupertinoStyleNamespace$",
-      "parameters": {
-        "evaluator": "C++",
-        "cases": [
-          {
-            "condition": "(useCupertino)",
+            "condition": "(appThemeEvaluator == 'cupertino')",
             "value": "\n                    xmlns:uc=\"using:Uno.Cupertino\""
           },
           {
@@ -1865,10 +1837,6 @@
           }
         ]
       }
-    },
-    "HostIdentifier": {
-      "type": "bind",
-      "binding": "HostIdentifier"
     },
     "OS": {
       "type": "bind",

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1515,7 +1515,7 @@
         "evaluator": "C++",
         "cases": [
           {
-            "condition": "(appThemeEvaluator == 'material' && useToolkit == true)",
+            "condition": "(appThemeEvaluator == 'material' && useToolkit == 'true')",
             "value": "\n                    xmlns:utum=\"using:Uno.Toolkit.UI.Material\""
           },
           {

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1551,7 +1551,7 @@
         "evaluator": "C++",
         "cases": [
           {
-            "condition": "(useMaterial)",
+            "condition": "(useCupertino)",
             "value": "\n                    xmlns:uc=\"using:Uno.Cupertino\""
           },
           {

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/AppResources.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/AppResources.xaml
@@ -1,5 +1,5 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"$materialStyleNamespace$$toolkitMaterialStyleNamespace$$cupertinoStyleNamespace$>
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"$useThemesResourceNamespace$>
 
   <ResourceDictionary.MergedDictionaries>
     <!-- Load WinUI resources -->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/AppResources.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/AppResources.xaml
@@ -1,24 +1,40 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"$materialStyleNamespace$$toolkitMaterialStyleNamespace$$cupertinoStyleNamespace$>
 
   <ResourceDictionary.MergedDictionaries>
     <!-- Load WinUI resources -->
     <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
 <!--#if (useMaterial)-->
 <!--#if (useToolkit)-->
-    <MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
-      ColorOverrideSource="ms-appx:///MyExtensionsApp._1/Styles/ColorPaletteOverride.xaml"
-      FontOverrideSource="ms-appx:///MyExtensionsApp._1/Styles/MaterialFontsOverride.xaml" />
+    <utum:MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
+      ColorOverrideSource="ms-appx:///MyExtensionsApp._1/Styles/ColorPaletteOverride.xaml">
+      <!-- NOTE: You can override the default Roboto font by providing your font assets here. -->
+      <!-- <utum:MaterialToolkitTheme.FontOverrideDictionary>
+        <ResourceDictionary>
+          <FontFamily x:Key="MaterialLightFontFamily">ms-appx:///Uno.Fonts.Roboto/Fonts/Roboto-Light.ttf#Roboto</FontFamily>
+          <FontFamily x:Key="MaterialMediumFontFamily">ms-appx:///Uno.Fonts.Roboto/Fonts/Roboto-Medium.ttf#Roboto</FontFamily>
+          <FontFamily x:Key="MaterialRegularFontFamily">ms-appx:///Uno.Fonts.Roboto/Fonts/Roboto-Regular.ttf#Roboto</FontFamily>
+        </ResourceDictionary>
+      </utum:MaterialToolkitTheme.FontOverrideDictionary> -->
+    </utum:MaterialToolkitTheme>
 <!--#else-->
-    <MaterialTheme  xmlns="using:Uno.Material"
-      ColorOverrideSource="ms-appx:///MyExtensionsApp._1/Styles/ColorPaletteOverride.xaml"
-      FontOverrideSource="ms-appx:///MyExtensionsApp._1/Styles/MaterialFontsOverride.xaml" />
+    <um:MaterialTheme  xmlns="using:Uno.Material"
+      ColorOverrideSource="ms-appx:///MyExtensionsApp._1/Styles/ColorPaletteOverride.xaml">
+      <!-- NOTE: You can override the default Roboto font by providing your font assets here. -->
+      <!-- <um:MaterialTheme.FontOverrideDictionary>
+        <ResourceDictionary>
+          <FontFamily x:Key="MaterialLightFontFamily">ms-appx:///Uno.Fonts.Roboto/Fonts/Roboto-Light.ttf#Roboto</FontFamily>
+          <FontFamily x:Key="MaterialMediumFontFamily">ms-appx:///Uno.Fonts.Roboto/Fonts/Roboto-Medium.ttf#Roboto</FontFamily>
+          <FontFamily x:Key="MaterialRegularFontFamily">ms-appx:///Uno.Fonts.Roboto/Fonts/Roboto-Regular.ttf#Roboto</FontFamily>
+        </ResourceDictionary>
+      </um:MaterialTheme.FontOverrideDictionary> -->
+    </um:MaterialTheme>
 <!--#endif-->
 <!--#else-->
 <!--#if (useCupertino)-->
-    <CupertinoColors xmlns="using:Uno.Cupertino" />
-    <CupertinoFonts xmlns="using:Uno.Cupertino" />
-    <CupertinoResources xmlns="using:Uno.Cupertino" />
+    <uc:CupertinoColors />
+    <uc:CupertinoFonts />
+    <uc:CupertinoResources />
 <!--#endif-->
 <!--#if (useToolkit)-->
     <!-- Load Uno.UI.Toolkit resources -->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Styles/MaterialFontsOverride.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Styles/MaterialFontsOverride.cs
@@ -5,9 +5,10 @@ public sealed class MaterialFontsOverride : ResourceDictionary
 {
     public MaterialFontsOverride()
     {
-        this.Build(r => r
-            .Add<FontFamily>("MaterialLightFontFamily", "ms-appx:///Uno.Fonts.Roboto/Fonts/Roboto-Light.ttf#Roboto")
-            .Add<FontFamily>("MaterialMediumFontFamily", "ms-appx:///Uno.Fonts.Roboto/Fonts/Roboto-Medium.ttf#Roboto")
-            .Add<FontFamily>("MaterialRegularFontFamily", "ms-appx:///Uno.Fonts.Roboto/Fonts/Roboto-Regular.ttf#Roboto"));
+        // NOTE: You can override the default Roboto font by providing your font assets here.
+        // this.Build(r => r
+        //     .Add<FontFamily>("MaterialLightFontFamily", "ms-appx:///Uno.Fonts.Roboto/Fonts/Material/Roboto-Light.ttf#Roboto")
+        //     .Add<FontFamily>("MaterialMediumFontFamily", "ms-appx:///Uno.Fonts.Roboto/Fonts/Material/Roboto-Medium.ttf#Roboto")
+        //     .Add<FontFamily>("MaterialRegularFontFamily", "ms-appx:///Uno.Fonts.Roboto/Fonts/Material/Roboto-Regular.ttf#Roboto"));
     }
 }

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Styles/MaterialFontsOverride.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Styles/MaterialFontsOverride.xaml
@@ -1,8 +1,0 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-
-  <FontFamily x:Key="MaterialLightFontFamily">ms-appx:///Uno.Fonts.Roboto/Fonts/Roboto-Light.ttf#Roboto</FontFamily>
-  <FontFamily x:Key="MaterialMediumFontFamily">ms-appx:///Uno.Fonts.Roboto/Fonts/Roboto-Medium.ttf#Roboto</FontFamily>
-  <FontFamily x:Key="MaterialRegularFontFamily">ms-appx:///Uno.Fonts.Roboto/Fonts/Roboto-Regular.ttf#Roboto</FontFamily>
-
-</ResourceDictionary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Font Overrides use default Roboto Fonts that aren't actually needed anymore.

## What is the new behavior?

FontOverrides.xaml has been removed. We now show developers how to override in a commented out ResourceDictionary added directly to the FontOverrideDictionary property of the MaterialTheme or MaterialToolkitTheme

