### PR TITLE
fix: Enabling XAML hot reload in debug by avoiding trimming

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/Properties/PublishProfiles/win-arm64.pubxml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/Properties/PublishProfiles/win-arm64.pubxml
@@ -13,7 +13,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 		<PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
 		<PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
 		<!-- Note: This may still be an issue with PublishTrimmed support https://github.com/microsoft/CsWinRT/issues/373 -->
-		<PublishTrimmed>True</PublishTrimmed>
+		<PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
 		<TrimMode>partial</TrimMode>
 		<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
 	</PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/Properties/PublishProfiles/win-x64.pubxml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/Properties/PublishProfiles/win-x64.pubxml
@@ -13,7 +13,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 		<PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
 		<PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
 		<!-- Note: This may still be an issue with PublishTrimmed support https://github.com/microsoft/CsWinRT/issues/373 -->
-		<PublishTrimmed>True</PublishTrimmed>
+		<PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
 		<TrimMode>partial</TrimMode>
 		<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
 	</PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/Properties/PublishProfiles/win-x86.pubxml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/Properties/PublishProfiles/win-x86.pubxml
@@ -13,7 +13,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 		<PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
 		<PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
 		<!-- Note: This may still be an issue with PublishTrimmed support https://github.com/microsoft/CsWinRT/issues/373 -->
-		<PublishTrimmed>True</PublishTrimmed>
+		<PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
 		<TrimMode>partial</TrimMode>
 		<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
 	</PropertyGroup>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Hot Reload window reports:
13:27 29.12 HRWindowsApp.Windows: [Warning] Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.
This will prevent HR working due to trimming being enabled in debug

## What is the new behavior?

Trimming is only enabled in release builds

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
