### PR TITLE
feat: Updating name of icon files

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/Icons/icon.svg
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/Icons/icon.svg
@@ -5,7 +5,7 @@
    viewBox="0 0 456 456"
    version="1.1"
    id="svg453"
-   sodipodi:docname="iconapp.old.svg"
+   sodipodi:docname="icon.svg"
    inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/Icons/icon_foreground.svg
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/Icons/icon_foreground.svg
@@ -5,7 +5,7 @@
    viewBox="0 0 50.369617 49.826836"
    version="1.1"
    id="svg151"
-   sodipodi:docname="appconfig.svg"
+   sodipodi:docname="icon_foreground.svg"
    inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/Splash/splash_screen.svg
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/Splash/splash_screen.svg
@@ -5,7 +5,7 @@
    viewBox="0 0 50.369617 49.826836"
    version="1.1"
    id="svg151"
-   sodipodi:docname="appconfig.svg"
+   sodipodi:docname="icon_foreground.svg"
    inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/base.props
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Base/base.props
@@ -16,8 +16,8 @@
         XamlRuntime="WinUI"
         DependentUpon="AppHead.xaml"
         Link="AppHead.xaml.cs" />
-    <UnoIcon Include="$(MSBuildThisFileDirectory)Icons\iconapp.svg"
-        ForegroundFile="$(MSBuildThisFileDirectory)Icons\appconfig.svg"
+    <UnoIcon Include="$(MSBuildThisFileDirectory)Icons\icon.svg"
+        ForegroundFile="$(MSBuildThisFileDirectory)Icons\icon_foreground.svg"
         ForegroundScale="0.65"
         Color="#00000000" />
     <UnoSplashScreen
@@ -25,8 +25,8 @@
       BaseSize="128,128"
       Color="#FFFFFF" />
     <!-- NOTE: Files explicitly linked to display in the head projects for clarity. -->
-    <None Include="$(MSBuildThisFileDirectory)Icons\iconapp.svg" Link="Icons\iconapp.svg" />
-    <None Include="$(MSBuildThisFileDirectory)Icons\appconfig.svg" Link="Icons\appconfig.svg" />
+    <None Include="$(MSBuildThisFileDirectory)Icons\icon.svg" Link="Icons\icon.svg" />
+    <None Include="$(MSBuildThisFileDirectory)Icons\icon_foreground.svg" Link="Icons\icon_foreground.svg" />
     <None Include="$(MSBuildThisFileDirectory)Splash\splash_screen.svg" Link="Splash\splash_screen.svg" />
   </ItemGroup>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/Android/Main.Android.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/Android/Main.Android.cs
@@ -15,7 +15,7 @@ namespace MyExtensionsApp._1.Droid;
 
 [global::Android.App.ApplicationAttribute(
     Label = "@string/ApplicationName",
-    Icon = "@mipmap/iconapp",
+    Icon = "@mipmap/icon",
     LargeHeap = true,
     HardwareAccelerated = true,
     Theme = "@style/AppTheme"

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MacCatalyst/Info.plist
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MacCatalyst/Info.plist
@@ -15,7 +15,7 @@
 			<string>UIInterfaceOrientationLandscapeRight</string>
 		</array>
 		<key>XSAppIconAssets</key>
-		<string>Assets.xcassets/iconapp.appiconset</string>
+		<string>Assets.xcassets/icon.appiconset</string>
 
 		<!--
 		Adjust this to your application's encryption usage.

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/iOS/Info.plist
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/iOS/Info.plist
@@ -30,7 +30,7 @@
 		<key>UIViewControllerBasedStatusBarAppearance</key>
 		<false/>
 		<key>XSAppIconAssets</key>
-		<string>Assets.xcassets/iconapp.appiconset</string>
+		<string>Assets.xcassets/icon.appiconset</string>
 		<key>UIApplicationSupportsIndirectInputEvents</key>
 		<true/>
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/macOS/Info.plist
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/macOS/Info.plist
@@ -17,7 +17,7 @@
 		<key>NSPrincipalClass</key>
 		<string>NSApplication</string>
 		<key>XSAppIconAssets</key>
-		<string>Assets.xcassets/iconapp.appiconset</string>
+		<string>Assets.xcassets/icon.appiconset</string>
 		<key>ATSApplicationFontsPath</key>
 		<string>Fonts</string>
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #342

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Name of icon files isn't clear what they're for

## What is the new behavior?

Icon file is now just icon.svg
Icon foreground is called icon_foreground.svg

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
