### PR TITLE
chore: Disabling (again) trimming on windows

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/Properties/PublishProfiles/win-arm64.pubxml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/Properties/PublishProfiles/win-arm64.pubxml
@@ -12,9 +12,11 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 		<PublishSingleFile>False</PublishSingleFile>
 		<PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
 		<PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-		<!-- Note: This may still be an issue with PublishTrimmed support https://github.com/microsoft/CsWinRT/issues/373 -->
+		<!-- Note: Trimming disabled by default as there may still be an issues with PublishTrimmed support: https://github.com/microsoft/CsWinRT/issues/373 -->
+		<!-- 
 		<PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
 		<TrimMode>partial</TrimMode>
-		<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+		<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings> 
+		-->
 	</PropertyGroup>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/Properties/PublishProfiles/win-x64.pubxml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/Properties/PublishProfiles/win-x64.pubxml
@@ -12,9 +12,11 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 		<PublishSingleFile>False</PublishSingleFile>
 		<PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
 		<PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-		<!-- Note: This may still be an issue with PublishTrimmed support https://github.com/microsoft/CsWinRT/issues/373 -->
+		<!-- Note: Trimming disabled by default as there may still be an issues with PublishTrimmed support: https://github.com/microsoft/CsWinRT/issues/373 -->
+		<!-- 
 		<PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
 		<TrimMode>partial</TrimMode>
-		<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+		<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings> 
+		-->
 	</PropertyGroup>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/Properties/PublishProfiles/win-x86.pubxml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/Properties/PublishProfiles/win-x86.pubxml
@@ -12,9 +12,11 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 		<PublishSingleFile>False</PublishSingleFile>
 		<PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
 		<PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-		<!-- Note: This may still be an issue with PublishTrimmed support https://github.com/microsoft/CsWinRT/issues/373 -->
+		<!-- Note: Trimming disabled by default as there may still be an issues with PublishTrimmed support: https://github.com/microsoft/CsWinRT/issues/373 -->
+		<!-- 
 		<PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
 		<TrimMode>partial</TrimMode>
-		<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+		<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings> 
+		-->
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Trimming has been causing a number of issues eg:
- ImmutableList failing to serialise
- Converters not able to cast from bool to Visibility

## What is the new behavior?

Trimming has been commented out (both in debug and release) to avoid issues arising unexpected.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
