### PR TITLE
fix: Adjust launchSettings.json to use a port other than 5000

### DIFF
--- a/src/Uno.Templates/content/unoapp/.vscode/launch.json
+++ b/src/Uno.Templates/content/unoapp/.vscode/launch.json
@@ -21,7 +21,7 @@
       "name": "Debug (Chrome, WebAssembly)",
       "type": "chrome",
       "request": "launch",
-      "url": "http://localhost:5000",
+      "url": "http://localhost:5001",
       "webRoot": "${workspaceFolder}/MyExtensionsApp._1.Wasm",
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "timeout": 30000,

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/Properties/launchSettings.json
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/Properties/launchSettings.json
@@ -5,7 +5,7 @@
     "anonymousAuthentication": true,
     "iisExpress": {
       "applicationUrl": "http://localhost:5001",
-      "sslPort": 5001
+      "sslPort": 5002
     }
   },
   "profiles": {

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/Properties/launchSettings.json
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/Properties/launchSettings.json
@@ -19,7 +19,7 @@
       //#else
       "launchUrl": "swagger",
       //#endif
-      "applicationUrl": "https://localhost:5001;http://localhost:5002",
+      "applicationUrl": "http://localhost:5001;https://localhost:5002",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/Properties/launchSettings.json
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/Properties/launchSettings.json
@@ -4,7 +4,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:5000",
+      "applicationUrl": "http://localhost:5001",
       "sslPort": 5001
     }
   },
@@ -19,7 +19,7 @@
       //#else
       "launchUrl": "swagger",
       //#endif
-      "applicationUrl": "https://localhost:5000;http://localhost:5001",
+      "applicationUrl": "https://localhost:5001;http://localhost:5002",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/Constants.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/Constants.cs
@@ -3,7 +3,7 @@ namespace MyExtensionsApp._1.UITests;
 
 public class Constants
 {
-    public readonly static string WebAssemblyDefaultUri = "http://localhost:5000/";
+    public readonly static string WebAssemblyDefaultUri = "http://localhost:5001/";
     public readonly static string iOSAppName = "com.companyname.myextensionsapp";
     public readonly static string AndroidAppName = "com.companyname.myextensionsapp";
     public readonly static string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (3rd generation)";

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/Properties/launchSettings.json
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/Properties/launchSettings.json
@@ -12,7 +12,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:5000",
+      "applicationUrl": "http://localhost:5001",
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This is a workaround for https://developercommunity.visualstudio.com/t/BrowserLink-WebSocket-is-disconnecting-a/10500228, which can break the hot reload session when the port is specifically 5000 in some machine configurations.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
