### PR TITLE
chore: adding Generator to generate for local types

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -128,6 +128,7 @@
     <PackageVersion Include="Uno.WinUI.Lottie" Version="$UnoWinUIVersion$" />
     <!--#if (useCsharpMarkup)-->
     <PackageVersion Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
+    <PackageVersion Include="Uno.Extensions.Markup.Generators" Version="$UnoMarkupVersion$" />
     <!--#if (useToolkit)-->
     <PackageVersion Include="Uno.Toolkit.WinUI.Markup" Version="$UnoToolkitMarkupVersion$" />
     <!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -26,6 +26,10 @@
     <PackageReference Include="Uno.Resizetizer" />
     <!--#if (useCsharpMarkup)-->
     <PackageReference Include="Uno.WinUI.Markup" />
+    <PackageReference Include="Uno.Extensions.Markup.Generators">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <!--#if (useMaterial)-->
     <PackageReference Include="Uno.Material.WinUI.Markup" />
     <!--#endif-->
@@ -127,6 +131,10 @@
     <PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
     <!--#if (useCsharpMarkup)-->
     <PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
+    <PackageReference Include="Uno.Extensions.Markup.Generators" Version="$UnoMarkupVersion$">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <!--#if (useMaterial)-->
     <PackageReference Include="Uno.Material.WinUI.Markup" Version="$UnoThemesVersion$" />
     <!--#endif-->


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Other... Enable Generator by default

## What is the current behavior?

If you use C# Markup and want extensions generated for your custom controls you need to additionally install the Generator package

## What is the new behavior?

The Generator is now added by default to provide extensions automatically for your custom controls.