### PR TITLE
chore: Adding IsTestProject so that dotnet test executes tests

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$baseTargetFramework$</TargetFramework>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/MyExtensionsApp._1.UITests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/MyExtensionsApp._1.UITests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$baseTargetFramework$</TargetFramework>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Executing "dotnet test --no-build" triggers the following error indicating missing IsTestProject property
![image](https://github.com/unoplatform/uno.templates/assets/1614057/07fddebd-2dde-4321-ad49-7fe146f5fcc3)

## What is the new behavior?

dotnet test will detect the test project

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
