### PR TITLE
fix: Avoid VS 2022 from asking to reload the mobile project

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -74,6 +74,7 @@
       <!--
       Eagerly define capabilities for iOS to avoid VS 2022 to ask for
       project reload, and ninitialize the debugger toolbar faster.
+      See https://github.com/unoplatform/uno/issues/14303.
       -->
       <ItemGroup>
         <ProjectCapability Include="XamarinStaticLaunchProfiles" />

--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
 
   <!--
     If working on a single target framework, copy solution-config.props.sample to solution-config.props
@@ -70,6 +70,16 @@
         <IsIOS>true</IsIOS>
         <SupportedOSPlatformVersion>14.2</SupportedOSPlatformVersion>
       </PropertyGroup>
+
+      <!--
+      Eagerly define capabilities for iOS to avoid VS 2022 to ask for
+      project reload, and ninitialize the debugger toolbar faster.
+      -->
+      <ItemGroup>
+        <ProjectCapability Include="XamarinStaticLaunchProfiles" />
+        <ProjectCapability Include="Maui" />
+        <ProjectCapability Include="MauiCore" />
+      </ItemGroup>
     </When>
     <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'">
       <PropertyGroup>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Applies solution load workaround to avoid having VS asking to reload projects when creating a template from the VSIX. VS 2022 only.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
