### PR TITLE
fix: Set WinAppsdk version in class library

### DIFF
--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
@@ -17,8 +17,10 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
+		<!-- If you update Extensions or Uno version, make sure you update the versions in the reinstall.ps1 file too !-->
 		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">3.0.10</UnoExtensionsVersion>
 		<UnoVersion Condition="'$(UnoVersion)' == ''">5.0.19</UnoVersion>
+		
 		<UnoExtensionsLoggingVersion Condition="'$(UnoExtensionsLoggingVersion)' == ''">1.7.0</UnoExtensionsLoggingVersion>
 		<SkiaSharpVersion Condition="'$(SkiaSharpVersion)' == ''">2.88.6</SkiaSharpVersion>
 		<UnoCoreExtensionsLoggingVersion Condition="'$(UnoCoreExtensionsLoggingVersion)' == ''">4.0.1</UnoCoreExtensionsLoggingVersion>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -256,8 +256,8 @@
         -->
         <!-- <WindowsSdkPackageVersion>10.0.22621.28</WindowsSdkPackageVersion> -->
       </PropertyGroup>
-      <!--#if (!mauiEmbedding)-->
       <ItemGroup>
+      <!--#if (!mauiEmbedding)-->
         <!--#if (useCPM)-->
         <PackageReference Include="Microsoft.WindowsAppSDK" />
         <PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
@@ -265,8 +265,11 @@
         <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
         <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
         <!--#endif-->
-      </ItemGroup>
+      <!--#else-->
+        <PackageReference Include="Microsoft.WindowsAppSDK" VersionOverride="1.4.231008000" />
+        <PackageReference Include="Microsoft.Windows.SDK.BuildTools" VersionOverride="10.0.22621.756" />
       <!--#endif-->
+      </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -3,10 +3,10 @@ param(
     [string]$TemplatesVersion = "255.255.255.255",
 
     # Version of published Uno.Extensions packages
-    [string]$ExtensionsVersion = "3.0.8",
+    [string]$ExtensionsVersion = "3.0.10",
 
     # Version of published Uno.WinUI packages
-    [string]$UnoVersion = "5.0.13"
+    [string]$UnoVersion = "5.0.19"
 )
 
 function RemoveNuGetPackage {


### PR DESCRIPTION
GitHub Issue (If applicable): closes [#winapps](https://github.com/unoplatform/uno.templates/issues/396)

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Missing reference causing version mismathc

## What is the new behavior?

Added reference to class library

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
