### PR TITLE
Update CSM for Uno 5 remove strong typing on Grid Row Definitions

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/LoginPage.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/LoginPage.xaml.cs
@@ -18,7 +18,7 @@ public sealed partial class LoginPage : Page
 #if useToolkit
                 .SafeArea(SafeArea.InsetMask.All)
 #endif
-                .RowDefinitions<Grid>("Auto,*")
+                .RowDefinitions("Auto,*")
                 .Children(
 #if useToolkit
                     new NavigationBar().Content(() => vm.Title),

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/MainPage.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/Presentation/MainPage.xaml.cs
@@ -18,7 +18,7 @@ public sealed partial class MainPage : Page
 #if useToolkit
                 .SafeArea(SafeArea.InsetMask.All)
 #endif
-                .RowDefinitions<Grid>("Auto,*")
+                .RowDefinitions("Auto,*")
                 .Children(
 #if useToolkit
                     new NavigationBar().Content(() => vm.Title),


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

CSM version of the template still using strongly typed `RowDefinitions` that were required in 4.x

## What is the new behavior?

CSM now uses implicit type from the Grid