### PR TITLE
Make net8.0 default

### DIFF
--- a/build/.azure-pipelines.TemplateValidation.yml
+++ b/build/.azure-pipelines.TemplateValidation.yml
@@ -44,6 +44,7 @@ jobs:
         templateArgs: '-tests none'
       FrameNavigation:
         templateArgs: '--navigation blank'
+      # net8 is the default for tfm, so validating net7.0
       Net7:
         templateArgs: '-tfm net7.0'
       # https://github.com/unoplatform/uno.templates/issues/22

--- a/build/.azure-pipelines.TemplateValidation.yml
+++ b/build/.azure-pipelines.TemplateValidation.yml
@@ -44,8 +44,8 @@ jobs:
         templateArgs: '-tests none'
       FrameNavigation:
         templateArgs: '--navigation blank'
-      Net8:
-        templateArgs: '-tfm net8.0'
+      Net7:
+        templateArgs: '-tfm net7.0'
       # https://github.com/unoplatform/uno.templates/issues/22
       Issue22:
         templateArgs: '-preset blank -tfm net7.0 -platforms android -platforms ios -platforms maccatalyst -platforms macos -platforms windows -platforms wasm -platforms gtk -platforms wpf -platforms linux-fb -presentation mvvm -server false -tests none -vscode false -pwa false -di true -nav regions -log none -theme material'
@@ -69,8 +69,6 @@ jobs:
        templateArgs: '-preset=blank -maui'
       MauiRecommended:
        templateArgs: '-preset=recommended -maui'
-      MauiRecommendedNet8:
-       templateArgs: '-preset=recommended -maui -tfm net8.0'
       ThemeService:
        templateArgs: '-theme-service'
       # https://github.com/unoplatform/uno.templates/issues/396

--- a/build/templates/package-validation.yml
+++ b/build/templates/package-validation.yml
@@ -13,9 +13,9 @@ steps:
     $dotnetVersion = '7.0.402'
     $workloadRestore = 'https://maui.blob.core.windows.net/metadata/rollbacks/7.0.96.json'
 
-    if ($templateArgs.Contains('net8')) {
+    if (!$templateArgs.Contains('net7')) {
       $dotnetVersion = '8.0.100-rc.2.23502.2'
-      $workloadRestore = 'https://maui.blob.core.windows.net/metadata/rollbacks/8.0.0-rc.2.9373.json'
+      $workloadRestore = 'https://maui.blob.core.windows.net/metadata/rollbacks/8.0.0-rc.2.9511.json'
     }
 
     Write-Host "DotNetVersion = $dotnetVersion"

--- a/build/templates/package-validation.yml
+++ b/build/templates/package-validation.yml
@@ -10,8 +10,8 @@ steps:
 - powershell: |
     $templateArgs = '${{ parameters.arguments }}'
     Write-Host "TemplateArgs = '$templateArgs'"
-    $dotnetVersion = '7.0.402'
-    $workloadRestore = 'https://maui.blob.core.windows.net/metadata/rollbacks/7.0.96.json'
+    $dotnetVersion = '7.0.403'
+    $workloadRestore = 'https://maui.blob.core.windows.net/metadata/rollbacks/7.0.101.json'
 
     if (!$templateArgs.Contains('net7')) {
       $dotnetVersion = '8.0.100-rc.2.23502.2'
@@ -44,12 +44,11 @@ steps:
       dotnet nuget add source -n nuget_local $(Build.SourcesDirectory)\src\PackageCache
       dotnet nuget add source -n uno_dev "https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json"
       dotnet nuget add source -n net8 "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json"
-      dotnet nuget add source -n ApiLocal "https://api.nuget.org/v3/index.json"
       Set-PSDebug -Trace 1
       $ErrorActionPreference = 'Stop'
 
       # Create app with defaults
-      dotnet new unoapp -skip -o UnoApp1 ${{ parameters.arguments }}
+      dotnet new unoapp -skip -d -v diagnostic -o UnoApp1 ${{ parameters.arguments }}
       if ($LASTEXITCODE -ne 0)
       {
           throw "Exit code must be zero."

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -185,7 +185,7 @@
       "datatype": "choice",
       "enableQuotelessLiterals": true,
       "replaces": "$baseTargetFramework$",
-      "defaultValue": "net7.0",
+      "defaultValue": "net8.0",
       "description": "Select the .NET version of your solution",
       "choices": [
         {

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -197,7 +197,7 @@
         {
           "choice": "net8.0",
           "displayName": ".NET 8.0",
-          "description": "Target .NET 8.0 (Preview)"
+          "description": "Target .NET 8.0 (Long Term Support)"
         }
       ]
     },

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -13,6 +13,7 @@
     "WebAssembly",
     "WinUI"
   ],
+  "generatorVersions": "[1.0.0.0-*)",
   "name": "Uno Platform App",
   "identity": "Uno.Platform.UnoApp.WinUI.netcoremobile.CSharp",
   "groupIdentity": "Uno.Platform.UnoApp.WinUI.netcoremobile",


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #417 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

.net7.0 is the default Target Framework

## What is the new behavior?

.net8.0 is the new default target framework

Also adjusts Maui Embedding to use a calculated parameter in the template.