### PR TITLE
fix: Adjusting overrides to be single target and provide warnings

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1408,25 +1408,6 @@
       "datatype": "bool",
       "value": "cultures == 'zh-Hant'"
     },
-    "libraryBaseTargetFramework": {
-      "type": "generated",
-      "generator": "switch",
-      "replaces": "$libraryBaseTargetFramework$",
-      "parameters": {
-        "evaluator": "C++",
-        "datatype": "string",
-        "cases": [
-          {
-            "condition": "(tfm == 'net7.0')",
-            "value": "net7.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0')",
-            "value": "net8.0"
-          }
-        ]
-      }
-    },
     "ciTargetDotNetVersion": {
       "type": "generated",
       "generator": "switch",

--- a/src/Uno.Templates/content/unoapp/AzurePipelines/jobs/unit-test.yml
+++ b/src/Uno.Templates/content/unoapp/AzurePipelines/jobs/unit-test.yml
@@ -13,7 +13,7 @@ jobs:
       inputs:
         solution: ./MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj
         configuration: 'Release'
-        msbuildArguments: '/p:OverrideTargetFrameworks=$baseTargetFramework$ /r'
+        msbuildArguments: '/p:OverrideTargetFramework=$baseTargetFramework$ /r'
 
     - task: VSTest@3
       inputs:

--- a/src/Uno.Templates/content/unoapp/AzurePipelines/jobs/unit-test.yml
+++ b/src/Uno.Templates/content/unoapp/AzurePipelines/jobs/unit-test.yml
@@ -13,7 +13,7 @@ jobs:
       inputs:
         solution: ./MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj
         configuration: 'Release'
-        msbuildArguments: '/p:OverrideTargetFrameworks=$libraryBaseTargetFramework$ /r'
+        msbuildArguments: '/p:OverrideTargetFrameworks=$baseTargetFramework$ /r'
 
     - task: VSTest@3
       inputs:

--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -1,13 +1,4 @@
 ﻿<Project>
-
-  <!--
-    If working on a single target framework, copy solution-config.props.sample to solution-config.props
-    and uncomment the appropriate lines in solution-config.props to build for the desired platforms only.
-
-    https://platform.uno/docs/articles/guides/solution-building-single-targetframework.html
-  -->
-  <Import Project="solution-config.props" Condition="exists('solution-config.props')" />
-
   <PropertyGroup>
     <DotNetVersion>$baseTargetFramework$</DotNetVersion>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -105,4 +96,11 @@
     </When>
   </Choose>
 
+  <!--
+    If working on a single target framework, copy solution-config.props.sample to solution-config.props
+    and uncomment the appropriate lines in solution-config.props to build for the desired platforms only.
+
+    https://platform.uno/docs/articles/guides/solution-building-single-targetframework.html
+  -->
+  <Import Project="solution-config.props" Condition="exists('solution-config.props')" />
 </Project>

--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
 
   <!--
     If working on a single target framework, copy solution-config.props.sample to solution-config.props
@@ -8,6 +8,24 @@
   -->
   <Import Project="solution-config.props" Condition="exists('solution-config.props')" />
 
+  <PropertyGroup>
+      <!-- Don't modify these. To adjust overrides, use the solution-config.props file -->
+        <OverrideTargetFrameworks Condition="'$(WindowsOverrideTargetFramework)'!=''">$(OverrideTargetFrameworks);$(WindowsOverrideTargetFramework)</OverrideTargetFrameworks> 
+        <OverrideTargetFrameworks Condition="'$(NeutralOverrideTargetFramework)'!=''">$(OverrideTargetFrameworks);$(NeutralOverrideTargetFramework)</OverrideTargetFrameworks> 
+        <OverrideTargetFrameworks Condition="'$(MobileOverrideTargetFrameworks)'!=''">$(OverrideTargetFrameworks);$(MobileOverrideTargetFrameworks)</OverrideTargetFrameworks> 
+  </PropertyGroup>
+
+  <Target Name="ValidateOverrides" BeforeTargets="Restore">
+    <Error
+        Text="OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing 'WindowsOverrideTargetFramework'. Either set WindowsOverrideTargetFramework in solution-config.props, or skip building this project"
+        Condition="$(TargetFramework.Contains('windows10')) and '$(OverrideTargetFrameworks)' != '' and '$(WindowsOverrideTargetFramework)' == '' " />
+    <Error
+        Text="OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing 'MobileOverrideTargetFrameworks'. Either set MobileOverrideTargetFrameworks in solution-config.props, or skip building this project"
+        Condition="($(TargetFrameworks.Contains('android')) or $(TargetFrameworks.Contains('ios')) or $(TargetFrameworks.Contains('macos')) or $(TargetFrameworks.Contains('maccatalyst'))) and '$(OverrideTargetFrameworks)' != '' and '$(MobileOverrideTargetFrameworks)' == '' " />
+    <Error
+        Text="OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing 'NeutralOverrideTargetFramework'. Either set NeutralOverrideTargetFramework in solution-config.props, or skip building this project"
+        Condition="!(($(TargetFramework.Contains('windows10')) or $(TargetFrameworks.Contains('windows10'))) or $(TargetFrameworks.Contains('android')) or $(TargetFrameworks.Contains('ios')) or $(TargetFrameworks.Contains('macos')) or $(TargetFrameworks.Contains('maccatalyst'))) and '$(OverrideTargetFrameworks)' != '' and '$(NeutralOverrideTargetFramework)' == '' " />
+  </Target>
 
   <PropertyGroup>
     <DotNetVersion>$libraryBaseTargetFramework$</DotNetVersion>

--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -9,26 +9,7 @@
   <Import Project="solution-config.props" Condition="exists('solution-config.props')" />
 
   <PropertyGroup>
-      <!-- Don't modify these. To adjust overrides, use the solution-config.props file -->
-        <OverrideTargetFrameworks Condition="'$(WindowsOverrideTargetFramework)'!=''">$(OverrideTargetFrameworks);$(WindowsOverrideTargetFramework)</OverrideTargetFrameworks> 
-        <OverrideTargetFrameworks Condition="'$(NeutralOverrideTargetFramework)'!=''">$(OverrideTargetFrameworks);$(NeutralOverrideTargetFramework)</OverrideTargetFrameworks> 
-        <OverrideTargetFrameworks Condition="'$(MobileOverrideTargetFrameworks)'!=''">$(OverrideTargetFrameworks);$(MobileOverrideTargetFrameworks)</OverrideTargetFrameworks> 
-  </PropertyGroup>
-
-  <Target Name="ValidateOverrides" BeforeTargets="Restore">
-    <Error
-        Text="OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing 'WindowsOverrideTargetFramework'. Either set WindowsOverrideTargetFramework in solution-config.props, or skip building this project"
-        Condition="$(TargetFramework.Contains('windows10')) and '$(OverrideTargetFrameworks)' != '' and '$(WindowsOverrideTargetFramework)' == '' " />
-    <Error
-        Text="OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing 'MobileOverrideTargetFrameworks'. Either set MobileOverrideTargetFrameworks in solution-config.props, or skip building this project"
-        Condition="($(TargetFrameworks.Contains('android')) or $(TargetFrameworks.Contains('ios')) or $(TargetFrameworks.Contains('macos')) or $(TargetFrameworks.Contains('maccatalyst'))) and '$(OverrideTargetFrameworks)' != '' and '$(MobileOverrideTargetFrameworks)' == '' " />
-    <Error
-        Text="OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing 'NeutralOverrideTargetFramework'. Either set NeutralOverrideTargetFramework in solution-config.props, or skip building this project"
-        Condition="!(($(TargetFramework.Contains('windows10')) or $(TargetFrameworks.Contains('windows10'))) or $(TargetFrameworks.Contains('android')) or $(TargetFrameworks.Contains('ios')) or $(TargetFrameworks.Contains('macos')) or $(TargetFrameworks.Contains('maccatalyst'))) and '$(OverrideTargetFrameworks)' != '' and '$(NeutralOverrideTargetFramework)' == '' " />
-  </Target>
-
-  <PropertyGroup>
-    <DotNetVersion>$libraryBaseTargetFramework$</DotNetVersion>
+    <DotNetVersion>$baseTargetFramework$</DotNetVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/Uno.Templates/content/unoapp/Directory.Build.targets
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.targets
@@ -3,4 +3,22 @@
     <!-- Removes native usings to avoid Ambiguous reference -->
     <Using Remove="@(Using->HasMetadata('Platform'))" />
   </ItemGroup>
+
+  <Target Name="ValidateOverrides" BeforeTargets="Restore;_CheckForUnsupportedTargetFramework" Condition="'$(OverrideTargetFrameworks)' != ''">
+    <Error
+        Text="OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing Windows target. Either add $baseTargetFramework$-windows10.0.19041.0 to OverrideTargetFrameworks in solution-config.props, or skip building this project (eg unload the project in Visual Studio)"
+        Condition="$(TargetFramework.Contains('windows10')) and !$(OverrideTargetFrameworks.Contains('windows'))" />
+    <Error
+        Text="$(TargetFramework) OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing iOS. Either add $baseTargetFramework$-ios to OverrideTargetFrameworks in solution-config.props, or skip building this project (eg unload the project in Visual Studio)"
+        Condition="('$(TargetFramework)'=='' and '$(TargetFrameworks)'=='') or ( $(TargetFrameworks.Contains('ios')) and !$(OverrideTargetFrameworks.Contains('ios')) )"/>
+    <Error
+        Text="$(TargetFramework) OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing Android. Either add $baseTargetFramework$-android to OverrideTargetFrameworks in solution-config.props, or skip building this project (eg unload the project in Visual Studio)"
+        Condition="('$(TargetFramework)'=='' and '$(TargetFrameworks)'=='') or ( $(TargetFrameworks.Contains('android')) and !$(OverrideTargetFrameworks.Contains('android')) )"/>
+    <Error
+        Text="$(TargetFramework) OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing MacOS. Either add $baseTargetFramework$-macos to OverrideTargetFrameworks in solution-config.props, or skip building this project (eg unload the project in Visual Studio)"
+        Condition="('$(TargetFramework)'=='' and '$(TargetFrameworks)'=='') or ( $(TargetFrameworks.Contains('macos')) and !$(OverrideTargetFrameworks.Contains('macos')) )"/>
+    <Error
+        Text="$(TargetFramework) OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing MacCatalyst. Either add $baseTargetFramework$-maccatalyst to OverrideTargetFrameworks in solution-config.props, or skip building this project (eg unload the project in Visual Studio)"
+        Condition="('$(TargetFramework)'=='' and '$(TargetFrameworks)'=='') or ( $(TargetFrameworks.Contains('maccatalyst')) and !$(OverrideTargetFrameworks.Contains('maccatalyst')) )"/>
+  </Target>
 </Project>

--- a/src/Uno.Templates/content/unoapp/Directory.Build.targets
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.targets
@@ -3,22 +3,4 @@
     <!-- Removes native usings to avoid Ambiguous reference -->
     <Using Remove="@(Using->HasMetadata('Platform'))" />
   </ItemGroup>
-
-  <Target Name="ValidateOverrides" BeforeTargets="Restore;_CheckForUnsupportedTargetFramework" Condition="'$(OverrideTargetFrameworks)' != ''">
-    <Error
-        Text="OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing Windows target. Either add $baseTargetFramework$-windows10.0.19041.0 to OverrideTargetFrameworks in solution-config.props, or skip building this project (eg unload the project in Visual Studio)"
-        Condition="$(TargetFramework.Contains('windows10')) and !$(OverrideTargetFrameworks.Contains('windows'))" />
-    <Error
-        Text="$(TargetFramework) OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing iOS. Either add $baseTargetFramework$-ios to OverrideTargetFrameworks in solution-config.props, or skip building this project (eg unload the project in Visual Studio)"
-        Condition="('$(TargetFramework)'=='' and '$(TargetFrameworks)'=='') or ( $(TargetFrameworks.Contains('ios')) and !$(OverrideTargetFrameworks.Contains('ios')) )"/>
-    <Error
-        Text="$(TargetFramework) OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing Android. Either add $baseTargetFramework$-android to OverrideTargetFrameworks in solution-config.props, or skip building this project (eg unload the project in Visual Studio)"
-        Condition="('$(TargetFramework)'=='' and '$(TargetFrameworks)'=='') or ( $(TargetFrameworks.Contains('android')) and !$(OverrideTargetFrameworks.Contains('android')) )"/>
-    <Error
-        Text="$(TargetFramework) OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing MacOS. Either add $baseTargetFramework$-macos to OverrideTargetFrameworks in solution-config.props, or skip building this project (eg unload the project in Visual Studio)"
-        Condition="('$(TargetFramework)'=='' and '$(TargetFrameworks)'=='') or ( $(TargetFrameworks.Contains('macos')) and !$(OverrideTargetFrameworks.Contains('macos')) )"/>
-    <Error
-        Text="$(TargetFramework) OverrideTargetFrameworks set to '$(OverrideTargetFrameworks)' is missing MacCatalyst. Either add $baseTargetFramework$-maccatalyst to OverrideTargetFrameworks in solution-config.props, or skip building this project (eg unload the project in Visual Studio)"
-        Condition="('$(TargetFramework)'=='' and '$(TargetFrameworks)'=='') or ( $(TargetFrameworks.Contains('maccatalyst')) and !$(OverrideTargetFrameworks.Contains('maccatalyst')) )"/>
-  </Target>
 </Project>

--- a/src/Uno.Templates/content/unoapp/GitHub/workflows/ci.yml
+++ b/src/Uno.Templates/content/unoapp/GitHub/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build MyExtensionsApp._1.Tests (Release)
         shell: pwsh
-        run: msbuild ./MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj /p:Configuration=Release /p:OverrideTargetFrameworks=$libraryBaseTargetFramework$ /r
+        run: msbuild ./MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj /p:Configuration=Release /p:OverrideTargetFrameworks=$baseTargetFramework$ /r
 
       - name: Run Unit Tests
         shell: pwsh

--- a/src/Uno.Templates/content/unoapp/GitHub/workflows/ci.yml
+++ b/src/Uno.Templates/content/unoapp/GitHub/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build MyExtensionsApp._1.Tests (Release)
         shell: pwsh
-        run: msbuild ./MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj /p:Configuration=Release /p:OverrideTargetFrameworks=$baseTargetFramework$ /r
+        run: msbuild ./MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj /p:Configuration=Release /p:OverrideTargetFramework=$baseTargetFramework$ /r
 
       - name: Run Unit Tests
         shell: pwsh

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/MyExtensionsApp._1.MauiControls.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/MyExtensionsApp._1.MauiControls.csproj
@@ -1,16 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!--#if (unoMauiClassLibrary)-->
+    <DotNetVersion Condition="'$(DotNetVersion)'==''">$baseTargetFramework$</DotNetVersion>
+
+    <!--#endif-->
     <!--#if (useWinAppSdk) -->
-    <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'=='' and ($([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true')">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'==''">$(TargetFrameworks);$(DotNetVersion);$mobileTargetFrameworks$</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);$(DotNetVersion);$mobileTargetFrameworks$</TargetFrameworks>
     <!--#else -->
-    <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'==''">$(DotNetVersion);$mobileTargetFrameworks$</TargetFrameworks>
+    <TargetFrameworks>$(DotNetVersion);$mobileTargetFrameworks$</TargetFrameworks>
     <!--#endif -->
-    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('ios'))">$(TargetFrameworks);$(DotNetVersion)-ios</TargetFrameworks>
-    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('android'))">$(TargetFrameworks);$(DotNetVersion)-android</TargetFrameworks>
-    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('maccatalyst'))">$(TargetFrameworks);$(DotNetVersion)-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('macos'))">$(TargetFrameworks);$(DotNetVersion)-macos</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OverrideTargetFramework)'!=''">$(OverrideTargetFramework)</TargetFrameworks>
 
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/MyExtensionsApp._1.MauiControls.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/MyExtensionsApp._1.MauiControls.csproj
@@ -7,7 +7,7 @@
     <!--#else -->
     <TargetFrameworks>$(DotNetVersion);$mobileTargetFrameworks$</TargetFrameworks>
     <!--#endif -->
-    <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'!=''">$(OverrideTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MobileOverrideTargetFrameworks)'!=''">$(MobileOverrideTargetFrameworks)</TargetFrameworks>
 
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/MyExtensionsApp._1.MauiControls.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/MyExtensionsApp._1.MauiControls.csproj
@@ -2,12 +2,15 @@
 
   <PropertyGroup>
     <!--#if (useWinAppSdk) -->
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);$(DotNetVersion);$mobileTargetFrameworks$</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'=='' and ($([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true')">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'==''">$(TargetFrameworks);$(DotNetVersion);$mobileTargetFrameworks$</TargetFrameworks>
     <!--#else -->
-    <TargetFrameworks>$(DotNetVersion);$mobileTargetFrameworks$</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'==''">$(DotNetVersion);$mobileTargetFrameworks$</TargetFrameworks>
     <!--#endif -->
-    <TargetFrameworks Condition="'$(MobileOverrideTargetFrameworks)'!=''">$(MobileOverrideTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('ios'))">$(TargetFrameworks);$(DotNetVersion)-ios</TargetFrameworks>
+    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('android'))">$(TargetFrameworks);$(DotNetVersion)-android</TargetFrameworks>
+    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('maccatalyst'))">$(TargetFrameworks);$(DotNetVersion)-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('macos'))">$(TargetFrameworks);$(DotNetVersion)-macos</TargetFrameworks>
 
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
@@ -5,7 +5,7 @@
     <!-- Disabled because of https://github.com/xamarin/xamarin-macios/issues/16401-->
     <!-- <TargetFrameworks>$(TargetFrameworks);$(DotNetVersion)-macos</TargetFrameworks> -->
     <!--#endif-->
-    <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'!=''">$(OverrideTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MobileOverrideTargetFrameworks)'!=''">$(MobileOverrideTargetFrameworks)</TargetFrameworks>
     <SingleProject>true</SingleProject>
     <OutputType>Exe</OutputType>
     <!-- Display name -->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
@@ -1,11 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$mobileTargetFrameworks$</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'==''">$mobileTargetFrameworks$</TargetFrameworks>
     <!--#if (useMacOS)-->
     <!-- Disabled because of https://github.com/xamarin/xamarin-macios/issues/16401-->
-    <!-- <TargetFrameworks>$(TargetFrameworks);$(DotNetVersion)-macos</TargetFrameworks> -->
+    <!-- <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'==''">$(TargetFrameworks);$(DotNetVersion)-macos</TargetFrameworks> -->
     <!--#endif-->
-    <TargetFrameworks Condition="'$(MobileOverrideTargetFrameworks)'!=''">$(MobileOverrideTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('ios'))">$(TargetFrameworks);$(DotNetVersion)-ios</TargetFrameworks>
+    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('android'))">$(TargetFrameworks);$(DotNetVersion)-android</TargetFrameworks>
+    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('maccatalyst'))">$(TargetFrameworks);$(DotNetVersion)-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('macos'))">$(TargetFrameworks);$(DotNetVersion)-macos</TargetFrameworks>
     <SingleProject>true</SingleProject>
     <OutputType>Exe</OutputType>
     <!-- Display name -->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
@@ -1,14 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'==''">$mobileTargetFrameworks$</TargetFrameworks>
+    <TargetFrameworks>$mobileTargetFrameworks$</TargetFrameworks>
     <!--#if (useMacOS)-->
     <!-- Disabled because of https://github.com/xamarin/xamarin-macios/issues/16401-->
-    <!-- <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'==''">$(TargetFrameworks);$(DotNetVersion)-macos</TargetFrameworks> -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);$(DotNetVersion)-macos</TargetFrameworks> -->
     <!--#endif-->
-    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('ios'))">$(TargetFrameworks);$(DotNetVersion)-ios</TargetFrameworks>
-    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('android'))">$(TargetFrameworks);$(DotNetVersion)-android</TargetFrameworks>
-    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('maccatalyst'))">$(TargetFrameworks);$(DotNetVersion)-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$(OverrideTargetFrameworks.Contains('macos'))">$(TargetFrameworks);$(DotNetVersion)-macos</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OverrideTargetFramework)'!=''">$(OverrideTargetFramework)</TargetFrameworks>
     <SingleProject>true</SingleProject>
     <OutputType>Exe</OutputType>
     <!-- Display name -->
@@ -277,4 +274,10 @@
     <!--#endif-->
   </ItemGroup>
   <Import Project="..\MyExtensionsApp._1.Shared\base.props" />
+
+  <Target Name="ValidateOverrides" BeforeTargets="Restore;_CheckForUnsupportedTargetFramework" Condition="'$(OverrideTargetFramework)' != ''">
+    <Error
+        Text="OverrideTargetFramework set to '$(OverrideTargetFramework)' is missing valid target. Set OverrideTargetFramework to one of the TargetFrameworks for this project or skip building this project (eg unload the project in Visual Studio)"
+        Condition="$(OverrideTargetFramework.Contains('windows10')) or !$(OverrideTargetFrameork.Contains('-'))" />
+  </Target>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
@@ -181,4 +181,10 @@
     <!--#endif-->
   </ItemGroup>
   <Import Project="..\MyExtensionsApp._1.Shared\base.props" />
+
+  <Target Name="ValidateOverrides" BeforeTargets="Restore;_CheckForUnsupportedTargetFramework" Condition="'$(OverrideTargetFramework)' != ''">
+    <Error
+        Text="OverrideTargetFramework set to '$(OverrideTargetFramework)' is invalid. Set OverrideTargetFramework to $([MSBuild]::Escape('$'))(DotNetVersion) or skip building this project (eg unload the project in Visual Studio)"
+        Condition="'$(OverrideTargetFramework)'!='$(DotNetVersion)'" />
+  </Target>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
@@ -179,4 +179,10 @@
     <!--#endif-->
   </ItemGroup>
   <Import Project="..\MyExtensionsApp._1.Shared\base.props" />
+
+  <Target Name="ValidateOverrides" BeforeTargets="Restore;_CheckForUnsupportedTargetFramework" Condition="'$(OverrideTargetFramework)' != ''">
+    <Error
+        Text="OverrideTargetFramework set to '$(OverrideTargetFramework)' is invalid. Set OverrideTargetFramework to $([MSBuild]::Escape('$'))(DotNetVersion) or skip building this project (eg unload the project in Visual Studio)"
+        Condition="'$(OverrideTargetFramework)'!='$(DotNetVersion)'" />
+  </Target>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
@@ -196,4 +196,10 @@
     <!--#endif-->
   </ItemGroup>
   <Import Project="..\MyExtensionsApp._1.Shared\base.props" />
+
+  <Target Name="ValidateOverrides" BeforeTargets="Restore;_CheckForUnsupportedTargetFramework" Condition="'$(OverrideTargetFramework)' != ''">
+    <Error
+        Text="OverrideTargetFramework set to '$(OverrideTargetFramework)' is invalid. Set OverrideTargetFramework to $([MSBuild]::Escape('$'))(DotNetVersion) or skip building this project (eg unload the project in Visual Studio)"
+        Condition="'$(OverrideTargetFramework)'!='$(DotNetVersion)'" />
+  </Target>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
@@ -239,4 +239,10 @@
     <!--#endif-->
   </ItemGroup>
   <Import Project="..\MyExtensionsApp._1.Shared\base.props" />
+
+  <Target Name="ValidateOverrides" BeforeTargets="Restore;_CheckForUnsupportedTargetFramework" Condition="'$(OverrideTargetFramework)' != ''">
+    <Error
+        Text="OverrideTargetFramework set to '$(OverrideTargetFramework)' is invalid. Set OverrideTargetFramework to $([MSBuild]::Escape('$'))(DotNetVersion) or skip building this project (eg unload the project in Visual Studio)"
+        Condition="'$(OverrideTargetFramework)'!='$(DotNetVersion)'" />
+  </Target>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
@@ -250,4 +250,10 @@
   </PropertyGroup>
 
   <Import Project="..\MyExtensionsApp._1.Shared\base.props" />
+  
+  <Target Name="ValidateOverrides" BeforeTargets="Restore;_CheckForUnsupportedTargetFramework" Condition="'$(OverrideTargetFramework)' != ''">
+    <Error
+        Text="OverrideTargetFramework set to '$(OverrideTargetFramework)' is missing Windows target. Set OverrideTargetFramework to $([MSBuild]::Escape('$'))(DotNetVersion)-windows10.0.19041.0 or skip building this project (eg unload the project in Visual Studio)"
+        Condition="!$(OverrideTargetFramework.Contains('windows10'))" />
+  </Target>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -10,7 +10,7 @@
     <!-- Disabled because of https://github.com/xamarin/xamarin-macios/issues/16401-->
     <!--<TargetFrameworks>$(TargetFrameworks);$(DotNetVersion)-macos</TargetFrameworks>-->
     <!--#endif -->
-    <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'!=''">$(OverrideTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OverrideTargetFramework)'!=''">$(OverrideTargetFramework)</TargetFrameworks>
 
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>

--- a/src/Uno.Templates/content/unoapp/solution-config.props.sample
+++ b/src/Uno.Templates/content/unoapp/solution-config.props.sample
@@ -12,11 +12,11 @@
     <PropertyGroup>
         <!-- Uncomment each line for each platform that you want to build: -->
 
-        <!-- <OverrideTargetFrameworks Condition="''!='hint: Windows App Sdk (WinUI)'">$(OverrideTargetFrameworks);$baseTargetFramework$-windows10.0.19041.0</OverrideTargetFrameworks> -->
-        <!-- <OverrideTargetFrameworks Condition="''!='hint: WASM, Skia'">$(OverrideTargetFrameworks);$baseTargetFramework$</OverrideTargetFrameworks> -->
-        <!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 iOS'">$(OverrideTargetFrameworks);$baseTargetFramework$-ios</OverrideTargetFrameworks> -->
-        <!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 Android'">$(OverrideTargetFrameworks);$baseTargetFramework$-android</OverrideTargetFrameworks> -->
-        <!-- <OverrideTargetFrameworks Condition="''!='hint: .NET 6.0 macOS Catalyst'">$(OverrideTargetFrameworks);$baseTargetFramework$-maccatalyst</OverrideTargetFrameworks> -->
+        <!-- <WindowsOverrideTargetFramework Condition="''!='hint: Windows App Sdk (WinUI)' and ($([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true')">$baseTargetFramework$-windows10.0.19041.0</WindowsOverrideTargetFramework>  -->
+        <!-- <NeutralOverrideTargetFramework Condition="''!='hint: WASM, Skia'">$baseTargetFramework$</NeutralOverrideTargetFramework>  -->
+        <!-- <MobileOverrideTargetFrameworks Condition="''!='hint: $baseTargetFramework$ iOS'">$(MobileOverrideTargetFrameworks);$baseTargetFramework$-ios</MobileOverrideTargetFrameworks>  -->
+        <!-- <MobileOverrideTargetFrameworks Condition="''!='hint: $baseTargetFramework$ Android'">$(MobileOverrideTargetFrameworks);$baseTargetFramework$-android</MobileOverrideTargetFrameworks>  -->
+        <!-- <MobileOverrideTargetFrameworks Condition="''!='hint: $baseTargetFramework$ macOS Catalyst'">$(MobileOverrideTargetFrameworks);$baseTargetFramework$-maccatalyst</MobileOverrideTargetFrameworks>  -->
     </PropertyGroup>
 
 </Project>

--- a/src/Uno.Templates/content/unoapp/solution-config.props.sample
+++ b/src/Uno.Templates/content/unoapp/solution-config.props.sample
@@ -1,22 +1,29 @@
 <Project>
     <!--
-        This file is used to control the platforms compiled by visual studio, and
-            allow for a faster build when testing for a single platform.
+        This file is used to control the platforms compiled by Visual Studio, and allow for a faster
+        build when testing for a single platform. This will also result in better intellisense, as
+        the compiler will only load the assemblies for the platforms that are being built. You do not
+        need to use this when compiling from Visual Studio Code, the command line or other IDEs.
 
-            Instructions:
-            1) Copy this file and remove the ".sample" name
-            2) Uncomment and adjust the properties below
-            3) Make sure to do a Rebuild, so that nuget restores the proper packages for the new target
+        Instructions:
+        1) Copy this file and remove the ".sample" name
+        2) Uncomment the single property below for the target you want to build
+        3) Make sure to do a Rebuild, so that nuget restores the proper packages for the new target
+
+        Notes:
+        - You may optionally close the solution before making changes and reload the solution afterwards. This will avoid Visual Studio
+          asking you to reload any projects, it will also ensure that the changes are picked up by Visual Studio, and trigger a restore of
+          the packages.
+        - You may want to unload the platform heads that you are not going to build for. This will ensure that Visual Studio does not
+          try to build them, and will speed up the build process.
     -->
 
     <PropertyGroup>
         <!-- Uncomment each line for each platform that you want to build: -->
 
-        <!-- <WindowsOverrideTargetFramework Condition="''!='hint: Windows App Sdk (WinUI)' and ($([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true')">$baseTargetFramework$-windows10.0.19041.0</WindowsOverrideTargetFramework>  -->
-        <!-- <NeutralOverrideTargetFramework Condition="''!='hint: WASM, Skia'">$baseTargetFramework$</NeutralOverrideTargetFramework>  -->
-        <!-- <MobileOverrideTargetFrameworks Condition="''!='hint: $baseTargetFramework$ iOS'">$(MobileOverrideTargetFrameworks);$baseTargetFramework$-ios</MobileOverrideTargetFrameworks>  -->
-        <!-- <MobileOverrideTargetFrameworks Condition="''!='hint: $baseTargetFramework$ Android'">$(MobileOverrideTargetFrameworks);$baseTargetFramework$-android</MobileOverrideTargetFrameworks>  -->
-        <!-- <MobileOverrideTargetFrameworks Condition="''!='hint: $baseTargetFramework$ macOS Catalyst'">$(MobileOverrideTargetFrameworks);$baseTargetFramework$-maccatalyst</MobileOverrideTargetFrameworks>  -->
+        <!-- <OverrideTargetFrameworks Condition="''!='hint: Windows App Sdk (WinUI)'">$baseTargetFramework$-windows10.0.19041.0</OverrideTargetFrameworks>  -->
+        <!-- <OverrideTargetFrameworks Condition="''!='hint: iOS'">$baseTargetFramework$-ios</OverrideTargetFrameworks>  -->
+        <!-- <OverrideTargetFrameworks Condition="''!='hint: Android'">$baseTargetFramework$-android</OverrideTargetFrameworks>  -->
+        <!-- <OverrideTargetFrameworks Condition="''!='hint: MacCatalyst'">$baseTargetFramework$-maccatalyst</OverrideTargetFrameworks>  -->
     </PropertyGroup>
-
 </Project>

--- a/src/Uno.Templates/content/unoapp/solution-config.props.sample
+++ b/src/Uno.Templates/content/unoapp/solution-config.props.sample
@@ -2,7 +2,7 @@
     <!--
         This file is used to control the platforms compiled by Visual Studio, and allow for a faster
         build when testing for a single platform. This will also result in better intellisense, as
-        the compiler will only load the assemblies for the platforms that are being built. You do not
+        the compiler will only load the assemblies for the platform that is being built. You do not
         need to use this when compiling from Visual Studio Code, the command line or other IDEs.
 
         Instructions:
@@ -21,9 +21,10 @@
     <PropertyGroup>
         <!-- Uncomment each line for each platform that you want to build: -->
 
-        <!-- <OverrideTargetFrameworks Condition="''!='hint: Windows App Sdk (WinUI)'">$baseTargetFramework$-windows10.0.19041.0</OverrideTargetFrameworks>  -->
-        <!-- <OverrideTargetFrameworks Condition="''!='hint: iOS'">$baseTargetFramework$-ios</OverrideTargetFrameworks>  -->
-        <!-- <OverrideTargetFrameworks Condition="''!='hint: Android'">$baseTargetFramework$-android</OverrideTargetFrameworks>  -->
-        <!-- <OverrideTargetFrameworks Condition="''!='hint: MacCatalyst'">$baseTargetFramework$-maccatalyst</OverrideTargetFrameworks>  -->
+        <!-- <OverrideTargetFramework Condition="''!='hint: Windows App Sdk (WinUI)'">$(DotNetVersion)-windows10.0.19041.0</OverrideTargetFramework> -->
+        <!-- <OverrideTargetFramework Condition="''!='hint: WASM, Skia'">$(DotNetVersion)</OverrideTargetFramework> -->
+        <!-- <OverrideTargetFramework Condition="''!='hint: iOS'">$(DotNetVersion)-ios</OverrideTargetFramework> -->
+        <!-- <OverrideTargetFramework Condition="''!='hint: Android'">$(DotNetVersion)-android</OverrideTargetFramework> -->
+        <!-- <OverrideTargetFramework Condition="''!='hint: MacCatalyst'">$(DotNetVersion)-maccatalyst</OverrideTargetFramework> -->
     </PropertyGroup>
 </Project>

--- a/src/Uno.Templates/content/unomauilib/.template.config/template.json
+++ b/src/Uno.Templates/content/unomauilib/.template.config/template.json
@@ -112,25 +112,7 @@
         ]
       }
     },
-    "libraryBaseTargetFramework": {
-      "type": "generated",
-      "generator": "switch",
-      "replaces": "$libraryBaseTargetFramework$",
-      "parameters": {
-        "evaluator": "C++",
-        "datatype": "string",
-        "cases": [
-          {
-            "condition": "(tfm == 'net7.0')",
-            "value": "net7.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0')",
-            "value": "net8.0"
-          }
-        ]
-      }
-    },
+    // TODO: Should we be using $(DotNetVersion) instead of explicitly defining each tfm?
     "mobileTargetFrameworks": {
       "type": "generated",
       "generator": "switch",

--- a/src/Uno.Templates/content/unomauilib/.template.config/template.json
+++ b/src/Uno.Templates/content/unomauilib/.template.config/template.json
@@ -112,7 +112,6 @@
         ]
       }
     },
-    // TODO: Should we be using $(DotNetVersion) instead of explicitly defining each tfm?
     "mobileTargetFrameworks": {
       "type": "generated",
       "generator": "switch",
@@ -122,63 +121,35 @@
         "datatype": "string",
         "cases": [
           {
-            "condition": "(tfm == 'net7.0' && useAndroid && useiOS && useMacCatalyst)",
-            "value": "net7.0-android;net7.0-ios;net7.0-maccatalyst"
+            "condition": "(platforms == android && platforms == ios && platforms == maccatalyst)",
+            "value": "$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net8.0' && useAndroid && useiOS && useMacCatalyst)",
-            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst"
+            "condition": "(platforms == android && platforms == ios && platforms != maccatalyst)",
+            "value": "$(DotNetVersion)-android;$(DotNetVersion)-ios"
           },
           {
-            "condition": "(tfm == 'net7.0' && useAndroid && useiOS && !useMacCatalyst)",
-            "value": "net7.0-android;net7.0-ios"
+            "condition": "(platforms != android && platforms == ios && platforms == maccatalyst)",
+            "value": "$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net8.0' && useAndroid && useiOS && !useMacCatalyst)",
-            "value": "net8.0-android;net8.0-ios"
+            "condition": "(platforms == android && platforms != ios && platforms == maccatalyst)",
+            "value": "$(DotNetVersion)-android;$(DotNetVersion)-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net7.0' && !useAndroid && useiOS && useMacCatalyst)",
-            "value": "net7.0-ios;net7.0-maccatalyst"
+            "condition": "(platforms == android && platforms != ios && platforms != maccatalyst)",
+            "value": "$(DotNetVersion)-android"
           },
           {
-            "condition": "(tfm == 'net8.0' && !useAndroid && useiOS && useMacCatalyst)",
-            "value": "net8.0-ios;net8.0-maccatalyst"
+            "condition": "(platforms != android && platforms == ios && platforms != maccatalyst)",
+            "value": "$(DotNetVersion)-ios"
           },
           {
-            "condition": "(tfm == 'net7.0' && useAndroid && !useiOS && useMacCatalyst)",
-            "value": "net7.0-android;net7.0-maccatalyst"
+            "condition": "(platforms != android && platforms != ios && platforms == maccatalyst)",
+            "value": "$(DotNetVersion)-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net8.0' && useAndroid && !useiOS && useMacCatalyst)",
-            "value": "net8.0-android;net8.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net7.0' && useAndroid && !useiOS && !useMacCatalyst)",
-            "value": "net7.0-android"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useAndroid && !useiOS && !useMacCatalyst)",
-            "value": "net8.0-android"
-          },
-          {
-            "condition": "(tfm == 'net7.0' && !useAndroid && useiOS && !useMacCatalyst)",
-            "value": "net7.0-ios"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && !useAndroid && useiOS && !useMacCatalyst)",
-            "value": "net8.0-ios"
-          },
-          {
-            "condition": "(tfm == 'net7.0' && !useAndroid && !useiOS && useMacCatalyst)",
-            "value": "net7.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && !useAndroid && !useiOS && useMacCatalyst)",
-            "value": "net8.0-maccatalyst"
-          },
-          {
-            "condition": "(!useAndroid && !useiOS && !useMacCatalyst)",
+            "condition": "(platforms != android && platforms != ios && platforms != maccatalyst)",
             "value": ""
           }
         ]


### PR DESCRIPTION
GitHub Issue (If applicable): closes #424 #423 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

If you add non-mobile overrides, the mobile project won't build.

## What is the new behavior?

OverrideFrameworkVersions is now designed to be single target - if you uncomment more than one line in the solution-config.props it will pick up only the last

Validation messages have been added to build.props to help warn developers if they are trying to build a project with an invalid set of tfms/overrides

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
