### PR TITLE
Control .NET version globally from Directory.Build.props

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1455,60 +1455,32 @@
         "datatype": "string",
         "cases": [
           {
-            "condition": "(tfm == 'net7.0' && platforms == android && platforms == ios && platforms == maccatalyst)",
-            "value": "net7.0-android;net7.0-ios;net7.0-maccatalyst"
+            "condition": "(platforms == android && platforms == ios && platforms == maccatalyst)",
+            "value": "$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst)",
-            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst"
+            "condition": "(platforms == android && platforms == ios && platforms != maccatalyst)",
+            "value": "$(DotNetVersion)-android;$(DotNetVersion)-ios"
           },
           {
-            "condition": "(tfm == 'net7.0' && platforms == android && platforms == ios && platforms != maccatalyst)",
-            "value": "net7.0-android;net7.0-ios"
+            "condition": "(platforms != android && platforms == ios && platforms == maccatalyst)",
+            "value": "$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst)",
-            "value": "net8.0-android;net8.0-ios"
+            "condition": "(platforms == android && platforms != ios && platforms == maccatalyst)",
+            "value": "$(DotNetVersion)-android;$(DotNetVersion)-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net7.0' && platforms != android && platforms == ios && platforms == maccatalyst)",
-            "value": "net7.0-ios;net7.0-maccatalyst"
+            "condition": "(platforms == android && platforms != ios && platforms != maccatalyst)",
+            "value": "$(DotNetVersion)-android"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst)",
-            "value": "net8.0-ios;net8.0-maccatalyst"
+            "condition": "(platforms != android && platforms == ios && platforms != maccatalyst)",
+            "value": "$(DotNetVersion)-ios"
           },
           {
-            "condition": "(tfm == 'net7.0' && platforms == android && platforms != ios && platforms == maccatalyst)",
-            "value": "net7.0-android;net7.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst)",
-            "value": "net8.0-android;net8.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net7.0' && platforms == android && platforms != ios && platforms != maccatalyst)",
-            "value": "net7.0-android"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst)",
-            "value": "net8.0-android"
-          },
-          {
-            "condition": "(tfm == 'net7.0' && platforms != android && platforms == ios && platforms != maccatalyst)",
-            "value": "net7.0-ios"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst)",
-            "value": "net8.0-ios"
-          },
-          {
-            "condition": "(tfm == 'net7.0' && platforms != android && platforms != ios && platforms == maccatalyst)",
-            "value": "net7.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst)",
-            "value": "net8.0-maccatalyst"
+            "condition": "(platforms != android && platforms != ios && platforms == maccatalyst)",
+            "value": "$(DotNetVersion)-maccatalyst"
           },
           {
             "condition": "(platforms != android && platforms != ios && platforms != maccatalyst)",

--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -10,6 +10,7 @@
 
 
   <PropertyGroup>
+    <DotNetVersion>$libraryBaseTargetFramework$</DotNetVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.DataContracts/MyExtensionsApp._1.DataContracts.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.DataContracts/MyExtensionsApp._1.DataContracts.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$libraryBaseTargetFramework$</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/MyExtensionsApp._1.MauiControls.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.MauiControls/MyExtensionsApp._1.MauiControls.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <!--#if (useWinAppSdk) -->
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$baseTargetFramework$-windows10.0.19041</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);$libraryBaseTargetFramework$;$mobileTargetFrameworks$</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);$(DotNetVersion);$mobileTargetFrameworks$</TargetFrameworks>
     <!--#else -->
-    <TargetFrameworks>$libraryBaseTargetFramework$;$mobileTargetFrameworks$</TargetFrameworks>
+    <TargetFrameworks>$(DotNetVersion);$mobileTargetFrameworks$</TargetFrameworks>
     <!--#endif -->
     <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'!=''">$(OverrideTargetFrameworks)</TargetFrameworks>
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Mobile/MyExtensionsApp._1.Mobile.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$mobileTargetFrameworks$</TargetFrameworks>
     <!--#if (useMacOS)-->
     <!-- Disabled because of https://github.com/xamarin/xamarin-macios/issues/16401-->
-    <!-- <TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$-macos</TargetFrameworks> -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);$(DotNetVersion)-macos</TargetFrameworks> -->
     <!--#endif-->
     <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'!=''">$(OverrideTargetFrameworks)</TargetFrameworks>
     <SingleProject>true</SingleProject>
@@ -207,7 +207,7 @@
         <PackageReference Include="Xamarin.AndroidX.Navigation.Runtime" VersionOverride="$(AndroidXNavigationVersion)" />
         <PackageReference Include="Xamarin.AndroidX.Navigation.Common" VersionOverride="$(AndroidXNavigationVersion)" />
         <PackageReference Include="Xamarin.AndroidX.Collection" VersionOverride="$(AndroidXCollectionVersion)" />
-        <PackageReference Include="Xamarin.AndroidX.Collection.Ktx" VersionOverride="$(AndroidXCollectionVersion)" />    
+        <PackageReference Include="Xamarin.AndroidX.Collection.Ktx" VersionOverride="$(AndroidXCollectionVersion)" />
         <!--#endif-->
 
         <!--#if (useCPM)-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/MyExtensionsApp._1.Server.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Server/MyExtensionsApp._1.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>$baseTargetFramework$</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--#if (useCsharpMarkup)-->
     <EnableUnoCSMUsings>false</EnableUnoCSMUsings>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Shared/MyExtensionsApp._1.Shared.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Shared/MyExtensionsApp._1.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Build.NoTargets/3.7.0">
   <PropertyGroup>
     <!-- NOTE: The TargetFramework is required by MSBuild but not used as this project is not built. -->
-    <TargetFramework>$libraryBaseTargetFramework$</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Gtk/MyExtensionsApp._1.Skia.Gtk.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>$baseTargetFramework$</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.Linux.FrameBuffer/MyExtensionsApp._1.Skia.Linux.FrameBuffer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>$baseTargetFramework$</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Package.appxmanifest" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Skia.WPF/MyExtensionsApp._1.Skia.WPF.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>$baseTargetFramework$-windows</TargetFramework>
+    <TargetFramework>$(DotNetVersion)-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Tests/MyExtensionsApp._1.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$baseTargetFramework$</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/MyExtensionsApp._1.UITests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.UITests/MyExtensionsApp._1.UITests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$baseTargetFramework$</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Wasm/MyExtensionsApp._1.Wasm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$baseTargetFramework$</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <NoWarn>$(NoWarn);NU1504;NU1505;NU1701</NoWarn>
     <!-- Disabled due to issue with Central Package Management with implicit using -->
     <ImplicitUsings>disable</ImplicitUsings>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1.Windows/MyExtensionsApp._1.Windows.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>$baseTargetFramework$-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>$(DotNetVersion)-windows10.0.19041.0</TargetFramework>
     <RootNamespace>MyExtensionsApp._1.Windows</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;arm64</Platforms>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp._1/MyExtensionsApp._1.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!--#if (useWinAppSdk) -->
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$baseTargetFramework$-windows10.0.19041</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);$libraryBaseTargetFramework$;$mobileTargetFrameworks$</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);$(DotNetVersion);$mobileTargetFrameworks$</TargetFrameworks>
     <!--#else -->
-    <TargetFrameworks>$libraryBaseTargetFramework$;$mobileTargetFrameworks$</TargetFrameworks>
+    <TargetFrameworks>$(DotNetVersion);$mobileTargetFrameworks$</TargetFrameworks>
     <!--#endif -->
     <!--#if (useMacOS)-->
     <!-- Disabled because of https://github.com/xamarin/xamarin-macios/issues/16401-->
-    <!--<TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$-macos</TargetFrameworks>-->
+    <!--<TargetFrameworks>$(TargetFrameworks);$(DotNetVersion)-macos</TargetFrameworks>-->
     <!--#endif -->
     <TargetFrameworks Condition="'$(OverrideTargetFrameworks)'!=''">$(OverrideTargetFrameworks)</TargetFrameworks>
 
@@ -236,7 +236,7 @@
     <PackageReference Include="Xamarin.AndroidX.Navigation.Runtime" VersionOverride="$(AndroidXNavigationVersion)" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.Common" VersionOverride="$(AndroidXNavigationVersion)" />
     <PackageReference Include="Xamarin.AndroidX.Collection" VersionOverride="$(AndroidXCollectionVersion)" />
-    <PackageReference Include="Xamarin.AndroidX.Collection.Ktx" VersionOverride="$(AndroidXCollectionVersion)" />    
+    <PackageReference Include="Xamarin.AndroidX.Collection.Ktx" VersionOverride="$(AndroidXCollectionVersion)" />
   </ItemGroup>
   <!--#endif-->
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

If you create the app with net7 and want to experiment with net8 you need to find/replace net7 with net8 in all of the projects.

## What is the new behavior?

You can now simply change the `DotNetVersion` in the Directory.Build.props. This will globally update the entire solution to use the version that you want. 

**NOTE:** This may result in undesired behavior such as with MAUI Embedding where get the requirement for the additional NuGet Packages, and you may have API breaks in libraries you are referencing when changing from net7 to net8 to net9. 