### PR TITLE
Avoid name clash for DSP Generator

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -887,7 +887,7 @@
       "datatype": "bool",
       "value": "(markup == 'xaml')"
     },
-    "DspGenerator": {
+    "dspGeneratorOutputType": {
       "type": "generated",
       "generator": "switch",
       "replaces": "$DspGenerator$",


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes unoplatform/uno#14431

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The Symbol name is duplicated between parameter to disable DSP and the generated symbol that replaces the Generator Output Type in the csproj.

## What is the new behavior?

We renamed the generated symbol to avoid a name clash. `dspGenerator` and `DspGenerator` these seem to have been similar enough to potentially cause issues.