### PR TITLE
Enable wasm multi-threading

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
@@ -96,7 +96,7 @@
     "skipRestore": {
       "longName": "skip-restore",
       "shortName": "skip"
-    },  
+    },
     "themeService": {
       "longName": "theme-service",
       "shortName": "theme-service"
@@ -112,6 +112,10 @@
     "defaultBranchName": {
       "longName": "default-branch-name",
       "shortName": "branch"
+    },
+    "wasmMultiThreading": {
+      "longName": "wasm-multi-threading",
+      "shortName": "wasm-multi-threading"
     },
     "unoWinUIVersion": {
       "isHidden": true

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -709,6 +709,13 @@
       "datatype": "bool",
       "defaultValue": "false"
     },
+    "wasmMultiThreading": {
+      "displayName": "WASM Multi-Threading",
+      "description": "Configures application to use multi-threading in WebAssembly",
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false"
+    },
     "skipRestore": {
       "type": "parameter",
       "datatype": "bool",
@@ -1112,6 +1119,12 @@
       "type": "computed",
       "datatype": "bool",
       "value": "useMvux || useMvvm"
+    },
+    "useWasmMultiThreading": {
+      "type": "computed",
+      "datatype": "bool",
+      // NOTE: This doesn't work well in net7.0
+      "value": "(tfm != 'net7.0' && wasmMultiThreading)"
     },
     "useGtk": {
       "type": "computed",

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
@@ -18,7 +18,7 @@
 
     <!--
       Enable WebAssembly Threads
-      https://platform.uno/docs/articles/external/uno.wasm.bootstrap/doc/features-threading.html
+      https://aka.platform.uno/wasm-threading
 
       NOTE: This feature is still considered experimental by the dotnet team
     -->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
@@ -14,6 +14,17 @@
       https://aka.platform.uno/wasm-deeplink
     -->
     <WasmShellWebAppBasePath>/</WasmShellWebAppBasePath>
+    <!--#if (useWasmMultiThreading)-->
+
+    <!--
+      Enable WebAssembly Threads
+      https://platform.uno/docs/articles/external/uno.wasm.bootstrap/doc/features-threading.html
+
+      NOTE: This feature is still considered experimental by the dotnet team
+    -->
+    <WasmShellEnableThreads>true</WasmShellEnableThreads>
+    <WasmShellPThreadsPoolSize>8</WasmShellPThreadsPoolSize>
+    <!--#endif-->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <MonoRuntimeDebuggerEnabled>true</MonoRuntimeDebuggerEnabled>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #432 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

To use WASM Multi-Threading you must first know about it, have read the docs, and then modified your project with the additional properties that need to be set.

## What is the new behavior?

When creating a new project you can now optionally specify `-wasm-multi-threading` from the CLI to enable WASM Multi-Threading. This includes a comment in the csproj to the docs as this is still a new feature and Multi-Threading is still not fully supported by the dotnet team. Also for that reason it is disabled by default and must be opted into. We will look to change this behavior when the feature is considered stable by Microsoft.