### PR TITLE
Workaround for malformed YAML when tests are disabled

### DIFF
--- a/src/Uno.Templates/content/unoapp/GitHub/workflows/ci.yml
+++ b/src/Uno.Templates/content/unoapp/GitHub/workflows/ci.yml
@@ -59,4 +59,5 @@ jobs:
       - name: Run Unit Tests
         shell: pwsh
         run: dotnet test ./MyExtensionsApp.1.Tests/MyExtensionsApp.1.Tests.csproj --no-build -c Release --logger GitHubActions --blame-crash --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+#else
 #endif

--- a/src/Uno.Templates/content/unoapp/azure-pipelines.yml
+++ b/src/Uno.Templates/content/unoapp/azure-pipelines.yml
@@ -21,5 +21,8 @@ stages:
     displayName: Tests
     jobs:
       - template: build/jobs/smoke-test.yml
+#if (useUnitTests)
 
       - template: build/jobs/unit-test.yml
+#else
+#endif


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #433 
- related dotnet/templating#7269

## PR Type

What kind of change does this PR introduce?

- Bugfix (Workaround)

## What is the current behavior?

When someone creates a template without Unit Tests but with GitHub Actions, the generated YAML is malformed as the template engine removes most but not all of the code block for the Unit Test job.

## What is the new behavior?

We now have an empty `#else`. The Template Engine seems to now properly box the job for the Unit Tests and include it when the condition is true and exclude it in its entirety when the condition is false.

## Other information

This is a workaround. Hopefully the .NET Templating team will come up with a better long term fix for this so we can remove the hack of the empty `#else`
