### PR TITLE
fix: The new "shared" project does not have `$libraryBaseTargetFramework$` replaced

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Shared/MyExtensionsApp.1.Shared.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Shared/MyExtensionsApp.1.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Build.NoTargets/3.7.0">
   <PropertyGroup>
     <!-- NOTE: The TargetFramework is required by MSBuild but not used as this project is not built. -->
-    <TargetFramework>$libraryBaseTargetFramework$</TargetFramework>
+    <TargetFramework>$(DotNetVersion)</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #463

GitHub Issue (If applicable): closes #463

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Invalid token left in code after running template

## What is the new behavior?

No invalid tokens remain

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
