### PR TITLE
Incorrect xmlns on Material Resources

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/AppResources.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/AppResources.xaml
@@ -6,7 +6,7 @@
     <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
 <!--#if (useMaterial)-->
 <!--#if (useToolkit)-->
-    <utum:MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
+    <utum:MaterialToolkitTheme
       ColorOverrideSource="ms-appx:///MyExtensionsApp._1/Styles/ColorPaletteOverride.xaml">
       <!-- NOTE: You can override the default Roboto font by providing your font assets here. -->
       <!-- <utum:MaterialToolkitTheme.FontOverrideDictionary>
@@ -18,7 +18,7 @@
       </utum:MaterialToolkitTheme.FontOverrideDictionary> -->
     </utum:MaterialToolkitTheme>
 <!--#else-->
-    <um:MaterialTheme  xmlns="using:Uno.Material"
+    <um:MaterialTheme
       ColorOverrideSource="ms-appx:///MyExtensionsApp._1/Styles/ColorPaletteOverride.xaml">
       <!-- NOTE: You can override the default Roboto font by providing your font assets here. -->
       <!-- <um:MaterialTheme.FontOverrideDictionary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #468

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When using Material there was still an un-named xmlns on the Resources node itself. This caused the build to assume the children were within that namespace.

## What is the new behavior?

We only use the namespaces at the top of the AppResources.
