### PR TITLE
Maui Control doesn't work with Frame Navigation

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1115,10 +1115,10 @@
       "datatype": "bool",
       "value": "architectureEvaluator == 'mvvm' || (architectureEvaluator == 'none' && useExtensionsNavigation)"
     },
-    "useMvvmOrMvux": {
+    "useMauiMvvmOrMvux": {
       "type": "computed",
       "datatype": "bool",
-      "value": "useMvux || useMvvm"
+      "value": "(navigationEvaluator != 'blank' && (useMvux || useMvvm))"
     },
     "useWasmMultiThreading": {
       "type": "computed",

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/EmbeddedControl.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/EmbeddedControl.xaml
@@ -29,7 +29,7 @@
       FontSize="18"
       HorizontalOptions="Center" />
 
-<!--#if (useMvvmOrMvux)-->
+<!--#if (useMauiMvvmOrMvux)-->
     <Button
       Text="{Binding CounterText}"
       SemanticProperties.Hint="Counts the number of times you click"
@@ -41,7 +41,6 @@
       Text="Press Me"
       SemanticProperties.Hint="Counts the number of times you click"
       Clicked="CounterClicked"
-      Command="{Binding Counter}"
       HorizontalOptions="Center" />
 <!--#endif-->
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/EmbeddedControl.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/EmbeddedControl.xaml.cs
@@ -9,9 +9,10 @@ public partial class EmbeddedControl : ContentView
     }
 
 //+:cnd:noEmit
-#if (!useMvvmOrMvux)
+#if (!useMauiMvvmOrMvux)
     private int count=0;
-    public void CounterClicked(object sender, EventArgs e)
+
+    private void CounterClicked(object sender, EventArgs e)
     {
         CounterButton.Text = ++count switch
         {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #466

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

If creating a blank app which defaults to use Frame Navigation and then selecting MVVM and Maui, the Maui Control will be wired up to expect that it should data bind to the ViewModel. Since we are using Frame Navigation there is no ViewModel available.

## What is the new behavior?

When selecting these options the CommunityToolkit.Mvvm package will still be install and no ViewModel will be created for the page, however the Maui Control will now recognize that we are using Frame Navigation and will default back to using the Clicked Event Handler in the Control's code behind to drive the updated text in the button and track the count state.

Also updating the computed symbol name to make it clearer that it is used specifically for MAUI and nowhere else in the template.