### PR TITLE
feat: Recommend unoplatform.vscode inside VS Code

### DIFF
--- a/src/Uno.Templates/content/unoapp/.vscode/extensions.json
+++ b/src/Uno.Templates/content/unoapp/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+	"recommendations": [
+		"unoplatform.vscode"
+	],
+	"unwantedRecommendations": [
+		"ms-dotnettools.csdevkit"
+	],
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Opening a new solution, based on the templates, inside VS Code does not suggest installing the Uno Platform extension. Instead it suggest installed C# DevKit which does not work with our extension.

## What is the new behavior?

This will suggest the installation of the Uno Platform extension (if not already installed) when opening the solution folder inside VS Code.

As the Uno Platform extension depends on the MS C# extension, the latter will also be installed (if not already). Sadly it does not enable the `useOmniSharp` setting even when C# DevKit is not present :( The **Uno Platform** logs prints an error and a link to the documentation in this case [1].

This also stop VS Code from recommending C# DevKit (which was done before suggesting Uno) since the Uno extension cannot work _yet_ with it (and the available experimental API could break the integration at any time). We'll recommend C# DevKit when ready on our own terms.

[1] a [future version](https://github.com/unoplatform/uno.vscode/pull/536) of the Uno Platform extension will show a notification and open the settings (or the web documentation) to make the required change easier.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
