### PR TITLE
chore: hide isVsix parameter on the cli

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
@@ -161,6 +161,9 @@
     },
     "enableDeveloperMode": {
       "isHidden": true
+    },
+    "isVsix": {
+      "isHidden": true
     }
   }
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #483

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

vsix flag is exposed on the cli

## What is the new behavior?

vsix flag is hidden on the cli

