### PR TITLE
chore: remove unwanted recommendation on vscode extension

### DIFF
--- a/src/Uno.Templates/content/unoapp/.vscode/extensions.json
+++ b/src/Uno.Templates/content/unoapp/.vscode/extensions.json
@@ -2,7 +2,4 @@
   "recommendations": [
     "unoplatform.vscode"
   ],
-  "unwantedRecommendations": [
-    "ms-dotnettools.csdevkit"
-  ],
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

Adapt VS Code extension recommendation to the new default.

## What is the current behavior?

* `unoplatform.vscode` is recommended
* `ms-dotnettools.csdevkit` was unwanted (for O# compatibility)

## What is the new behavior?

* `unoplatform.vscode` is recommended **and** has a dependency on `ms-dotnettools.csdevkit`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
