### PR TITLE
fix: allow vscode w/dev kit to load solutions made from template

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Windows/MyExtensionsApp.1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Windows/MyExtensionsApp.1.Windows.csproj
@@ -9,6 +9,7 @@
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <!--#if (useWinAppSdkSelfContained)-->
     <!-- Bundles the WinAppSDK binaries -->


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

VS Code with OmniSharp can load the solution create from the templates.

VS Code with C# DevKit can NOT load the solution create from the templates. In this case a notification is shown

> Failed to restore solution.

and the logs shows

```
  Determining projects to restore...
/usr/local/share/dotnet/sdk/8.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(90,5): error NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true. [/Users/poupou/git/external/uno/Uno.Samples/reference/SimpleCalc/MVU-X-CSharp/SimpleCalculator.Windows/SimpleCalculator.Windows.csproj]
```

## What is the new behavior?

VS Code can load the solution in either OmniSharp or Dev Kit modes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
