### PR TITLE
fix: Use pre-launch task for vscode wasm

### DIFF
--- a/src/Uno.Templates/content/unoapp/.vscode/launch.json
+++ b/src/Uno.Templates/content/unoapp/.vscode/launch.json
@@ -25,9 +25,11 @@
       "webRoot": "${workspaceFolder}/MyExtensionsApp.1.Wasm",
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "timeout": 30000,
+      "preLaunchTask": "build-wasm",
       "server": {
         "runtimeExecutable": "dotnet",
         "program": "run",
+        "args": ["--no-build"],
         "outputCapture": "std",
         "timeout": 30000,
         "cwd": "${workspaceFolder}/MyExtensionsApp.1.Wasm"


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.templates/issues/497

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures that vscode will pre-build the app before starting the app's server, avoiding `about:blank` navigation issues.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
