### PR TITLE
feat: Updating winappsdk version and removing UseRidGraph (as no longer required with 1.4.231219000)

### DIFF
--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -42,7 +42,7 @@
 		<NewtonsoftJsonVersion Condition="'$(NewtonsoftJsonVersion)' == ''">13.0.3</NewtonsoftJsonVersion>
 		<XamarinUITestVersion Condition="'$(XamarinUITestVersion)' == ''">4.3.3</XamarinUITestVersion>
 		<MicrosoftWindowsSDKBuildToolsVersion Condition="'$(MicrosoftWindowsSDKBuildToolsVersion)' == ''">10.0.22621.2428</MicrosoftWindowsSDKBuildToolsVersion>
-		<MicrosoftWindowsAppSDKVersion Condition="'$(MicrosoftWindowsAppSDKVersion)' == ''">1.4.231115000</MicrosoftWindowsAppSDKVersion>
+		<MicrosoftWindowsAppSDKVersion Condition="'$(MicrosoftWindowsAppSDKVersion)' == ''">1.4.231219000</MicrosoftWindowsAppSDKVersion>
 		<XamarinGoogleAndroidMaterialVersion Condition="'$(XamarinGoogleAndroidMaterialVersion)' == ''">1.10.0.2</XamarinGoogleAndroidMaterialVersion>
 	</PropertyGroup>
 	<PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -87,7 +87,6 @@
     </When>
     <When Condition="$(TargetFramework.Contains('windows10'))">
       <PropertyGroup>
-        <UseRidGraph>true</UseRidGraph>
         <IsWinAppSdk>true</IsWinAppSdk>
         <SupportedOSPlatformVersion>10.0.18362.0</SupportedOSPlatformVersion>
         <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/MyExtensionsApp.1.MauiControls.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/MyExtensionsApp.1.MauiControls.csproj
@@ -45,7 +45,7 @@
       <PropertyGroup>
         <SupportedOSPlatformVersion>10.0.18362.0</SupportedOSPlatformVersion>
         <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
-        <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+        <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
         <EnableCoreMrtTooling Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">false</EnableCoreMrtTooling>
       </PropertyGroup>
     </When>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

WinUI requires "UseRidGraph" to be set to true due to not supporting net8 runtime identifiers

## What is the new behavior?

WinAppSdk is updated to latest release
UseRidGraph property has been removed as no longer required

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
