### PR TITLE
Fixing incorrect variable in custom login logic with C# markup

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/LoginPage.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/LoginPage.xaml.cs
@@ -36,7 +36,7 @@ public sealed partial class LoginPage : Page
                         .Children(
 #if useCustomAuthentication
                             new TextBox()
-                                .Text(x => x.Bind(() => vm.Name).TwoWay())
+                                .Text(x => x.Bind(() => vm.Username).TwoWay())
                                 .PlaceholderText("Username")
                                 .HorizontalAlignment(HorizontalAlignment.Stretch),
                             new PasswordBox()


### PR DESCRIPTION
Fixes #505

GitHub Issue (If applicable): closes #505 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Refactoring (no functional changes, no api changes)

## What is the current behavior?
The custom login logic with C# markup has an incorrect variable, so compilation fails

## What is the new behavior?
The variable is binded correctly now

## PR Checklist

- [ X ] Associated with an issue (GitHub or internal)

## Other information

Internal Issue (If applicable):
https://github.com/unoplatform/uno.templates/issues/505