### PR TITLE
Drop net7 support

### DIFF
--- a/build/.azure-pipelines.TemplateValidation.yml
+++ b/build/.azure-pipelines.TemplateValidation.yml
@@ -44,12 +44,10 @@ jobs:
         templateArgs: '-preset recommended -tests none'
       FrameNavigation:
         templateArgs: '-preset recommended --navigation blank'
-      # net8 is the default for tfm, so validating net7.0
-      Net7:
-        templateArgs: '-preset recommended -tfm net7.0'
+      # Disabling this test for now as it was specific to net7
       # https://github.com/unoplatform/uno.templates/issues/22
-      Issue22:
-        templateArgs: '-preset blank -tfm net7.0 -platforms android -platforms ios -platforms maccatalyst -platforms macos -platforms windows -platforms wasm -platforms gtk -platforms wpf -platforms linux-fb -presentation mvvm -server false -tests none -vscode false -pwa false -di true -nav regions -log none -theme material'
+      # Issue22:
+      #   templateArgs: '-preset blank -tfm net7.0 -platforms android -platforms ios -platforms maccatalyst -platforms macos -platforms windows -platforms wasm -platforms gtk -platforms wpf -platforms linux-fb -presentation mvvm -server false -tests none -vscode false -pwa false -di true -nav regions -log none -theme material'
       CustomAuthMvux:
         templateArgs: '-preset=recommended -auth=custom'
       CustomAuthMvvm:

--- a/build/templates/dotnet-install-windows.yml
+++ b/build/templates/dotnet-install-windows.yml
@@ -1,5 +1,5 @@
 parameters:
-  DotNetVersion: '7.0.400'
+  DotNetVersion: '8.0.101'
 
 steps:
 

--- a/build/templates/dotnet-install-windows.yml
+++ b/build/templates/dotnet-install-windows.yml
@@ -1,5 +1,5 @@
 parameters:
-  DotNetVersion: '8.0.101'
+  DotNetVersion: '8.0.100'
 
 steps:
 

--- a/build/templates/package-validation.yml
+++ b/build/templates/package-validation.yml
@@ -10,13 +10,8 @@ steps:
 - powershell: |
     $templateArgs = '${{ parameters.arguments }}'
     Write-Host "TemplateArgs = '$templateArgs'"
-    $dotnetVersion = '7.0.403'
-    $workloadRestore = 'https://maui.blob.core.windows.net/metadata/rollbacks/7.0.101.json'
-
-    if (!$templateArgs.Contains('net7')) {
-      $dotnetVersion = '8.0.100'
-      $workloadRestore = 'https://maui.blob.core.windows.net/metadata/rollbacks/8.0.3.json'
-    }
+    $dotnetVersion = '8.0.101'
+    $workloadRestore = 'https://maui.blob.core.windows.net/metadata/rollbacks/8.0.5.json'
 
     Write-Host "DotNetVersion = $dotnetVersion"
     Write-Output "##vso[task.setvariable variable=DotNetVersion]$dotnetVersion"

--- a/build/templates/package-validation.yml
+++ b/build/templates/package-validation.yml
@@ -10,8 +10,8 @@ steps:
 - powershell: |
     $templateArgs = '${{ parameters.arguments }}'
     Write-Host "TemplateArgs = '$templateArgs'"
-    $dotnetVersion = '8.0.101'
-    $workloadRestore = 'https://maui.blob.core.windows.net/metadata/rollbacks/8.0.5.json'
+    $dotnetVersion = '8.0.100'
+    $workloadRestore = 'https://maui.blob.core.windows.net/metadata/rollbacks/8.0.3.json'
 
     Write-Host "DotNetVersion = $dotnetVersion"
     Write-Output "##vso[task.setvariable variable=DotNetVersion]$dotnetVersion"

--- a/build/templates/propertiesToUpdate.json
+++ b/build/templates/propertiesToUpdate.json
@@ -10,7 +10,6 @@
   { "PropertyName": "UnoToolkitMarkupVersion", "PackageId": "Uno.Toolkit.WinUI.Markup" }, 
   { "PropertyName": "UnoResizetizerVersion", "PackageId": "Uno.Resizetizer" }, 
   { "PropertyName": "UnoUniversalImageLoaderVersion", "PackageId": "Uno.UniversalImageLoader" }, 
-  { "PropertyName": "UnoWasmBootstrapVersionNet7", "PackageId": "Uno.Wasm.Bootstrap" }, 
   { "PropertyName": "UnoWasmBootstrapVersionNet8", "PackageId": "Uno.Wasm.Bootstrap" }, 
   { "PropertyName": "UnoMarkupVersion", "PackageId": "Uno.WinUI.Markup" }, 
   { "PropertyName": "UnoUITestHelpersVersion", "PackageId": "Uno.UITest.Helpers" }

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -30,7 +30,6 @@
 		<UnoToolkitMarkupVersion Condition="'$(UnoToolkitMarkupVersion)' == ''">5.0.17</UnoToolkitMarkupVersion>
 		<UnoResizetizerVersion Condition="'$(UnoResizetizerVersion)' == ''">1.2.0</UnoResizetizerVersion>
 		<UnoUniversalImageLoaderVersion Condition="'$(UnoUniversalImageLoaderVersion)' == ''">1.9.36</UnoUniversalImageLoaderVersion>
-		<UnoWasmBootstrapVersionNet7 Condition="'$(UnoWasmBootstrapVersionNet7)' == ''">7.0.31</UnoWasmBootstrapVersionNet7>
 		<UnoWasmBootstrapVersionNet8 Condition="'$(UnoWasmBootstrapVersionNet8)' == ''">8.0.4</UnoWasmBootstrapVersionNet8>
 		<UnoMarkupVersion Condition="'$(UnoMarkupVersion)' == ''">5.0.13</UnoMarkupVersion>
 		<UnoUITestHelpersVersion Condition="'$(UnoUITestHelpersVersion)' == ''">1.1.0-dev.70</UnoUITestHelpersVersion>
@@ -113,7 +112,6 @@
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoToolkitMarkupVersion" ReplacementText="$(UnoToolkitMarkupVersion)"/>
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoResizetizerVersion" ReplacementText="$(UnoResizetizerVersion)"/>
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoUniversalImageLoaderVersion" ReplacementText="$(UnoUniversalImageLoaderVersion)" />
-		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoWasmBootstrapVersionNet7" ReplacementText="$(UnoWasmBootstrapVersionNet7)" />
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoWasmBootstrapVersionNet8" ReplacementText="$(UnoWasmBootstrapVersionNet8)"/>
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoMarkupVersion" ReplacementText="$(UnoMarkupVersion)"/>
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoUITestHelpersVersion" ReplacementText="$(UnoUITestHelpersVersion)"/>

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -18,7 +18,7 @@
 
 	<PropertyGroup>
 		<!-- If you update Extensions or Uno version, make sure you update the versions in the reinstall.ps1 file too !-->
-		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">3.0.11</UnoExtensionsVersion>
+		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">4.0.0-dev.212</UnoExtensionsVersion>
 		<UnoVersion Condition="'$(UnoVersion)' == ''">5.1.0-dev.768</UnoVersion>
 		
 		<UnoExtensionsLoggingVersion Condition="'$(UnoExtensionsLoggingVersion)' == ''">1.7.0</UnoExtensionsLoggingVersion>

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -190,11 +190,6 @@
       "description": "Select the .NET version of your solution",
       "choices": [
         {
-          "choice": "net7.0",
-          "displayName": ".NET 7.0",
-          "description": "Target .NET 7.0 (Standard Term Support)"
-        },
-        {
           "choice": "net8.0",
           "displayName": ".NET 8.0",
           "description": "Target .NET 8.0 (Long Term Support)"
@@ -802,12 +797,8 @@
         "datatype": "text",
         "cases": [
           {
-            "condition": "(tfm == 'net7.0')",
-            "value": "7.0.101"
-          },
-          {
             "condition": "(tfm == 'net8.0')",
-            "value": "8.0.3"
+            "value": "8.0.5"
           }
         ]
       }
@@ -820,10 +811,6 @@
         "evaluator": "C++",
         "datatype": "string",
         "cases": [
-          {
-            "condition": "(tfm == 'net7.0')",
-            "value": "DefaultUnoWasmBootstrapVersionNet7"
-          },
           {
             "condition": "(tfm == 'net8.0')",
             "value": "DefaultUnoWasmBootstrapVersionNet8"
@@ -863,12 +850,6 @@
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false"
-    },
-    // TODO: change this to != net7.0 when we don't have backport concerns
-    "useMauiPackageReference": {
-      "type": "computed",
-      "datatype": "bool",
-      "value": "(mauiEmbedding && tfm == 'net8.0')"
     },
     "useAzurePipelines": {
       "type": "computed",
@@ -1129,8 +1110,7 @@
     "useWasmMultiThreading": {
       "type": "computed",
       "datatype": "bool",
-      // NOTE: This doesn't work well in net7.0
-      "value": "(tfm != 'net7.0' && wasmMultiThreading)"
+      "value": "(wasmMultiThreading)"
     },
     "useGtk": {
       "type": "computed",
@@ -1436,10 +1416,6 @@
         "evaluator": "C++",
         "datatype": "string",
         "cases": [
-          {
-            "condition": "(tfm == 'net7.0')",
-            "value": "7.0.x"
-          },
           {
             "condition": "(tfm == 'net8.0')",
             "value": "8.0.x"
@@ -1828,10 +1804,6 @@
         "datatype": "string",
         "cases": [
           {
-            "condition": "(tfm == 'net7.0')",
-            "value": "7.0.0"
-          },
-          {
             "condition": "(tfm == 'net8.0')",
             "value": "8.0.0"
           }
@@ -1846,10 +1818,6 @@
         "evaluator": "C++",
         "datatype": "string",
         "cases": [
-          {
-            "condition": "(tfm == 'net7.0')",
-            "value": "7.0.5"
-          },
           {
             "condition": "(tfm == 'net8.0')",
             "value": "8.0.0"

--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -3,9 +3,10 @@
     <!--#if (useMvvm)-->
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.1" />
     <!--#endif-->
-    <!--#if (useMauiPackageReference)-->
+    <!--#if (mauiEmbedding)-->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+    <PackageVersion Include="Microsoft.Maui.Graphics" Version="$(MauiVersion)" />
     <!--#endif-->
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
     <!--#if (useTestSolutionFolder)-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/MyExtensionsApp.1.MauiControls.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/MyExtensionsApp.1.MauiControls.csproj
@@ -52,7 +52,7 @@
     <!--#endif-->
   </Choose>
   <!--#endif-->
-  <!--#if (useMauiPackageReference)-->
+  <!--#if (mauiEmbedding)-->
 
   <ItemGroup>
     <!--#if (useCPM)-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Mobile/MyExtensionsApp.1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Mobile/MyExtensionsApp.1.Mobile.csproj
@@ -105,7 +105,7 @@
     <PackageReference Include="Uno.Extensions.Logging.OSLog" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
     <PackageReference Include="Uno.WinUI.DevServer" Condition="'$(Configuration)'=='Debug'" />
-    <!--#if (useMauiPackageReference)-->
+    <!--#if (mauiEmbedding)-->
     <PackageReference Include="Microsoft.Maui.Controls" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
     <!--#endif -->
@@ -190,7 +190,7 @@
     <PackageReference Include="Uno.Extensions.Logging.OSLog" Version="$UnoExtensionsLoggingVersion$" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
     <PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
-    <!--#if (useMauiPackageReference)-->
+    <!--#if (mauiEmbedding)-->
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
     <!--#endif -->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Windows/MyExtensionsApp.1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Windows/MyExtensionsApp.1.Windows.csproj
@@ -112,7 +112,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Uno.Core.Extensions.Logging.Singleton" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
-    <!--#if (useMauiPackageReference)-->
+    <!--#if (mauiEmbedding)-->
     <PackageReference Include="Microsoft.Maui.Controls" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
     <!--#endif -->
@@ -203,7 +203,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
     <PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="$UnoCoreExtensionsLoggingVersion$" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
-    <!--#if (useMauiPackageReference)-->
+    <!--#if (mauiEmbedding)-->
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
     <!--#endif -->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -112,13 +112,10 @@
     <!--#endif-->
     <!--#endif-->
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
-    <!--#if (useMauiPackageReference)-->
+    <!--#if (mauiEmbedding)-->
     <PackageReference Include="Microsoft.Maui.Controls" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
-    <!--#else -->
-    <!--#if (mauiEmbedding)-->
-    <PackageReference Include="Microsoft.Maui.Graphics" VersionOverride="$(MauiVersion)" />
-    <!--#endif-->
+    <PackageReference Include="Microsoft.Maui.Graphics" />
     <!--#endif -->
     <!--#if (enableDeveloperMode)-->
     $$EnableDeveloperMode_CPM_PackageReference$$
@@ -220,7 +217,7 @@
     <!--#endif-->
     <!--#endif-->
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
-    <!--#if (useMauiPackageReference)-->
+    <!--#if (mauiEmbedding)-->
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
     <!--#else -->

--- a/src/Uno.Templates/content/unomauilib/.template.config/template.json
+++ b/src/Uno.Templates/content/unomauilib/.template.config/template.json
@@ -31,18 +31,13 @@
       "datatype": "choice",
       "enableQuotelessLiterals": true,
       "replaces": "$baseTargetFramework$",
-      "defaultValue": "net7.0",
+      "defaultValue": "net8.0",
       "description": "Select the .NET version of your solution",
       "choices": [
         {
-          "choice": "net7.0",
-          "displayName": ".NET 7.0",
-          "description": "Target .NET 7.0 (Standard Term Support)"
-        },
-        {
           "choice": "net8.0",
           "displayName": ".NET 8.0",
-          "description": "Target .NET 8.0 (Preview)"
+          "description": "Target .NET 8.0 (Long Term Support)"
         }
       ]
     },
@@ -155,11 +150,6 @@
           }
         ]
       }
-    },
-    "useMauiPackageReference": {
-      "type": "computed",
-      "datatype": "bool",
-      "value": "(tfm != 'net7.0')"
     }
   }
 }

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -3,7 +3,7 @@ param(
     [string]$TemplatesVersion = "255.255.255.255",
 
     # Version of published Uno.Extensions packages
-    [string]$ExtensionsVersion = "3.0.11",
+    [string]$ExtensionsVersion = "4.0.0-dev.212",
 
     # Version of published Uno.WinUI packages
     [string]$UnoVersion = "5.1.0-dev.768"


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Template provides an option for both .NET 7.0 and .NET 8.0

## What is the new behavior?

Template is dropping support for .NET 7.0 in favor of having the minimum target be the latest LTS version (.NET 8.0). Will add .NET 9.0 when a preview is available.

