### PR TITLE
Use Uno.Sdk

### DIFF
--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -19,7 +19,7 @@
 	<PropertyGroup>
 		<!-- If you update Extensions or Uno version, make sure you update the versions in the reinstall.ps1 file too !-->
 		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">4.0.0-dev.212</UnoExtensionsVersion>
-		<UnoVersion Condition="'$(UnoVersion)' == ''">5.1.0-dev.1459</UnoVersion>
+		<UnoVersion Condition="'$(UnoVersion)' == ''">5.2.0-dev.24</UnoVersion>
 		
 		<UnoExtensionsLoggingVersion Condition="'$(UnoExtensionsLoggingVersion)' == ''">1.7.0</UnoExtensionsLoggingVersion>
 		<SkiaSharpVersion Condition="'$(SkiaSharpVersion)' == ''">2.88.6</SkiaSharpVersion>

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -19,7 +19,7 @@
 	<PropertyGroup>
 		<!-- If you update Extensions or Uno version, make sure you update the versions in the reinstall.ps1 file too !-->
 		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">4.0.0-dev.212</UnoExtensionsVersion>
-		<UnoVersion Condition="'$(UnoVersion)' == ''">5.1.0-dev.1406</UnoVersion>
+		<UnoVersion Condition="'$(UnoVersion)' == ''">5.1.0-dev.1459</UnoVersion>
 		
 		<UnoExtensionsLoggingVersion Condition="'$(UnoExtensionsLoggingVersion)' == ''">1.7.0</UnoExtensionsLoggingVersion>
 		<SkiaSharpVersion Condition="'$(SkiaSharpVersion)' == ''">2.88.6</SkiaSharpVersion>

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
@@ -19,7 +19,7 @@
 	<PropertyGroup>
 		<!-- If you update Extensions or Uno version, make sure you update the versions in the reinstall.ps1 file too !-->
 		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">4.0.0-dev.212</UnoExtensionsVersion>
-		<UnoVersion Condition="'$(UnoVersion)' == ''">5.1.0-dev.768</UnoVersion>
+		<UnoVersion Condition="'$(UnoVersion)' == ''">5.1.0-dev.1406</UnoVersion>
 		
 		<UnoExtensionsLoggingVersion Condition="'$(UnoExtensionsLoggingVersion)' == ''">1.7.0</UnoExtensionsLoggingVersion>
 		<SkiaSharpVersion Condition="'$(SkiaSharpVersion)' == ''">2.88.6</SkiaSharpVersion>

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -19,7 +19,7 @@
 	<PropertyGroup>
 		<!-- If you update Extensions or Uno version, make sure you update the versions in the reinstall.ps1 file too !-->
 		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">4.0.0-dev.212</UnoExtensionsVersion>
-		<UnoVersion Condition="'$(UnoVersion)' == ''">5.2.0-dev.24</UnoVersion>
+		<UnoVersion Condition="'$(UnoVersion)' == ''">5.1.19</UnoVersion>
 		
 		<UnoExtensionsLoggingVersion Condition="'$(UnoExtensionsLoggingVersion)' == ''">1.7.0</UnoExtensionsLoggingVersion>
 		<SkiaSharpVersion Condition="'$(SkiaSharpVersion)' == ''">2.88.6</SkiaSharpVersion>

--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -41,34 +41,6 @@
     <IncludeSourceRevisionInInformationalVersion Condition="'$(Configuration)'=='Debug'">false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
-  <Choose>
-    <!--
-      Defaults are provided by the Uno.Sdk. In the event you need to override the default minimum supported OS
-      Version, uncomment the appropriate platform and set the value to the desired minimum version.
-    -->
-    <!-- <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
-      <PropertyGroup>
-        <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
-      </PropertyGroup>
-    </When> -->
-    <!-- <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-      <PropertyGroup>
-        <SupportedOSPlatformVersion>14.2</SupportedOSPlatformVersion>
-      </PropertyGroup>
-    </When> -->
-    <!-- <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-      <PropertyGroup>
-        <SupportedOSPlatformVersion>14.0</SupportedOSPlatformVersion>
-      </PropertyGroup>
-    </When> -->
-    <!-- <When Condition="$(TargetFramework.Contains('windows10'))">
-      <PropertyGroup>
-        <SupportedOSPlatformVersion>10.0.18362.0</SupportedOSPlatformVersion>
-        <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
-      </PropertyGroup>
-    </When> -->
-  </Choose>
-
   <!--
     If working on a single target framework, copy solution-config.props.sample to solution-config.props
     and uncomment the appropriate lines in solution-config.props to build for the desired platforms only.

--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -43,8 +43,8 @@
 
   <Choose>
     <!--
-      Defaults are provided by the Uno.Sdk. Uncomment these and provide the SupportedOSPlatformVersion if you need to customize
-      the supported OS version for a specific platform for your application.
+      Defaults are provided by the Uno.Sdk. In the event you need to override the default minimum supported OS
+      Version, uncomment the appropriate platform and set the value to the desired minimum version.
     -->
     <!-- <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
       <PropertyGroup>
@@ -61,18 +61,12 @@
         <SupportedOSPlatformVersion>14.0</SupportedOSPlatformVersion>
       </PropertyGroup>
     </When> -->
-    <When Condition="$(TargetFramework.Contains('windows10'))">
+    <!-- <When Condition="$(TargetFramework.Contains('windows10'))">
       <PropertyGroup>
-        <!--
-          Defaults are provided by the Uno.Sdk. Uncomment these and provide the SupportedOSPlatformVersion and/or the
-          TargetPlatformMinVersion if you need to customize the supported OS version for your application.
-        -->
-        <!-- <SupportedOSPlatformVersion>10.0.18362.0</SupportedOSPlatformVersion> -->
-        <!-- <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion> -->
-        <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-        <EnableCoreMrtTooling Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">false</EnableCoreMrtTooling>
+        <SupportedOSPlatformVersion>10.0.18362.0</SupportedOSPlatformVersion>
+        <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
       </PropertyGroup>
-    </When>
+    </When> -->
   </Choose>
 
   <!--

--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <DotNetVersion>$baseTargetFramework$</DotNetVersion>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -29,14 +29,6 @@
     -->
     <NoWarn>$(NoWarn);NU1507;NETSDK1201;PRI257</NoWarn>
     <!--#endif-->
-
-    <DefaultLanguage>en</DefaultLanguage>
-
-    <IsAndroid>false</IsAndroid>
-    <IsIOS>false</IsIOS>
-    <IsMac>false</IsMac>
-    <IsMacCatalyst>false</IsMacCatalyst>
-    <IsWinAppSdk>false</IsWinAppSdk>
     <!--#if (mauiEmbedding)-->
 
     <MauiVersion Condition=" '$(MauiVersion)' == '' ">$DefaultMauiVersion$</MauiVersion>
@@ -50,46 +42,33 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+    <!--
+      Defaults are provided by the Uno.Sdk. Uncomment these and provide the SupportedOSPlatformVersion if you need to customize
+      the supported OS version for a specific platform for your application.
+    -->
+    <!-- <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
       <PropertyGroup>
-        <IsAndroid>true</IsAndroid>
         <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
       </PropertyGroup>
-    </When>
-    <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+    </When> -->
+    <!-- <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
       <PropertyGroup>
-        <IsIOS>true</IsIOS>
         <SupportedOSPlatformVersion>14.2</SupportedOSPlatformVersion>
       </PropertyGroup>
-
-      <!--
-      Eagerly define capabilities for iOS to avoid VS 2022 to ask for
-      project reload, and ninitialize the debugger toolbar faster.
-      See https://github.com/unoplatform/uno/issues/14303.
-      -->
-      <ItemGroup>
-        <ProjectCapability Include="XamarinStaticLaunchProfiles" />
-        <ProjectCapability Include="Maui" />
-        <ProjectCapability Include="MauiCore" />
-      </ItemGroup>
-    </When>
-    <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'">
+    </When> -->
+    <!-- <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
       <PropertyGroup>
-        <IsMac>true</IsMac>
-        <SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
-      </PropertyGroup>
-    </When>
-    <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-      <PropertyGroup>
-        <IsMacCatalyst>true</IsMacCatalyst>
         <SupportedOSPlatformVersion>14.0</SupportedOSPlatformVersion>
       </PropertyGroup>
-    </When>
+    </When> -->
     <When Condition="$(TargetFramework.Contains('windows10'))">
       <PropertyGroup>
-        <IsWinAppSdk>true</IsWinAppSdk>
-        <SupportedOSPlatformVersion>10.0.18362.0</SupportedOSPlatformVersion>
-        <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
+        <!--
+          Defaults are provided by the Uno.Sdk. Uncomment these and provide the SupportedOSPlatformVersion and/or the
+          TargetPlatformMinVersion if you need to customize the supported OS version for your application.
+        -->
+        <!-- <SupportedOSPlatformVersion>10.0.18362.0</SupportedOSPlatformVersion> -->
+        <!-- <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion> -->
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
         <EnableCoreMrtTooling Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">false</EnableCoreMrtTooling>
       </PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -3,9 +3,6 @@
     <DotNetVersion>$baseTargetFramework$</DotNetVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
-    <DebugType>portable</DebugType>
-    <DebugSymbols>True</DebugSymbols>
     <!--#if (cpm)-->
 
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
@@ -40,12 +37,4 @@
     <!-- Required for Hot Reload (See https://github.com/dotnet/sdk/issues/36666) -->
     <IncludeSourceRevisionInInformationalVersion Condition="'$(Configuration)'=='Debug'">false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
-
-  <!--
-    If working on a single target framework, copy solution-config.props.sample to solution-config.props
-    and uncomment the appropriate lines in solution-config.props to build for the desired platforms only.
-
-    https://platform.uno/docs/articles/guides/solution-building-single-targetframework.html
-  -->
-  <Import Project="solution-config.props" Condition="exists('solution-config.props')" />
 </Project>

--- a/src/Uno.Templates/content/unoapp/Directory.Build.targets
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.targets
@@ -1,6 +1,3 @@
 ﻿<Project>
-  <ItemGroup>
-    <!-- Removes native usings to avoid Ambiguous reference -->
-    <Using Remove="@(Using->HasMetadata('Platform'))" />
-  </ItemGroup>
+
 </Project>

--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -118,15 +118,15 @@
     <!--#endif-->
     <!--#endif-->
     <PackageVersion Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(UnoVersion)" />
     <PackageVersion Include="Uno.UniversalImageLoader" Version="$UnoUniversalImageLoaderVersion$" />
     <!--#if (useWasm)-->
     <PackageVersion Include="Uno.Wasm.Bootstrap" Version="$UnoWasmBootstrapVersion$" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="$UnoWasmBootstrapVersion$" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.Server" Version="$UnoWasmBootstrapVersion$" />
     <!--#endif-->
-    <PackageVersion Include="Uno.WinUI" Version="$UnoWinUIVersion$" />
-    <PackageVersion Include="Uno.WinUI.Lottie" Version="$UnoWinUIVersion$" />
+    <PackageVersion Include="Uno.WinUI" Version="$(UnoVersion)" />
+    <PackageVersion Include="Uno.WinUI.Lottie" Version="$(UnoVersion)" />
     <!--#if (useCsharpMarkup)-->
     <PackageVersion Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
     <PackageVersion Include="Uno.Extensions.Markup.Generators" Version="$UnoMarkupVersion$" />
@@ -144,18 +144,18 @@
     <!--#endif-->
     <PackageVersion Include="Uno.Themes.WinUI.Markup" Version="$UnoThemesVersion$" />
     <!--#endif-->
-    <PackageVersion Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" />
+    <PackageVersion Include="Uno.WinUI.DevServer" Version="$(UnoVersion)" />
     <!--#if (useGtk)-->
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="$UnoWinUIVersion$" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="$(UnoVersion)" />
     <!--#endif-->
     <!--#if (useLinuxFb)-->
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="$UnoWinUIVersion$" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="$(UnoVersion)" />
     <!--#endif-->
     <!--#if (useWpf)-->
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="$UnoWinUIVersion$" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="$(UnoVersion)" />
     <!--#endif-->
     <!--#if (useWasm)-->
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="$UnoWinUIVersion$" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="$(UnoVersion)" />
     <!--#endif-->
     <!--#if (useAndroidMaterial)-->
     <PackageVersion Include="Xamarin.Google.Android.Material" Version="$XamarinGoogleAndroidMaterial$" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Mobile/MyExtensionsApp.1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Mobile/MyExtensionsApp.1.Mobile.csproj
@@ -196,7 +196,7 @@
   <!--#endif-->
   <Choose>
     <!--#if (useAndroid)-->
-    <When Condition="$(IsAndroid)">
+    <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
       <ItemGroup>
         <!--#if (mauiEmbedding)-->
         <PackageReference Include="Xamarin.Google.Android.Material" VersionOverride="$(AndroidMaterialVersion)" />
@@ -223,7 +223,7 @@
     </When>
     <!--#endif-->
     <!--#if (useIOS)-->
-    <When Condition="$(IsIOS)">
+    <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
       <PropertyGroup>
         <MtouchExtraArgs>$(MtouchExtraArgs) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
         <!-- See https://github.com/unoplatform/uno/issues/9430 for more details. -->
@@ -237,7 +237,7 @@
     </When>
     <!--#endif-->
     <!--#if (useMacCatalyst)-->
-    <When Condition="$(IsMacCatalyst)">
+    <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
       <PropertyGroup>
         <!-- Configure the GC -->
         <MtouchExtraArgs>$(MtouchExtraArgs) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
@@ -254,7 +254,7 @@
     </When>
     <!--#endif-->
     <!--#if (useMacOS)-->
-    <When Condition="$(IsMac)">
+    <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'">
       <PropertyGroup>
         <TrimMode Condition="'$(Configuration)'=='Release'">link</TrimMode>
         <RuntimeIdentifier Condition="'$(RuntimeIdentifier)'==''">osx-x64</RuntimeIdentifier>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Mobile/MyExtensionsApp.1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Mobile/MyExtensionsApp.1.Mobile.csproj
@@ -17,8 +17,6 @@
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>
 
-    <AndroidManifest>Android\AndroidManifest.xml</AndroidManifest>
-
     <!-- Debugger workaround https://github.com/dotnet/maui-samples/blob/8aa6b8780b12e97b157514c3bdc54bb4a13001cd/HelloMacCatalyst/HelloMacCatalyst.csproj#L7 -->
     <!-- <MtouchExtraArgs Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">$(MtouchExtraArgs) -setenv:MONO_THREADS_SUSPEND=preemptive</MtouchExtraArgs> -->
     <!-- Required for C# Hot Reload -->
@@ -221,9 +219,6 @@
         <!--#endif-->
         <PackageReference Include="Uno.UniversalImageLoader" Version="$UnoUniversalImageLoaderVersion$" />
         <!--#endif-->
-      </ItemGroup>
-      <ItemGroup>
-        <AndroidEnvironment Include="Android/environment.conf" />
       </ItemGroup>
     </When>
     <!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Mobile/MyExtensionsApp.1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Mobile/MyExtensionsApp.1.Mobile.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$mobileTargetFrameworks$</TargetFrameworks>
     <!--#if (useMacOS)-->
@@ -113,7 +113,7 @@
   <!--#else-->
   <ItemGroup>
     <PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
-    <PackageReference Include="Uno.WinUI" Version="$UnoWinUIVersion$" />
+    <PackageReference Include="Uno.WinUI" Version="$(UnoVersion)" />
     <!--#if (useCsharpMarkup)-->
     <PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
     <!--#if (useMaterial)-->
@@ -188,8 +188,8 @@
     <!--#endif-->
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
     <PackageReference Include="Uno.Extensions.Logging.OSLog" Version="$UnoExtensionsLoggingVersion$" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
-    <PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(UnoVersion)" />
+    <PackageReference Include="Uno.WinUI.DevServer" Version="$(UnoVersion)" Condition="'$(Configuration)'=='Debug'" />
     <!--#if (mauiEmbedding)-->
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Shared/MyExtensionsApp.1.Shared.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Shared/MyExtensionsApp.1.Shared.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <!-- NOTE: The TargetFramework is required by MSBuild but not used as this project is not built. -->
     <TargetFramework>$(DotNetVersion)</TargetFramework>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.Gtk/MyExtensionsApp.1.Skia.Gtk.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.Gtk/MyExtensionsApp.1.Skia.Gtk.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
@@ -94,7 +94,7 @@
   <!--#else-->
   <ItemGroup>
     <PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
-    <PackageReference Include="Uno.WinUI.Skia.Gtk" Version="$UnoWinUIVersion$" />
+    <PackageReference Include="Uno.WinUI.Skia.Gtk" Version="$(UnoVersion)" />
     <!--#if (useCsharpMarkup)-->
     <PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
     <!--#if (useMaterial)-->
@@ -170,8 +170,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="$SkiaSharpVersion$" />
     <PackageReference Include="SkiaSharp.Skottie" Version="$SkiaSharpVersion$" />
-    <PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
+    <PackageReference Include="Uno.WinUI.DevServer" Version="$(UnoVersion)" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(UnoVersion)" />
   </ItemGroup>
   <!--#endif-->
   <ItemGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.Linux.FrameBuffer/MyExtensionsApp.1.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.Linux.FrameBuffer/MyExtensionsApp.1.Skia.Linux.FrameBuffer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
@@ -92,7 +92,7 @@
   <!--#else-->
   <ItemGroup>
     <PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
-    <PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="$UnoWinUIVersion$" />
+    <PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="$(UnoVersion)" />
     <!--#if (useCsharpMarkup)-->
     <PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
     <!--#if (useMaterial)-->
@@ -168,8 +168,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="$SkiaSharpVersion$" />
     <PackageReference Include="SkiaSharp.Skottie" Version="$SkiaSharpVersion$" />
-    <PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
+    <PackageReference Include="Uno.WinUI.DevServer" Version="$(UnoVersion)" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(UnoVersion)" />
   </ItemGroup>
   <!--#endif-->
   <ItemGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.WPF/MyExtensionsApp.1.Skia.WPF.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.WPF/MyExtensionsApp.1.Skia.WPF.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
@@ -106,7 +106,7 @@
   <!--#else-->
   <ItemGroup>
     <PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
-    <PackageReference Include="Uno.WinUI.Skia.Wpf" Version="$UnoWinUIVersion$" />
+    <PackageReference Include="Uno.WinUI.Skia.Wpf" Version="$(UnoVersion)" />
     <!--#if (useCsharpMarkup)-->
     <PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
     <!--#if (useMaterial)-->
@@ -182,8 +182,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
     <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="$SkiaSharpVersion$" />
     <PackageReference Include="SkiaSharp.Skottie" Version="$SkiaSharpVersion$" />
-    <PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
+    <PackageReference Include="Uno.WinUI.DevServer" Version="$(UnoVersion)" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(UnoVersion)" />
   </ItemGroup>
   <!--#endif-->
   <ItemGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
@@ -1,5 +1,5 @@
-<Project Sdk="Uno.Sdk">
-  <Sdk Name="Microsoft.NET.Sdk.Web" />
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <Sdk Name="Uno.Sdk" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
@@ -1,4 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Uno.Sdk">
+  <Sdk Name="Microsoft.NET.Sdk.Web" />
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
@@ -152,9 +154,9 @@
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="$MsftWindowsCompatibilityVersion$" />
     <PackageReference Include="Uno.Wasm.Bootstrap" Version="$UnoWasmBootstrapVersion$" />
     <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="$UnoWasmBootstrapVersion$" />
-    <PackageReference Include="Uno.WinUI.WebAssembly" Version="$UnoWinUIVersion$" />
-    <PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
+    <PackageReference Include="Uno.WinUI.WebAssembly" Version="$(UnoVersion)" />
+    <PackageReference Include="Uno.WinUI.DevServer" Version="$(UnoVersion)" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(UnoVersion)" />
     <!--#if (useCsharpMarkup)-->
     <PackageReference Include="Uno.WinUI.Markup" Version="$UnoMarkupVersion$" />
     <!--#if (useMaterial)-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Windows/MyExtensionsApp.1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Windows/MyExtensionsApp.1.Windows.csproj
@@ -3,6 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>$(DotNetVersion)-windows10.0.19041.0</TargetFramework>
     <RootNamespace>MyExtensionsApp.1.Windows</RootNamespace>
+    <Platforms>x86;x64;arm64</Platforms>
 
 
     <!--#if (useWinAppSdkSelfContained)-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Windows/MyExtensionsApp.1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Windows/MyExtensionsApp.1.Windows.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>$(DotNetVersion)-windows10.0.19041.0</TargetFramework>
@@ -120,7 +120,7 @@
   <!--#else-->
   <ItemGroup>
     <PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
-    <PackageReference Include="Uno.WinUI" Version="$UnoWinUIVersion$" />
+    <PackageReference Include="Uno.WinUI" Version="$(UnoVersion)" />
     <!--#if (!mauiEmbedding)-->
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$MicrosoftWindowsAppSDK$" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$MicrosoftWindowsSDKBuildTools$" />
@@ -202,7 +202,7 @@
     <!--#endif-->
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
     <PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="$UnoCoreExtensionsLoggingVersion$" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(UnoVersion)" />
     <!--#if (mauiEmbedding)-->
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Windows/MyExtensionsApp.1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Windows/MyExtensionsApp.1.Windows.csproj
@@ -3,13 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>$(DotNetVersion)-windows10.0.19041.0</TargetFramework>
     <RootNamespace>MyExtensionsApp.1.Windows</RootNamespace>
-    <ApplicationManifest>app.manifest</ApplicationManifest>
-    <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
-    <UseWinUI>true</UseWinUI>
-    <EnableMsixTooling>true</EnableMsixTooling>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+
 
     <!--#if (useWinAppSdkSelfContained)-->
     <!-- Bundles the WinAppSDK binaries -->
@@ -21,11 +15,6 @@
 
     <!-- <SelfContained>true</SelfContained> -->
   </PropertyGroup>
-
-  <ItemGroup>
-    <Content Include="Images\**" />
-    <Manifest Include="$(ApplicationManifest)" />
-  </ItemGroup>
 
   <!--#if (useCPM)-->
   <ItemGroup>
@@ -231,24 +220,6 @@
     <ProjectReference Include="..\MyExtensionsApp.1.DataContracts\MyExtensionsApp.1.DataContracts.csproj" />
     <!--#endif-->
   </ItemGroup>
-
-  <!--
-    Defining the "Msix" ProjectCapability here allows the Single-project MSIX Packaging
-    Tools extension to be activated for this project even if the Windows App SDK Nuget
-    package has not yet been restored.
-  -->
-  <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
-    <ProjectCapability Include="Msix"/>
-  </ItemGroup>
-
-  <!--
-    Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution
-    Explorer "Package and Publish" context menu entry to be enabled for this project even if
-    the Windows App SDK Nuget package has not yet been restored.
-  -->
-  <PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
-    <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
-  </PropertyGroup>
 
   <Import Project="..\MyExtensionsApp.1.Shared\base.props" />
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.sln
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.sln
@@ -71,6 +71,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		solution-config.props.sample = solution-config.props.sample
+		global.json = global.json
 #//#if (cpm)
 		Directory.Packages.props = Directory.Packages.props
 #//#endif

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <!--#if (useWinAppSdk) -->
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
@@ -123,10 +123,10 @@
   </ItemGroup>
   <!--#else-->
   <ItemGroup>
-    <PackageReference Include="Uno.WinUI" Version="$UnoWinUIVersion$" />
+    <PackageReference Include="Uno.WinUI" Version="$(UnoVersion)" />
     <!--#if (!useWinAppSdk) -->
-    <PackageReference Include="Uno.WinUI.Lottie" Version="$UnoWinUIVersion$" />
-    <PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.WinUI.Lottie" Version="$(UnoVersion)" />
+    <PackageReference Include="Uno.WinUI.DevServer" Version="$(UnoVersion)" Condition="'$(Configuration)'=='Debug'" />
     <!--#endif-->
     <PackageReference Include="Uno.Resizetizer" Version="$UnoResizetizerVersion$" />
     <!--#if (useCsharpMarkup)-->
@@ -280,8 +280,8 @@
         <PackageReference Include="Uno.WinUI.Lottie" />
         <PackageReference Include="Uno.WinUI.DevServer" Condition="'$(Configuration)'=='Debug'" />
         <!--#else-->
-        <PackageReference Include="Uno.WinUI.Lottie" Version="$UnoWinUIVersion$" />
-        <PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
+        <PackageReference Include="Uno.WinUI.Lottie" Version="$(UnoVersion)" />
+        <PackageReference Include="Uno.WinUI.DevServer" Version="$(UnoVersion)" Condition="'$(Configuration)'=='Debug'" />
         <!--#endif-->
 
         <!-- Include all images by default - matches the __WindowsAppSdkDefaultImageIncludes property in the WindowsAppSDK -->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -264,7 +264,6 @@
     <PackageReference Include="Xamarin.AndroidX.Collection.Ktx" VersionOverride="$(AndroidXCollectionVersion)" />
   </ItemGroup>
   <!--#endif-->
-
   <!--#if (coreProjectHasProjectReferences)-->
 
   <ItemGroup>
@@ -276,6 +275,7 @@
     <!--#endif-->
   </ItemGroup>
   <!--#endif-->
+  <!--#if (useDspGenerator || useConfiguration)-->
 
   <ItemGroup>
     <!--#if (useDspGenerator)-->
@@ -286,4 +286,5 @@
     <EmbeddedResource Include="appsettings.*.json" DependentUpon="appsettings.json" />
     <!--#endif-->
   </ItemGroup>
+  <!--#endif-->
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -14,11 +14,26 @@
 
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
+    <!--#if (useWinAppSdk) -->
+    <!--
+      If you encounter this error message:
+
+        error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll.
+        Please update to a newer .NET SDK in order to reference this assembly.
+
+      This means that the two packages below must be aligned with the "build" version number of
+      the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
+      must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
+    -->
+    <!-- <WindowsSdkPackageVersion>10.0.22621.28</WindowsSdkPackageVersion> -->
+    <!--#endif-->
   </PropertyGroup>
 
   <!--#if (useCPM)-->
   <ItemGroup>
     <PackageReference Include="Uno.WinUI" />
+    <PackageReference Include="Uno.WinUI.Lottie" Condition="!$(IsWinAppSdk)" />
+    <PackageReference Include="Uno.WinUI.DevServer" Condition="'$(Configuration)'=='Debug' AND !$(IsWinAppSdk)" />
     <!--#if (!useWinAppSdk) -->
     <PackageReference Include="Uno.WinUI.Lottie" />
     <PackageReference Include="Uno.WinUI.DevServer" Condition="'$(Configuration)'=='Debug'" />
@@ -116,6 +131,11 @@
     <PackageReference Include="Microsoft.Maui.Controls" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
     <PackageReference Include="Microsoft.Maui.Graphics" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" VersionOverride="$MicrosoftWindowsAppSDK$" Condition="$(IsWinAppSdk)" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" VersionOverride="$MicrosoftWindowsSDKBuildTools$" Condition="$(IsWinAppSdk)" />
+    <!--#else-->
+    <PackageReference Include="Microsoft.WindowsAppSDK" Condition="$(IsWinAppSdk)" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Condition="$(IsWinAppSdk)" />
     <!--#endif -->
     <!--#if (enableDeveloperMode)-->
     $$EnableDeveloperMode_CPM_PackageReference$$
@@ -124,6 +144,8 @@
   <!--#else-->
   <ItemGroup>
     <PackageReference Include="Uno.WinUI" Version="$(UnoVersion)" />
+    <PackageReference Include="Uno.WinUI.Lottie" Version="$(UnoVersion)" />
+    <PackageReference Include="Uno.WinUI.DevServer" Version="$(UnoVersion)" Condition="'$(Configuration)'=='Debug' AND !$(IsWinAppSdk)" />
     <!--#if (!useWinAppSdk) -->
     <PackageReference Include="Uno.WinUI.Lottie" Version="$(UnoVersion)" />
     <PackageReference Include="Uno.WinUI.DevServer" Version="$(UnoVersion)" Condition="'$(Configuration)'=='Debug'" />
@@ -220,11 +242,11 @@
     <!--#if (mauiEmbedding)-->
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-    <!--#else -->
-    <!--#if (mauiEmbedding)-->
     <PackageReference Include="Microsoft.Maui.Graphics" Version="$(MauiVersion)" />
+    <!--#else -->
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$MicrosoftWindowsAppSDK$" Condition="$(IsWinAppSdk)" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$MicrosoftWindowsSDKBuildTools$" Condition="$(IsWinAppSdk)" />
     <!--#endif-->
-    <!--#endif -->
     <!--#if (enableDeveloperMode)-->
     $$EnableDeveloperMode_PackageReference$$
     <!--#endif-->
@@ -243,68 +265,6 @@
   </ItemGroup>
   <!--#endif-->
 
-  <!--#if (useWinAppSdk) -->
-  <Choose>
-    <When Condition="$(IsWinAppSdk)">
-      <PropertyGroup>
-        <!--
-        If you encounter this error message:
-
-          error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll.
-          Please update to a newer .NET SDK in order to reference this assembly.
-
-        This means that the two packages below must be aligned with the "build" version number of
-        the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
-        must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
-        -->
-        <!-- <WindowsSdkPackageVersion>10.0.22621.28</WindowsSdkPackageVersion> -->
-      </PropertyGroup>
-      <ItemGroup>
-      <!--#if (!mauiEmbedding)-->
-        <!--#if (useCPM)-->
-        <PackageReference Include="Microsoft.WindowsAppSDK" />
-        <PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
-        <!--#else-->
-        <PackageReference Include="Microsoft.WindowsAppSDK" Version="$MicrosoftWindowsAppSDK$" />
-        <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$MicrosoftWindowsSDKBuildTools$" />
-        <!--#endif-->
-      <!--#else-->
-        <PackageReference Include="Microsoft.WindowsAppSDK" VersionOverride="$MicrosoftWindowsAppSDK$" />
-        <PackageReference Include="Microsoft.Windows.SDK.BuildTools" VersionOverride="$MicrosoftWindowsSDKBuildTools$" />
-      <!--#endif-->
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <!--#if (useCPM)-->
-        <PackageReference Include="Uno.WinUI.Lottie" />
-        <PackageReference Include="Uno.WinUI.DevServer" Condition="'$(Configuration)'=='Debug'" />
-        <!--#else-->
-        <PackageReference Include="Uno.WinUI.Lottie" Version="$(UnoVersion)" />
-        <PackageReference Include="Uno.WinUI.DevServer" Version="$(UnoVersion)" Condition="'$(Configuration)'=='Debug'" />
-        <!--#endif-->
-
-        <!-- Include all images by default - matches the __WindowsAppSdkDefaultImageIncludes property in the WindowsAppSDK -->
-        <Content Include="Assets\**;**/*.png;**/*.bmp;**/*.jpg;**/*.dds;**/*.tif;**/*.tga;**/*.gif" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);**\*.svg" />
-        <Page Include="**\*.xaml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
-        <Compile Update="**\*.xaml.cs">
-          <DependentUpon>%(Filename)</DependentUpon>
-        </Compile>
-        <PRIResource Include="**\*.resw" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-  <!--#else-->
-  <ItemGroup>
-    <!-- Include all images by default - matches the __WindowsAppSdkDefaultImageIncludes property in the WindowsAppSDK -->
-    <Content Include="Assets\**;**/*.png;**/*.bmp;**/*.jpg;**/*.dds;**/*.tif;**/*.tga;**/*.gif" Exclude="bin\**;obj\**;**\*.svg" />
-    <Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
-    <Compile Update="**\*.xaml.cs">
-      <DependentUpon>%(Filename)</DependentUpon>
-    </Compile>
-    <PRIResource Include="**\*.resw" />
-  </ItemGroup>
-  <!--#endif-->
   <!--#if (coreProjectHasProjectReferences)-->
 
   <ItemGroup>
@@ -321,13 +281,9 @@
     <!--#if (useDspGenerator)-->
     <UnoDspImportColors Include="Styles\*.zip" Generator="$DspGenerator$" />
     <!--#endif-->
-    <UnoImage Include="Assets\**\*.svg" />
     <!--#if (useConfiguration)-->
     <EmbeddedResource Include="appsettings.json" />
     <EmbeddedResource Include="appsettings.*.json" DependentUpon="appsettings.json" />
-    <!--#endif-->
-    <!--#if (useXaml)-->
-    <UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
     <!--#endif-->
   </ItemGroup>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -144,7 +144,7 @@
   <!--#else-->
   <ItemGroup>
     <PackageReference Include="Uno.WinUI" Version="$(UnoVersion)" />
-    <PackageReference Include="Uno.WinUI.Lottie" Version="$(UnoVersion)" />
+    <PackageReference Include="Uno.WinUI.Lottie" Version="$(UnoVersion)" Condition="!$(IsWinAppSdk)" />
     <PackageReference Include="Uno.WinUI.DevServer" Version="$(UnoVersion)" Condition="'$(Configuration)'=='Debug' AND !$(IsWinAppSdk)" />
     <!--#if (!useWinAppSdk) -->
     <PackageReference Include="Uno.WinUI.Lottie" Version="$(UnoVersion)" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -254,7 +254,7 @@
   <!--#endif-->
 
   <!--#if (mauiEmbedding)-->
-  <ItemGroup Condition="$(IsAndroid)">
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
     <PackageReference Include="Xamarin.Google.Android.Material" VersionOverride="$(AndroidMaterialVersion)" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.UI" VersionOverride="$(AndroidXNavigationVersion)" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.Fragment" VersionOverride="$(AndroidXNavigationVersion)" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/ReadMe.md
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/ReadMe.md
@@ -1,0 +1,7 @@
+# Getting Started
+
+Uno 5.1 has introduced a new Uno.Sdk. Among other new features that the Uno.Sdk will begin to light up over the coming months, the Uno.Sdk helps to manage the version of Uno by providing the $(UnoVersion) in MSBuild.
+
+The $(UnoVersion) allows you to easily manage the version of the core Uno packages across your application by simply updating the Uno.Sdk itself. To help better manage this we have added a global.json to your solution that sets the version of the Uno.Sdk to use across your application. You can centrally manage the version of the Uno.Sdk there. At this time the NuGet Manager in Visual Studio does not parse or manage Sdks provided by NuGet. If you would like to see this feature please be sure to provide your feedback [here](https://github.com/NuGet/Home/issues/13127).
+
+Note that the Uno.Sdk is shipped as part of the main Uno repository and is versioned with Uno itself. As a result while it will provide an $(UnoVersion), it cannot and does not currently support versions for Uno.Toolkit.UI, Uno.Extensions, Uno.Themes, Uno.Resizetizer, etc.

--- a/src/Uno.Templates/content/unoapp/global.json
+++ b/src/Uno.Templates/content/unoapp/global.json
@@ -1,0 +1,6 @@
+{
+  "msbuild-sdks": {
+    "Uno.Sdk": "$UnoWinUIVersion$",
+    "Microsoft.Build.NoTargets": "3.7.56"
+  }
+}

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Skia.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Skia.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -8,6 +8,6 @@
     <DefineConstants>$(DefineConstants);WINUI;__SKIA__</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.WinUI" Version="$UnoWinUIVersion$" />
+    <PackageReference Include="Uno.WinUI" Version="$(UnoVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Wasm.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Wasm.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,6 +7,6 @@
     <DefineConstants>$(DefineConstants);WINUI</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.WinUI.Runtime.WebAssembly" Version="$UnoWinUIVersion$" />
+    <PackageReference Include="Uno.WinUI.Runtime.WebAssembly" Version="$(UnoVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);$(DotNetVersion);$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst</TargetFrameworks>
@@ -15,7 +15,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.WinUI" Version="$UnoWinUIVersion$" />
+    <PackageReference Include="Uno.WinUI" Version="$(UnoVersion)" />
   </ItemGroup>
   <Choose>
     <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">

--- a/src/Uno.Templates/content/unolib-crossruntime/global.json
+++ b/src/Uno.Templates/content/unolib-crossruntime/global.json
@@ -1,0 +1,5 @@
+{
+  "msbuild-sdks": {
+    "Uno.Sdk": "$UnoWinUIVersion$"
+  }
+}

--- a/src/Uno.Templates/content/unolib/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unolib/.template.config/dotnetcli.host.json
@@ -1,5 +1,8 @@
 ﻿{
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
+    "unoWinUIVersion": {
+      "isHidden": true
+    }
   }
 }

--- a/src/Uno.Templates/content/unolib/.template.config/template.json
+++ b/src/Uno.Templates/content/unolib/.template.config/template.json
@@ -36,6 +36,12 @@
     "2B1FDFB6-C93C-4CA1-A6AB-528C4B3654B9" // UWP
   ],
   "symbols": {
+    "unoWinUIVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "defaultValue": "DefaultUnoWinUIVersion",
+      "replaces": "$UnoWinUIVersion$"
+    }
   },
   "primaryOutputs": [
     {

--- a/src/Uno.Templates/content/unolib/CrossTargetedLibrary.csproj
+++ b/src/Uno.Templates/content/unolib/CrossTargetedLibrary.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <DotNetVersion Condition=" $(DotNetVersion) == '' ">net8.0</DotNetVersion>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.WinUI" Version="$UnoWinUIVersion$" />
+    <PackageReference Include="Uno.WinUI" Version="$(UnoVersion)" />
   </ItemGroup>
   <Choose>
     <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">

--- a/src/Uno.Templates/content/unolib/global.json
+++ b/src/Uno.Templates/content/unolib/global.json
@@ -1,0 +1,5 @@
+{
+  "msbuild-sdks": {
+    "Uno.Sdk": "$UnoWinUIVersion$"
+  }
+}

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -6,7 +6,7 @@ param(
     [string]$ExtensionsVersion = "4.0.0-dev.212",
 
     # Version of published Uno.WinUI packages
-    [string]$UnoVersion = "5.1.0-dev.768"
+    [string]$UnoVersion = "5.1.0-dev.1406"
 )
 
 function RemoveNuGetPackage {

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -6,7 +6,7 @@ param(
     [string]$ExtensionsVersion = "4.0.0-dev.212",
 
     # Version of published Uno.WinUI packages
-    [string]$UnoVersion = "5.1.0-dev.1406"
+    [string]$UnoVersion = "5.1.0-dev.1459"
 )
 
 function RemoveNuGetPackage {

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -6,7 +6,7 @@ param(
     [string]$ExtensionsVersion = "4.0.0-dev.212",
 
     # Version of published Uno.WinUI packages
-    [string]$UnoVersion = "5.1.0-dev.1459"
+    [string]$UnoVersion = "5.2.0-dev.24"
 )
 
 function RemoveNuGetPackage {

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -6,7 +6,7 @@ param(
     [string]$ExtensionsVersion = "4.0.0-dev.212",
 
     # Version of published Uno.WinUI packages
-    [string]$UnoVersion = "5.2.0-dev.24"
+    [string]$UnoVersion = "5.1.19"
 )
 
 function RemoveNuGetPackage {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #365

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature
- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Projects use the Microsoft.NET.Sdk. The Mobile head lacks the necessary project capabilities which causes Visual Studio on Windows to want to reload the project.

## What is the new behavior?

Projects now use the Uno.Sdk. NuGet packages that ship as part of the Uno repo are now versioned with the $(UnoVersion) from the Uno.Sdk. A global.json has been added to provide an easier way to manage and the version of Uno globally across the solution.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Associated with an issue (GitHub or internal)


