### PR TITLE
fix: Remove unused itemgroup

### DIFF
--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
@@ -37,17 +37,6 @@
     <LinkerDescriptor Include="LinkerConfig.xml" />
   </ItemGroup>
   <ItemGroup>
-    <!--
-		This item group is required by the project template because of the
-		new SDK-Style project, otherwise some files are not added automatically.
-
-		You can safely remove this ItemGroup completely.
-		-->
-    <None Include="Program.cs" />
-    <None Include="LinkerConfig.xml" />
-    <None Include="wwwroot\web.config" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="$UnoExtensionsLoggingVersion$" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
@@ -63,18 +63,6 @@
   <ItemGroup>
     <LinkerDescriptor Include="LinkerConfig.xml" />
   </ItemGroup>
-  <ItemGroup>
-    <!--
-    This item group is required by the project template because of the
-    new SDK-Style project, otherwise some files are not added automatically.
-
-    You can safely remove this ItemGroup completely.
-    -->
-    <None Include="Program.cs" />
-    <None Include="LinkerConfig.xml" />
-    <None Include="wwwroot\web.config" />
-  </ItemGroup>
-
   <!--#if (useCPM)-->
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.Compatibility" />


### PR DESCRIPTION
This group was required when VSIX templates were used, we're using dotnet new templates now.