### PR TITLE
fix: adding intentional break for invalid project name

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -83,6 +83,15 @@
       },
       "replaces": "$sanitizedProjectName$"
     },
+    "failBuildOnInvalidProjectName": {
+      "type": "generated",
+      "generator": "regexMatch",
+      "datatype": "bool",
+      "parameters": {
+        "source": "name",
+        "pattern": "\\s"
+      }
+    },
     "appId": {
       "displayName": "Application ID",
       "type": "parameter",

--- a/src/Uno.Templates/content/unoapp/Directory.Build.targets
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.targets
@@ -1,3 +1,8 @@
 ﻿<Project>
-
+<!--#if (failBuildOnInvalidProjectName)-->
+  <Target Name="InvalidProjectName"
+          BeforeTargets="BeforeBuild">
+    <Error Text="The project name 'MyExtensionsApp.1' is invalid. Your project name may not contain spaces as this will break various .NET Source Generators and MSBuild targets." />
+  </Target>
+<!--#endif-->
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #474

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

From the CLI you are able to create a project with a space in the Project Name

## What is the new behavior?

If you create a project with a space in the project name a target will be added to the Directory.Build.targets. This will create an error to let you know you've created a project with an invalid name and that you should recreate the project without the use of spaces in the name.


