### PR TITLE
Exclude the Mobile project when Mobile is false

### DIFF
--- a/src/Uno.Templates/content/unoapp-uwp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp-uwp/.template.config/template.json
@@ -211,7 +211,7 @@
           ]
         },
         {
-          "condition": "(!mobile)",
+          "condition": "(!Mobile)",
           "exclude": [
             "UnoQuickStart.Mobile/**/*"
           ]


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes #511

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The source modifiers uses the lowercase `mobile` where the symbol used in the template uses the uppercase `Mobile`

## What is the new behavior?

The source modifier uses the correct `Mobile` for the symbol.


