### PR TITLE
Remove unused Logging Condition

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Shared/AppHead.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Shared/AppHead.xaml.cs
@@ -62,8 +62,6 @@ public sealed partial class AppHead : App
             builder.AddProvider(new global::Uno.Extensions.Logging.WebAssembly.WebAssemblyConsoleLoggerProvider());
 #elif __IOS__ || __MACCATALYST__
             builder.AddProvider(new global::Uno.Extensions.Logging.OSLogLoggerProvider());
-#elif NETFX_CORE
-            builder.AddDebug();
 #else
             builder.AddConsole();
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #382

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The template includes an unused condition for NETFX_CORE which came from the legacy template but is not defined. 

## What is the new behavior?

As WinAppSdk already uses the Console Logger there is no reason to switch this to the Debug logger by default. As a result we are simply removing the `NETFX_CORE` condition with the Debug Logger


