### PR TITLE
Fix preset display name for Recommended preset

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -60,7 +60,7 @@
         {
           "choice": "recommended",
           "description": "Recommended set of options to create a production-ready app targeting multiple platforms",
-          "displayName": "Default"
+          "displayName": "Recommended"
         },
         {
           "choice": "blank",


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The Recommended preset uses the display name 'Default' even though the default preset has been changed to blank.

## What is the new behavior?

The Recommended display name now shows 'Recommended'

