### PR TITLE
Use succinct syntax for RowDefinitions

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/Shell.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/Shell.xaml.cs
@@ -18,7 +18,7 @@ public sealed partial class Shell : UserControl, IContentControlProvider
                         .HorizontalContentAlignment(HorizontalAlignment.Stretch)
                         .VerticalContentAlignment(VerticalAlignment.Stretch)
                         .LoadingContentTemplate<object>(_ => new Grid()
-                            .RowDefinitions(new GridLength(2, GridUnitType.Star), new GridLength(1, GridUnitType.Star))
+                            .RowDefinitions("2*,*")
                             .Children(
                                 new ProgressRing()
                                     .Grid(row: 1)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When using C# Markup the Shell uses the RowDefinitions extension that takes the actual GridLength's.

## What is the new behavior?

When using C# Markup the Shell uses the succinct syntax for RowDefinitions