### PR TITLE
Add VS 17.8 workaround

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
@@ -162,6 +162,9 @@
     "enableDeveloperMode": {
       "isHidden": true
     },
+    "visualStudioSdkWorkaround": {
+      "isHidden": true
+    },
     "isVsix": {
       "isHidden": true
     }

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -854,6 +854,11 @@
       "datatype": "bool",
       "defaultValue": "false"
     },
+    "visualStudioSdkWorkaround": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false"
+    },
     "isVsix": {
       "displayName": "isVsix",
       "type": "parameter",
@@ -1930,6 +1935,18 @@
           "exclude": [
             "nuget.config"
           ]
+        },
+        {
+          "condition": "(!visualStudioSdkWorkaround || enableDeveloperMode)",
+          "exclude": [
+            "vs-workaround.config"
+          ]
+        },
+        {
+          "condition": "(visualStudioSdkWorkaround)",
+          "rename": {
+            "vs-workaround.config": "nuget.config"
+          }
         },
         {
           "condition": "(isVsix)",

--- a/src/Uno.Templates/content/unoapp/nuget.config
+++ b/src/Uno.Templates/content/unoapp/nuget.config
@@ -3,6 +3,7 @@
     <packageSources>
         <clear />
         <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+        <add key="uno.dev" value="https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json" />
         <add key="DeveloperMode" value="$$EnableDeveloperMode_NuGet_Feed$$" />
     </packageSources>
 </configuration>

--- a/src/Uno.Templates/content/unoapp/vs-workaround.config
+++ b/src/Uno.Templates/content/unoapp/vs-workaround.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+</configuration>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Workaround

## What is the current behavior?

Visual Studio 17.8 gets upset when creating a project with a custom Sdk unless you have a nuget.config in the project.

## What is the new behavior?

We now have an option for the VSIX to specify an override property to provide the nuget.config when creating a project in 17.8.