### PR TITLE
Cleanup WASM Sdk Loading

### DIFF
--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -19,7 +19,7 @@
 	<PropertyGroup>
 		<!-- If you update Extensions or Uno version, make sure you update the versions in the reinstall.ps1 file too !-->
 		<UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">4.0.0-dev.212</UnoExtensionsVersion>
-		<UnoVersion Condition="'$(UnoVersion)' == ''">5.1.19</UnoVersion>
+		<UnoVersion Condition="'$(UnoVersion)' == ''">5.1.23</UnoVersion>
 		
 		<UnoExtensionsLoggingVersion Condition="'$(UnoExtensionsLoggingVersion)' == ''">1.7.0</UnoExtensionsLoggingVersion>
 		<SkiaSharpVersion Condition="'$(SkiaSharpVersion)' == ''">2.88.6</SkiaSharpVersion>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
@@ -1,5 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
-  <Sdk Name="Uno.Sdk" />
+<Project Sdk="Uno.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Uno.Templates/reinstall.ps1
+++ b/src/Uno.Templates/reinstall.ps1
@@ -6,7 +6,7 @@ param(
     [string]$ExtensionsVersion = "4.0.0-dev.212",
 
     # Version of published Uno.WinUI packages
-    [string]$UnoVersion = "5.1.19"
+    [string]$UnoVersion = "5.1.23"
 )
 
 function RemoveNuGetPackage {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

WASM must explicitly load both Microsoft.NET.Sdk.Web and Uno.Sdk

## What is the new behavior?

WASM now only needs to load the Uno.Sdk

requires: unoplatform/uno#15204