### PR TITLE
Maui Embedding Fix

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -1,7 +1,7 @@
 ﻿<Project ToolsVersion="15.0">
   <ItemGroup>
     <!--#if (useMvvm)-->
-    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <!--#endif-->
     <!--#if (mauiEmbedding)-->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
@@ -32,7 +32,7 @@
     <!--#endif-->
     <!--#endif-->
     <!--#if (useAspNetCoreSerilogPackage)-->
-    <PackageVersion Include="Serilog.AspNetCore" Version="7.0.0" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="8.0.1" />
     <!--#endif-->
     <!--#if (useSkia)-->
     <PackageVersion Include="SkiaSharp.Skottie" Version="$SkiaSharpVersion$" />
@@ -52,7 +52,7 @@
     <PackageVersion Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useMsalAuthentication)-->
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.57.0" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.59.0" />
     <PackageVersion Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Mobile/MyExtensionsApp.1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Mobile/MyExtensionsApp.1.Mobile.csproj
@@ -120,7 +120,7 @@
     <PackageReference Include="Uno.Themes.WinUI.Markup" Version="$UnoThemesVersion$" />
     <!--#endif-->
     <!--#if (useMvvm) -->
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <!--#endif -->
     <!--#if (useConfiguration)-->
     <PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsVersion$" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Server/MyExtensionsApp.1.Server.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Server/MyExtensionsApp.1.Server.csproj
@@ -28,7 +28,7 @@
     <!--#endif -->
     <!--#else-->
     <!--#if (useSerilog)-->
-    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
     <!--#endif-->
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <!--#if (useWasm)-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.Gtk/MyExtensionsApp.1.Skia.Gtk.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.Gtk/MyExtensionsApp.1.Skia.Gtk.csproj
@@ -103,7 +103,7 @@
     <PackageReference Include="Uno.Themes.WinUI.Markup" Version="$UnoThemesVersion$" />
     <!--#endif-->
     <!--#if (useMvvm) -->
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <!--#endif -->
     <!--#if (useConfiguration)-->
     <PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsVersion$" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.Linux.FrameBuffer/MyExtensionsApp.1.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.Linux.FrameBuffer/MyExtensionsApp.1.Skia.Linux.FrameBuffer.csproj
@@ -101,7 +101,7 @@
     <PackageReference Include="Uno.Themes.WinUI.Markup" Version="$UnoThemesVersion$" />
     <!--#endif-->
     <!--#if (useMvvm) -->
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <!--#endif -->
     <!--#if (useConfiguration)-->
     <PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsVersion$" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.WPF/MyExtensionsApp.1.Skia.WPF.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Skia.WPF/MyExtensionsApp.1.Skia.WPF.csproj
@@ -115,7 +115,7 @@
     <PackageReference Include="Uno.Themes.WinUI.Markup" Version="$UnoThemesVersion$" />
     <!--#endif-->
     <!--#if (useMvvm) -->
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <!--#endif -->
     <!--#if (useConfiguration)-->
     <PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsVersion$" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
@@ -164,7 +164,7 @@
     <PackageReference Include="Uno.Themes.WinUI.Markup" Version="$UnoThemesVersion$" />
     <!--#endif-->
     <!--#if (useMvvm) -->
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <!--#endif -->
     <!--#if (useConfiguration)-->
     <PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsVersion$" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Windows/MyExtensionsApp.1.Windows.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Windows/MyExtensionsApp.1.Windows.csproj
@@ -126,7 +126,7 @@
     <PackageReference Include="Uno.Themes.WinUI.Markup" Version="$UnoThemesVersion$" />
     <!--#endif-->
     <!--#if (useMvvm) -->
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <!--#endif -->
     <!--#if (useConfiguration)-->
     <PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsVersion$" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.blank.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.blank.cs
@@ -1,13 +1,7 @@
 //-:cnd:noEmit
 namespace MyExtensionsApp._1;
 
-//+:cnd:noEmit
-#if mauiEmbedding
-public class App : EmbeddingApplication
-#else
 public class App : Application
-#endif
-//-:cnd:noEmit
 {
     protected Window? MainWindow { get; private set; }
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.recommended.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.recommended.cs
@@ -1,13 +1,7 @@
 //-:cnd:noEmit
 namespace MyExtensionsApp._1;
 
-//+:cnd:noEmit
-#if mauiEmbedding
-public class App : EmbeddingApplication
-#else
 public class App : Application
-#endif
-//-:cnd:noEmit
 {
     protected Window? MainWindow { get; private set; }
     protected IHost? Host { get; private set; }

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -163,7 +163,7 @@
     <PackageReference Include="Uno.Themes.WinUI.Markup" Version="$UnoThemesVersion$" />
     <!--#endif-->
     <!--#if (useMvvm) -->
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <!--#endif -->
     <!--#if (useConfiguration)-->
     <PackageReference Include="Uno.Extensions.Configuration" Version="$UnoExtensionsVersion$" />
@@ -213,7 +213,7 @@
     <PackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#if (useMsalAuthentication)-->
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.57.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.59.0" />
     <PackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" Version="$UnoExtensionsVersion$" />
     <!--#endif-->
     <!--#endif-->


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Maui Embedding uses the EmbeddingApplication which is obsolete in the updated version of Uno.Extensions.


## What is the new behavior?

Maui Embedding now just uses the default Application class