### PR TITLE
Align with MAUI behavior no default RuntimeIdentifier

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Mobile/MyExtensionsApp.1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Mobile/MyExtensionsApp.1.Mobile.csproj
@@ -228,7 +228,6 @@
         <MtouchExtraArgs>$(MtouchExtraArgs) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
         <!-- See https://github.com/unoplatform/uno/issues/9430 for more details. -->
         <MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
-        <RuntimeIdentifier Condition="'$(RuntimeIdentifier)'==''">iossimulator-x64</RuntimeIdentifier>
       </PropertyGroup>
       <PropertyGroup Condition="'$(Configuration)'=='Release'">
         <!-- https://github.com/xamarin/xamarin-macios/issues/14812 -->
@@ -245,7 +244,6 @@
         <MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
         <!-- Full globalization is required for Uno -->
         <InvariantGlobalization>false</InvariantGlobalization>
-        <RuntimeIdentifier Condition="'$(RuntimeIdentifier)'==''">maccatalyst-x64</RuntimeIdentifier>
       </PropertyGroup>
       <PropertyGroup Condition="'$(Configuration)'=='Release'">
         <!-- https://github.com/xamarin/xamarin-macios/issues/14812 -->
@@ -257,7 +255,6 @@
     <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'">
       <PropertyGroup>
         <TrimMode Condition="'$(Configuration)'=='Release'">link</TrimMode>
-        <RuntimeIdentifier Condition="'$(RuntimeIdentifier)'==''">osx-x64</RuntimeIdentifier>
       </PropertyGroup>
     </When>
     <!--#endif-->


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes #487

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

A default RuntimeIdentifier is provided for iOS/MacOS/MacCatalyst

## What is the new behavior?

The Mobile head now aligns with the default behavior of a MAUI project by not providing a default.