### PR TITLE
Fixing Cross Runtime template

### DIFF
--- a/build/.azure-pipelines.CrossRuntimeValidation.yml
+++ b/build/.azure-pipelines.CrossRuntimeValidation.yml
@@ -1,0 +1,14 @@
+jobs:
+- job: CrossRuntime_Validation
+
+  pool:
+    vmImage: 'windows-2022'
+
+  variables:
+    - name: UseDotNetNativeToolchain
+      value: false
+
+  steps:
+  - template: templates/template-validation.yml
+    parameters:
+      templateName: 'unolib-crossruntime'

--- a/build/.azure-pipelines.UWPValidation.yml
+++ b/build/.azure-pipelines.UWPValidation.yml
@@ -1,5 +1,5 @@
 jobs:
-- job: UnoMauiLib_Validation
+- job: UnoUI_Validation
 
   pool:
     vmImage: 'windows-2022'

--- a/build/.azure-pipelines.UWPValidation.yml
+++ b/build/.azure-pipelines.UWPValidation.yml
@@ -1,0 +1,14 @@
+jobs:
+- job: UnoMauiLib_Validation
+
+  pool:
+    vmImage: 'windows-2022'
+
+  variables:
+    - name: UseDotNetNativeToolchain
+      value: false
+
+  steps:
+  - template: templates/template-validation.yml
+    parameters:
+      templateName: 'unoapp-uwp'

--- a/build/.azure-pipelines.UnoLibValidation.yml
+++ b/build/.azure-pipelines.UnoLibValidation.yml
@@ -12,4 +12,3 @@ jobs:
   - template: templates/template-validation.yml
     parameters:
       templateName: 'unolib'
-      projectPath: 'UnoTemplateValidation1.csproj'

--- a/build/.azure-pipelines.UnoLibValidation.yml
+++ b/build/.azure-pipelines.UnoLibValidation.yml
@@ -1,0 +1,14 @@
+jobs:
+- job: UnoLib_Validation
+
+  pool:
+    vmImage: 'windows-2022'
+
+  variables:
+    - name: UseDotNetNativeToolchain
+      value: false
+
+  steps:
+  - template: templates/template-validation.yml
+    parameters:
+      templateName: 'unolib'

--- a/build/.azure-pipelines.UnoLibValidation.yml
+++ b/build/.azure-pipelines.UnoLibValidation.yml
@@ -12,3 +12,4 @@ jobs:
   - template: templates/template-validation.yml
     parameters:
       templateName: 'unolib'
+      projectPath: 'UnoTemplateValidation1.csproj'

--- a/build/.azure-pipelines.UnoMauiLibValidation.yml
+++ b/build/.azure-pipelines.UnoMauiLibValidation.yml
@@ -12,4 +12,3 @@ jobs:
   - template: templates/template-validation.yml
     parameters:
       templateName: 'unomauilib'
-      projectPath: 'UnoTemplateValidation1.MauiControls.csproj'

--- a/build/.azure-pipelines.UnoMauiLibValidation.yml
+++ b/build/.azure-pipelines.UnoMauiLibValidation.yml
@@ -1,0 +1,14 @@
+jobs:
+- job: UnoMauiLib_Validation
+
+  pool:
+    vmImage: 'windows-2022'
+
+  variables:
+    - name: UseDotNetNativeToolchain
+      value: false
+
+  steps:
+  - template: templates/template-validation.yml
+    parameters:
+      templateName: 'unomauilib'

--- a/build/.azure-pipelines.UnoMauiLibValidation.yml
+++ b/build/.azure-pipelines.UnoMauiLibValidation.yml
@@ -12,3 +12,4 @@ jobs:
   - template: templates/template-validation.yml
     parameters:
       templateName: 'unomauilib'
+      projectPath: 'UnoTemplateValidation1.MauiControls.csproj'

--- a/build/.azure-pipelines.yml
+++ b/build/.azure-pipelines.yml
@@ -63,7 +63,11 @@ stages:
 - stage: Template_validations
   dependsOn: Build
   jobs:
+  - template: .azure-pipelines.CrossRuntimeValidation.yml
   - template: .azure-pipelines.TemplateValidation.yml
+  - template: .azure-pipelines.UnoLibValidation.yml
+  - template: .azure-pipelines.UnoMauiLibValidation.yml
+  - template: .azure-pipelines.UWPValidation.yml
 
 - stage: Prepare
   condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['IsCanaryBranch'], true)))

--- a/build/templates/template-validation.yml
+++ b/build/templates/template-validation.yml
@@ -5,6 +5,9 @@ parameters:
 - name: arguments
   type: string
   default: ''
+- name: projectPath
+  type: string
+  default: 'UnoTemplateValidation1.sln'
 
 steps:
 - template: dotnet-install-windows.yml
@@ -55,7 +58,7 @@ steps:
 
       cd UnoTemplateValidation1
 
-      & dotnet build UnoTemplateValidation1.sln "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
+      & dotnet build ${{ parameters.projectPath }} "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
       if ($LASTEXITCODE -ne 0)
       {
           throw "Exit code must be zero."

--- a/build/templates/template-validation.yml
+++ b/build/templates/template-validation.yml
@@ -9,7 +9,7 @@ parameters:
 steps:
 - template: dotnet-install-windows.yml
   parameters:
-    DotNetVersion: $(DotNetVersion)
+    DotNetVersion: '8.0.100'
 
 - task: DownloadBuildArtifacts@0
   inputs:

--- a/build/templates/template-validation.yml
+++ b/build/templates/template-validation.yml
@@ -58,11 +58,11 @@ steps:
       if ('${{ parameters.templateName }}' -eq 'unoapp-uwp')
       {
           $msbuild = vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
-          $msbuild /r /bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog
+          & $msbuild /r "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
       }
       else
       {
-          dotnet build "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
+          & dotnet build "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
       }
       
       if ($LASTEXITCODE -ne 0)

--- a/build/templates/template-validation.yml
+++ b/build/templates/template-validation.yml
@@ -55,7 +55,16 @@ steps:
 
       cd UnoTemplateValidation1
 
-      & dotnet build "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
+      if (${{ parameters.templateName }} -eq 'unoapp-uwp')
+      {
+          $msbuild = vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
+          $msbuild "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
+      }
+      else
+      {
+          dotnet build "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
+      }
+      
       if ($LASTEXITCODE -ne 0)
       {
           throw "Exit code must be zero."

--- a/build/templates/template-validation.yml
+++ b/build/templates/template-validation.yml
@@ -1,0 +1,63 @@
+parameters:
+- name: templateName
+  type: string
+  default: ''
+- name: arguments
+  type: string
+  default: ''
+
+steps:
+- template: dotnet-install-windows.yml
+  parameters:
+    DotNetVersion: $(DotNetVersion)
+
+- task: DownloadBuildArtifacts@0
+  inputs:
+    artifactName: $(Build.DefinitionName)
+
+- script: |
+      md $(Build.SourcesDirectory)\src\PackageCache
+      copy "$(System.ArtifactsDirectory)\$(Build.DefinitionName)\*.nupkg" $(Build.SourcesDirectory)\src\PackageCache
+  displayName: Copy Artifacts to PackageCache
+
+- script: dotnet new install "$(System.ArtifactsDirectory)\$(Build.DefinitionName)\Uno.Templates*.nupkg"
+  displayName: Install Project Templates
+
+- powershell: |
+      dotnet nuget add source -n nuget_local $(Build.SourcesDirectory)\src\PackageCache
+      dotnet nuget add source -n uno_dev "https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json"
+      dotnet nuget add source -n net8 "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json"
+      Set-PSDebug -Trace 1
+      $ErrorActionPreference = 'Stop'
+
+      # Create app with defaults
+      dotnet new ${{ parameters.templateName }} -skip -d -v diagnostic -o UnoApp1 ${{ parameters.arguments }}
+      if ($LASTEXITCODE -ne 0)
+      {
+          throw "Exit code must be zero."
+      }
+
+  displayName: Create template app
+
+- template: canary-updater.yml
+  parameters:
+    MergeBranch: false
+
+- powershell: |
+    cd UnoApp1
+    & dotnet workload restore --skip-sign-check
+  displayName: Restore workloads
+
+- powershell: |
+      Set-PSDebug -Trace 1
+      $ErrorActionPreference = 'Stop'
+
+      cd UnoApp1
+
+      & dotnet build UnoApp1.sln "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
+      if ($LASTEXITCODE -ne 0)
+      {
+          throw "Exit code must be zero."
+      }
+
+  displayName: Build template app

--- a/build/templates/template-validation.yml
+++ b/build/templates/template-validation.yml
@@ -46,7 +46,7 @@ steps:
 - powershell: |
     dotnet tool install --global Uno.Check --version 1.20.0-dev.7
     cd UnoTemplateValidation1
-    & uno-check --fix --non-interactive --ci
+    & uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip androidemulator --skip androidsdk --skip vsmac
   displayName: Uno Check
 
 - powershell: |

--- a/build/templates/template-validation.yml
+++ b/build/templates/template-validation.yml
@@ -9,7 +9,7 @@ parameters:
 steps:
 - template: dotnet-install-windows.yml
   parameters:
-    DotNetVersion: '8.0.100'
+    DotNetVersion: '8.0.x'
 
 - task: DownloadBuildArtifacts@0
   inputs:
@@ -44,9 +44,10 @@ steps:
     MergeBranch: false
 
 - powershell: |
+    dotnet tool install --global Uno.Check --version 1.19.0
     cd UnoTemplateValidation1
-    & dotnet workload restore --skip-sign-check
-  displayName: Restore workloads
+    & uno-check --fix --non-interactive --ci
+  displayName: Uno Check
 
 - powershell: |
       Set-PSDebug -Trace 1

--- a/build/templates/template-validation.yml
+++ b/build/templates/template-validation.yml
@@ -55,10 +55,10 @@ steps:
 
       cd UnoTemplateValidation1
 
-      if (${{ parameters.templateName }} -eq 'unoapp-uwp')
+      if ('${{ parameters.templateName }}' -eq 'unoapp-uwp')
       {
           $msbuild = vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
-          $msbuild "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
+          $msbuild /r /bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog
       }
       else
       {

--- a/build/templates/template-validation.yml
+++ b/build/templates/template-validation.yml
@@ -31,7 +31,7 @@ steps:
       $ErrorActionPreference = 'Stop'
 
       # Create app with defaults
-      dotnet new ${{ parameters.templateName }} -skip -d -v diagnostic -o UnoApp1 ${{ parameters.arguments }}
+      dotnet new ${{ parameters.templateName }} -d -v diagnostic -o UnoTemplateValidation1 ${{ parameters.arguments }}
       if ($LASTEXITCODE -ne 0)
       {
           throw "Exit code must be zero."
@@ -44,7 +44,7 @@ steps:
     MergeBranch: false
 
 - powershell: |
-    cd UnoApp1
+    cd UnoTemplateValidation1
     & dotnet workload restore --skip-sign-check
   displayName: Restore workloads
 
@@ -52,9 +52,9 @@ steps:
       Set-PSDebug -Trace 1
       $ErrorActionPreference = 'Stop'
 
-      cd UnoApp1
+      cd UnoTemplateValidation1
 
-      & dotnet build UnoApp1.sln "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
+      & dotnet build UnoTemplateValidation1.sln "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
       if ($LASTEXITCODE -ne 0)
       {
           throw "Exit code must be zero."

--- a/build/templates/template-validation.yml
+++ b/build/templates/template-validation.yml
@@ -5,9 +5,6 @@ parameters:
 - name: arguments
   type: string
   default: ''
-- name: projectPath
-  type: string
-  default: 'UnoTemplateValidation1.sln'
 
 steps:
 - template: dotnet-install-windows.yml
@@ -58,7 +55,7 @@ steps:
 
       cd UnoTemplateValidation1
 
-      & dotnet build ${{ parameters.projectPath }} "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
+      & dotnet build "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
       if ($LASTEXITCODE -ne 0)
       {
           throw "Exit code must be zero."

--- a/build/templates/template-validation.yml
+++ b/build/templates/template-validation.yml
@@ -44,8 +44,9 @@ steps:
     MergeBranch: false
 
 - powershell: |
+    dotnet tool install --global Uno.Check --version 1.20.0
     cd UnoTemplateValidation1
-    dotnet workload restore
+    uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip androidemulator --skip androidsdk --skip vsmac --skip dotnetnewunotemplates
   displayName: Uno Check
 
 - powershell: |

--- a/build/templates/template-validation.yml
+++ b/build/templates/template-validation.yml
@@ -44,7 +44,7 @@ steps:
     MergeBranch: false
 
 - powershell: |
-    dotnet tool install --global Uno.Check --version 1.19.0
+    dotnet tool install --global Uno.Check --version 1.20.0-dev.7
     cd UnoTemplateValidation1
     & uno-check --fix --non-interactive --ci
   displayName: Uno Check

--- a/build/templates/template-validation.yml
+++ b/build/templates/template-validation.yml
@@ -44,9 +44,8 @@ steps:
     MergeBranch: false
 
 - powershell: |
-    dotnet tool install --global Uno.Check --version 1.20.0-dev.7
     cd UnoTemplateValidation1
-    & uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip androidemulator --skip androidsdk --skip vsmac
+    dotnet workload restore
   displayName: Uno Check
 
 - powershell: |

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -90,6 +90,8 @@
 		<Copy SourceFiles="content/unoapp/MyExtensionsApp.1.Windows/Package.appxmanifest" DestinationFiles="$(TemplateContentFolder)/unoapp/MyExtensionsApp.1.Skia.Linux.FrameBuffer/Package.appxmanifest" SkipUnchangedFiles="false" />
 		<Copy SourceFiles="content/unoapp/MyExtensionsApp.1.Windows/Package.appxmanifest" DestinationFiles="$(TemplateContentFolder)/unoapp/MyExtensionsApp.1.Skia.WPF/Package.appxmanifest" SkipUnchangedFiles="false" />
 		<Copy SourceFiles="@(MauiControlsTemplateFile)" DestinationFiles="$(TemplateContentFolder)/unomauilib/%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="false" />
+		<Copy SourceFiles="$(TemplateContentFolder)/unomauilib/MyExtensionsApp.1.MauiControls.csproj" DestinationFiles="$(TemplateContentFolder)/unomauilib/MyExtensionsApp.1.csproj" SkipUnchangedFiles="false" />
+		<Delete Files="$(TemplateContentFolder)/unomauilib/MyExtensionsApp.1.MauiControls.csproj" />
 		<ItemGroup>
 			<_PackageFiles Include="$(TemplateContentFolder)/**/*" PackagePath="content" />
 		</ItemGroup>
@@ -115,7 +117,8 @@
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoWasmBootstrapVersionNet8" ReplacementText="$(UnoWasmBootstrapVersionNet8)"/>
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoMarkupVersion" ReplacementText="$(UnoMarkupVersion)"/>
 		<ReplaceFileText Filename="%(_TemplateJson.Identity)" MatchExpression="DefaultUnoUITestHelpersVersion" ReplacementText="$(UnoUITestHelpersVersion)"/>
-		<ReplaceFileText Filename="%(_MauiLibTemplateFile.Identity)" MatchExpression="MyExtensionsApp\._1\.MauiControls" ReplacementText="MyExtensionsApp.1" />
+		<ReplaceFileText Filename="%(_MauiLibTemplateFile.Identity)" MatchExpression="MyExtensionsApp._1.MauiControls" ReplacementText="MyExtensionsApp._1" />
+		<ReplaceFileText Filename="%(_MauiLibTemplateFile.Identity)" MatchExpression="MyExtensionsApp.1.MauiControls" ReplacementText="MyExtensionsApp.1" />
 		<ReplaceFileText Filename="%(_PackageReferenceFile.Identity)" MatchExpression="$MicrosoftTestSdk$" ReplacementText="$(MicrosoftTestSdkVersion)" />
 		<ReplaceFileText Filename="%(_PackageReferenceFile.Identity)" MatchExpression="$NUnit$" ReplacementText="$(NUnitVersion)" />
 		<ReplaceFileText Filename="%(_PackageReferenceFile.Identity)" MatchExpression="$NUnit3TestAdapter$" ReplacementText="$(NUnit3TestAdapterVersion)" />

--- a/src/Uno.Templates/content/unoapp-uwp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp-uwp/.template.config/template.json
@@ -155,6 +155,21 @@
       "datatype": "text",
       "defaultValue": "8.0.0",
       "replaces": "$MsftExtensionsLoggingConsoleVersion$"
+    },
+    "unoWasmBootstrapVersionDefault": {
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "$WasmBootstrapServer$",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "('true' == 'true')",
+            "value": "DefaultUnoWasmBootstrapVersionNet8"
+          }
+        ]
+      }
     }
   },
   "primaryOutputs": [

--- a/src/Uno.Templates/content/unoapp-uwp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp-uwp/Directory.Build.props
@@ -2,18 +2,10 @@
   <PropertyGroup>
     <DotNetVersion>net8.0</DotNetVersion>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
 
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'">10.14</SupportedOSPlatformVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(RuntimeIdentifier)'==''">
-    <!-- Default values for command line builds -->
-    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">iossimulator-x64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">maccatalyst-x64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'">osx-x64</RuntimeIdentifier>
   </PropertyGroup>
 </Project>

--- a/src/Uno.Templates/content/unoapp-uwp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp-uwp/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
     <DotNetVersion>net8.0</DotNetVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
 
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Shared/App.xaml.cs
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Shared/App.xaml.cs
@@ -6,6 +6,7 @@ using Windows.ApplicationModel.Activation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
+using Application = Windows.UI.Xaml.Application;
 
 namespace UnoQuickStart
 {

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.UWP/UnoQuickStart.Uwp.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.UWP/UnoQuickStart.Uwp.csproj
@@ -4,11 +4,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <!--
-			If, in the same solution, you are referencing a project that uses https://github.com/onovotny/MSBuildSdkExtras,
-			you need to make sure that the version provided here matches https://github.com/novotnyllc/MSBuildSdkExtras/blob/main/Source/MSBuild.Sdk.Extras/DefaultItems/ImplicitPackages.targets#L11.
-			This is not an issue when libraries are referenced through nuget packages. See https://github.com/unoplatform/uno/issues/446 for more details.
-			-->
-      <Version>6.2.11</Version>
+      If, in the same solution, you are referencing a project that uses https://github.com/onovotny/MSBuildSdkExtras,
+      you need to make sure that the version provided here matches https://github.com/novotnyllc/MSBuildSdkExtras/blob/main/Source/MSBuild.Sdk.Extras/DefaultItems/ImplicitPackages.targets#L11.
+      This is not an issue when libraries are referenced through nuget packages. See https://github.com/unoplatform/uno/issues/446 for more details.
+      -->
+      <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml" Version="2.6.2" />
     <PackageReference Include="Uno.UI" Version="$UnoWinUIVersion$" />
@@ -144,10 +144,10 @@
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-			 Other similar extension points exist, see Microsoft.Common.targets.
-	<Target Name="BeforeBuild">
-	</Target>
-	<Target Name="AfterBuild">
-	</Target>
-	-->
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
 </Project>

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.UWP/UnoQuickStart.Uwp.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.UWP/UnoQuickStart.Uwp.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <ItemGroup>
@@ -12,7 +12,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml" Version="2.6.2" />
     <PackageReference Include="Uno.UI" Version="$UnoWinUIVersion$" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.UWP/UnoQuickStart.Uwp.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.UWP/UnoQuickStart.Uwp.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <ItemGroup>
@@ -30,7 +30,7 @@
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <PackageCertificateKeyFile>UnoQuickStart.Uwp_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <!-- <PackageCertificateKeyFile>TemporaryKey.pfx</PackageCertificateKeyFile> -->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
-    <NoWarn>NU1701</NoWarn>
+    <NoWarn>$(NoWarn);NU1504;NU1505;NU1701</NoWarn>
     <!--#if (wasm-pwa-manifest)
     <WasmPWAManifestFile>manifest.webmanifest</WasmPWAManifestFile>
 #endif -->

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
@@ -3,29 +3,29 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
     <NoWarn>NU1701</NoWarn>
-		<!--#if (wasm-pwa-manifest)
-		<WasmPWAManifestFile>manifest.webmanifest</WasmPWAManifestFile>
+    <!--#if (wasm-pwa-manifest)
+    <WasmPWAManifestFile>manifest.webmanifest</WasmPWAManifestFile>
 #endif -->
-	</PropertyGroup>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <MonoRuntimeDebuggerEnabled>true</MonoRuntimeDebuggerEnabled>
     <DefineConstants>$(DefineConstants);TRACE;DEBUG</DefineConstants>
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <!--
-		IL Linking is disabled in Debug configuration.
-		When building in Release, see https://platform.uno/docs/articles/features/using-il-linker-webassembly.html
-		-->
+        IL Linking is disabled in Debug configuration.
+        When building in Release, see https://platform.uno/docs/articles/features/using-il-linker-webassembly.html
+    -->
     <WasmShellILLinkerEnabled>false</WasmShellILLinkerEnabled>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Assets\SplashScreen.png" />
-		<!--#if (wasm-pwa-manifest)
-		
-		<Content Include="manifest.webmanifest" /><Content Include="Assets\AppIcon-*.png" />
-		
+    <!--#if (wasm-pwa-manifest)
+
+    <Content Include="manifest.webmanifest" /><Content Include="Assets\AppIcon-*.png" />
+
 #endif -->
-	</ItemGroup>
+  </ItemGroup>
   <ItemGroup>
     <UpToDateCheckInput Include="..\UnoQuickStart.Shared\**\*.xaml" />
   </ItemGroup>

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
@@ -37,14 +37,14 @@
     <LinkerDescriptor Include="LinkerConfig.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="$UnoExtensionsLoggingVersion$" />
     <PackageReference Include="Uno.UI.WebAssembly" Version="$UnoWinUIVersion$" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$UnoWinUIVersion$" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.20" />
-    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.20" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="$WasmBootstrapServer$" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="$WasmBootstrapServer$" />
   </ItemGroup>
   <Import Project="..\UnoQuickStart.Shared\UnoQuickStart.Shared.projitems" Label="Shared" />
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/App.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/App.xaml
@@ -2,7 +2,7 @@
 <Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:MyExtensionsApp._1"
-			 x:Class="MyExtensionsApp._1.MauiControls.App">
+             x:Class="MyExtensionsApp._1.MauiControls.App">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/MyExtensionsApp.1.MauiControls.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/MyExtensionsApp.1.MauiControls.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <!--#if (unoMauiClassLibrary)-->
     <DotNetVersion Condition="'$(DotNetVersion)'==''">$baseTargetFramework$</DotNetVersion>
+    <ImplicitUsings Condition="$(ImplicitUsings) == ''">enable</ImplicitUsings>
+    <Nullable Condition="$(Nullable) == ''">enable</Nullable>
 
     <!--#endif-->
     <!--#if (useWinAppSdk) -->

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/Directory.Build.props
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/Directory.Build.props
@@ -17,4 +17,13 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <_DirectoryBuildPropsFile Condition="'$(_DirectoryBuildPropsFile)' == ''">Directory.Build.props</_DirectoryBuildPropsFile>
+    <_ParentDirectory>$([MSBuild]::NormizePath($(MSBuildThisFileDirectory)\..))</_ParentDirectory>
+    <_ParentDirectoryBuildPropsBasePath Condition="'$(_ParentDirectoryBuildPropsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(_ParentDirectory), '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsBasePath>
+    <ParentDirectoryBuildPropsPath Condition="'$(_ParentDirectoryBuildPropsBasePath)' != '' and '$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('$(_ParentDirectoryBuildPropsBasePath)', '$(_DirectoryBuildPropsFile)'))</ParentDirectoryBuildPropsPath>
+  </PropertyGroup>
+
+  <Import Project="$(ParentDirectoryBuildPropsPath)" Condition="exists('$(ParentDirectoryBuildPropsPath)')"/>
+
 </Project>

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/Directory.Build.props
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/Directory.Build.props
@@ -11,6 +11,10 @@
     <DefaultItemExcludes>$(DefaultItemExcludes);obj/**;bin/**</DefaultItemExcludes>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
+
+    <RootNamespace>UnoCrossRuntimeLib</RootNamespace>
+    <AssemblyName>UnoCrossRuntimeLib</AssemblyName>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
 
 </Project>

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/Directory.Build.props
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/Directory.Build.props
@@ -19,7 +19,7 @@
 
   <PropertyGroup>
     <_DirectoryBuildPropsFile Condition="'$(_DirectoryBuildPropsFile)' == ''">Directory.Build.props</_DirectoryBuildPropsFile>
-    <_ParentDirectory>$([MSBuild]::NormizePath($(MSBuildThisFileDirectory)\..))</_ParentDirectory>
+    <_ParentDirectory>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory)\..))</_ParentDirectory>
     <_ParentDirectoryBuildPropsBasePath Condition="'$(_ParentDirectoryBuildPropsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(_ParentDirectory), '$(_DirectoryBuildPropsFile)'))</_ParentDirectoryBuildPropsBasePath>
     <ParentDirectoryBuildPropsPath Condition="'$(_ParentDirectoryBuildPropsBasePath)' != '' and '$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('$(_ParentDirectoryBuildPropsBasePath)', '$(_DirectoryBuildPropsFile)'))</ParentDirectoryBuildPropsPath>
   </PropertyGroup>

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Skia.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Skia.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
-    <RootNamespace>UnoCrossRuntimeLib</RootNamespace>
-    <AssemblyName>UnoCrossRuntimeLib</AssemblyName>
     <UnoRuntimeIdentifier>skia</UnoRuntimeIdentifier>
     <DefineConstants>$(DefineConstants);WINUI;__SKIA__</DefineConstants>
   </PropertyGroup>

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Wasm.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Wasm.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>$(DotNetVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);WINUI</DefineConstants>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Uno.WinUI.Runtime.WebAssembly" Version="$(UnoVersion)" />

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Wasm.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Wasm.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFramework>$(DotNetVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
-    <RootNamespace>UnoCrossRuntimeLib</RootNamespace>
-    <AssemblyName>UnoCrossRuntimeLib</AssemblyName>
     <DefineConstants>$(DefineConstants);WINUI</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);$(DotNetVersion);$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst</TargetFrameworks>
-    <AssemblyName>UnoCrossRuntimeLib</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <UnoRuntimeProjectReference Include="UnoCrossRuntimeLib.Skia.csproj" />

--- a/src/Uno.Templates/content/unomauilib/.template.config/template.json
+++ b/src/Uno.Templates/content/unomauilib/.template.config/template.json
@@ -76,6 +76,20 @@
       "description": "Include WinUI as a target platform",
       "displayName": "WinUI"
     },
+    "mauiEmbedding": {
+      "type": "generated",
+      "generator": "switch",
+      "parameters": {
+        "datatype": "bool",
+        "evaluator": "C++",
+        "cases": [
+          {
+            "condition": "(1 == 1)",
+            "value": "true"
+          }
+        ]
+      }
+    },
     "unoMauiClassLibrary": {
       "type": "generated",
       "generator": "switch",


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #559
- closes #553

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Build or CI related changes

## What is the current behavior?

The Cross Runtime library for Wasm gets updated to use an Exe for the output type.

## What is the new behavior?

The Wasm head explicitly sets the Output Type as Library.
