### PR TITLE
fix: typo in OverrideTargetFramework validation task

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Mobile/MyExtensionsApp.1.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Mobile/MyExtensionsApp.1.Mobile.csproj
@@ -270,6 +270,6 @@
   <Target Name="ValidateOverrides" BeforeTargets="Restore;_CheckForUnsupportedTargetFramework" Condition="'$(OverrideTargetFramework)' != ''">
     <Error
         Text="OverrideTargetFramework set to '$(OverrideTargetFramework)' is missing valid target. Set OverrideTargetFramework to one of the TargetFrameworks for this project or skip building this project (eg unload the project in Visual Studio)"
-        Condition="$(OverrideTargetFramework.Contains('windows10')) or !$(OverrideTargetFrameork.Contains('-'))" />
+        Condition="$(OverrideTargetFramework.Contains('windows10')) or !$(OverrideTargetFramework.Contains('-'))" />
   </Target>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes unoplatform/uno#15500
- closes #568 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

There is a typo in the Mobile head for the validation task of the OverrideTargetFramework

## What is the new behavior?

The typo has been fixed