### PR TITLE
Duplicate package reference

### DIFF
--- a/build/.azure-pipelines.TemplateValidation.yml
+++ b/build/.azure-pipelines.TemplateValidation.yml
@@ -98,6 +98,8 @@ jobs:
       # https://github.com/unoplatform/uno.templates/issues/500
       Issue500:
        templateArgs: '-preset blank -tfm net8.0 -markup csharp -presentation mvux -theme material -di -config -http -nav regions -log default -server -auth msal'
+      Issue572:
+        templateArgs: '-preset "recommended" -id "com.companyname.TestDuplicatedReference" -pub "O=TestDuplicatedReference" -platforms "android" -platforms "ios" -platforms "wasm" -platforms "gtk" -theme-service  -vscode False -pwa False -theme "material" -presentation "mvvm" -config  -di  -log "default" -nav "regions" -http  -loc  -server False -tests "unit" -tests "ui" -toolkit  -dsp'
 
   variables:
     - name: UseDotNetNativeToolchain

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -32,9 +32,10 @@
   <!--#if (useCPM)-->
   <ItemGroup>
     <PackageReference Include="Uno.WinUI" />
+    <!--#if (useWinAppSdk) -->
     <PackageReference Include="Uno.WinUI.Lottie" Condition="!$(TargetFramework.Contains('windows10'))" />
     <PackageReference Include="Uno.WinUI.DevServer" Condition="'$(Configuration)'=='Debug' AND !$(TargetFramework.Contains('windows10'))" />
-    <!--#if (!useWinAppSdk) -->
+    <!--#else-->
     <PackageReference Include="Uno.WinUI.Lottie" />
     <PackageReference Include="Uno.WinUI.DevServer" Condition="'$(Configuration)'=='Debug'" />
     <!--#endif-->
@@ -144,9 +145,10 @@
   <!--#else-->
   <ItemGroup>
     <PackageReference Include="Uno.WinUI" Version="$(UnoVersion)" />
+    <!--#if (useWinAppSdk) -->
     <PackageReference Include="Uno.WinUI.Lottie" Version="$(UnoVersion)" Condition="!$(TargetFramework.Contains('windows10'))" />
     <PackageReference Include="Uno.WinUI.DevServer" Version="$(UnoVersion)" Condition="'$(Configuration)'=='Debug' AND !$(TargetFramework.Contains('windows10'))" />
-    <!--#if (!useWinAppSdk) -->
+    <!--#else-->
     <PackageReference Include="Uno.WinUI.Lottie" Version="$(UnoVersion)" />
     <PackageReference Include="Uno.WinUI.DevServer" Version="$(UnoVersion)" Condition="'$(Configuration)'=='Debug'" />
     <!--#endif-->


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- Fixes #572

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The template adds references for Lottie and DevServer with a condition for when the TargetFramework does not contain windows10... The template conditionally adds references when we do not have a windows head without the Condition which results in duplicate references.

## What is the new behavior?

We now wrap both sets of PackageReferences in template conditions so that only one of the 2 blocks is included in the output project.