### PR TITLE
Fixing the TFM Order

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <!--#if (useWinAppSdk) -->
-    <TargetFrameworks>$(TargetFrameworks);$(DotNetVersion);$unoTargetFrameworks$</TargetFrameworks>
+    <TargetFrameworks>$unoTargetFrameworks$;$(DotNetVersion)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
     <!--#else -->
     <TargetFrameworks>$unoTargetFrameworks$;$(DotNetVersion)</TargetFrameworks>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

browserwasm is only the first tfm when not using Windows

## What is the new behavior?

browserwasm is now the first tfm
