### PR TITLE
fix: fix building single project from linux

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -1,11 +1,14 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
+    <TargetFrameworks>$unoTargetFrameworks$;$(DotNetVersion)</TargetFrameworks>
     <!--#if (useWinAppSdk) -->
-    <TargetFrameworks>$unoTargetFrameworks$;$(DotNetVersion)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
-    <!--#else -->
-    <TargetFrameworks>$unoTargetFrameworks$;$(DotNetVersion)</TargetFrameworks>
     <!--#endif -->
+    <!--
+      Under Linux we can't restore ios or maccatalyst workloads are not available on linux https://github.com/dotnet/runtime/issues/85505
+      dotnet restore would fail if they are not removed from the list
+    -->
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == 'true'">$(TargetFrameworks.Replace("$(DotNetVersion)-ios","").Replace("$(DotNetVersion)-maccatalyst",""))</TargetFrameworks>
     <TargetFrameworks Condition="'$(OverrideTargetFramework)'!=''">$(OverrideTargetFramework)</TargetFrameworks>
 
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When building under Linux `dotnet restore` fails because `ios` and `maccatalyst` workloads are **not** available on that platform.

## What is the new behavior?

`netX.Y-ios` and `netX.y-maccatalyst` are removed from the `<TargetFrameworks>` on Linux solving the `dotnet restore` issue.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Associated with an issue (GitHub or internal)

## Other information

https://github.com/dotnet/runtime/issues/85505
