### PR TITLE
feat: Initialize logging earlier in desktop target

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.blank.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.blank.cs
@@ -9,11 +9,6 @@ namespace MyExtensionsApp._1;
 
 public partial class App : Application
 {
-#if (useLoggingFallback)
-    static App() =>
-        InitializeLogging();
-
-#endif
     /// <summary>
     /// Initializes the singleton application object. This is the first line of authored code
     /// executed, and as such is the logical equivalent of main() or WinMain().
@@ -117,7 +112,7 @@ $$EnableDeveloperMode_Frame_MainWindowContent$$
     /// <summary>
     /// Configures global Uno Platform logging
     /// </summary>
-    private static void InitializeLogging()
+    public static void InitializeLogging()
     {
 //-:cnd:noEmit
 #if DEBUG

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/Desktop/Program.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/Desktop/Program.cs
@@ -7,6 +7,10 @@ public class Program
     [STAThread]
     public static void Main(string[] args)
     {
+#if (useLoggingFallback)
+        App.InitializeLogging();
+#endif
+
         var host = SkiaHostBuilder.Create()
             .App(() => new App())
             .UseX11()

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/Desktop/Program.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/Desktop/Program.cs
@@ -7,9 +7,9 @@ public class Program
     [STAThread]
     public static void Main(string[] args)
     {
-#if (!useDependencyInjection)
+#if (!useDependencyInjection && useLoggingFallback)
         App.InitializeLogging();
-        
+
 #endif
         var host = SkiaHostBuilder.Create()
             .App(() => new App())

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/Desktop/Program.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/Desktop/Program.cs
@@ -7,10 +7,10 @@ public class Program
     [STAThread]
     public static void Main(string[] args)
     {
-#if (useLoggingFallback)
+#if (!useDependencyInjection)
         App.InitializeLogging();
+        
 #endif
-
         var host = SkiaHostBuilder.Create()
             .App(() => new App())
             .UseX11()


### PR DESCRIPTION
Ensures that platform host logging shows up in the console for desktop