### PR TITLE
refactor: Restore original targetframework

### DIFF
--- a/src/Uno.Templates/content/unoapp-uitest/UnoUITestsLibrary.csproj
+++ b/src/Uno.Templates/content/unoapp-uitest/UnoUITestsLibrary.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <DotNetVersion Condition=" $(DotNetVersion) == '' ">net8.0</DotNetVersion>
-    <TargetFramework>$(DotNetVersion)</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Uno.Templates/content/unoapp-uitest/UnoUITestsLibrary.csproj
+++ b/src/Uno.Templates/content/unoapp-uitest/UnoUITestsLibrary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$baseTargetFramework$</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Uno.Templates/content/unoapp-uwp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp-uwp/Directory.Build.props
@@ -1,7 +1,5 @@
 <Project>
   <PropertyGroup>
-    <DotNetVersion>net8.0</DotNetVersion>
-
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Mobile/UnoQuickStart.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Mobile/UnoQuickStart.Mobile.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst</TargetFrameworks>
     <!-- Disabled because of https://github.com/xamarin/xamarin-macios/issues/16401-->
-    <!-- <TargetFrameworks>$(TargetFrameworks);$(DotNetVersion)-macos</TargetFrameworks> -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$-macos</TargetFrameworks> -->
     <SingleProject>true</SingleProject>
     <OutputType>Exe</OutputType>
     <!-- Display name -->

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Mobile/UnoQuickStart.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Mobile/UnoQuickStart.Mobile.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
     <!-- Disabled because of https://github.com/xamarin/xamarin-macios/issues/16401-->
-    <!-- <TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$-macos</TargetFrameworks> -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-macos</TargetFrameworks> -->
     <SingleProject>true</SingleProject>
     <OutputType>Exe</OutputType>
     <!-- Display name -->

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.Gtk/UnoQuickStart.Skia.Gtk.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.Gtk/UnoQuickStart.Skia.Gtk.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>$(DotNetVersion)</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup Condition="exists('..\UnoQuickStart.UWP')">

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.Gtk/UnoQuickStart.Skia.Gtk.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.Gtk/UnoQuickStart.Skia.Gtk.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>$baseTargetFramework$</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup Condition="exists('..\UnoQuickStart.UWP')">

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.Linux.FrameBuffer/UnoQuickStart.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.Linux.FrameBuffer/UnoQuickStart.Skia.Linux.FrameBuffer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>$baseTargetFramework$</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup Condition="exists('..\UnoQuickStart.UWP')">
     <EmbeddedResource Include="..\UnoQuickStart.UWP\Package.appxmanifest" LogicalName="Package.appxmanifest" />

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.Linux.FrameBuffer/UnoQuickStart.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.Linux.FrameBuffer/UnoQuickStart.Skia.Linux.FrameBuffer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>$(DotNetVersion)</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
   </PropertyGroup>
   <ItemGroup Condition="exists('..\UnoQuickStart.UWP')">
     <EmbeddedResource Include="..\UnoQuickStart.UWP\Package.appxmanifest" LogicalName="Package.appxmanifest" />

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.WPF/UnoQuickStart.Skia.WPF.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.WPF/UnoQuickStart.Skia.WPF.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>$(DotNetVersion)-windows</TargetFramework>
+    <TargetFramework>$baseTargetFramework$-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.WPF/UnoQuickStart.Skia.WPF.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.WPF/UnoQuickStart.Skia.WPF.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>$baseTargetFramework$-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(DotNetVersion)</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
     <NoWarn>$(NoWarn);NU1504;NU1505;NU1701</NoWarn>
     <!--#if (wasm-pwa-manifest)
     <WasmPWAManifestFile>manifest.webmanifest</WasmPWAManifestFile>

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$baseTargetFramework$</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);NU1504;NU1505;NU1701</NoWarn>
     <!--#if (wasm-pwa-manifest)
     <WasmPWAManifestFile>manifest.webmanifest</WasmPWAManifestFile>

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1360,31 +1360,31 @@
         "cases": [
           {
             "condition": "(platforms == android && platforms == ios && platforms == maccatalyst)",
-            "value": "$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms == android && platforms == ios && platforms != maccatalyst)",
-            "value": "$(DotNetVersion)-android;$(DotNetVersion)-ios"
+            "value": "$baseTargetFramework$-android;$baseTargetFramework$-ios"
           },
           {
             "condition": "(platforms != android && platforms == ios && platforms == maccatalyst)",
-            "value": "$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms == android && platforms != ios && platforms == maccatalyst)",
-            "value": "$(DotNetVersion)-android;$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-android;$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms == android && platforms != ios && platforms != maccatalyst)",
-            "value": "$(DotNetVersion)-android"
+            "value": "$baseTargetFramework$-android"
           },
           {
             "condition": "(platforms != android && platforms == ios && platforms != maccatalyst)",
-            "value": "$(DotNetVersion)-ios"
+            "value": "$baseTargetFramework$-ios"
           },
           {
             "condition": "(platforms != android && platforms != ios && platforms == maccatalyst)",
-            "value": "$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms != android && platforms != ios && platforms != maccatalyst)",
@@ -1403,127 +1403,127 @@
         "cases": [
           {
             "condition": "(platforms == android && platforms == ios && platforms == maccatalyst && platforms == wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-browserwasm;$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst;$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-browserwasm;$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst;$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms == android && platforms == ios && platforms == maccatalyst && platforms == wasm && platforms != desktop)",
-            "value": "$(DotNetVersion)-browserwasm;$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-browserwasm;$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms == android && platforms == ios && platforms == maccatalyst && platforms != wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst;$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst;$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms == android && platforms == ios && platforms == maccatalyst && platforms != wasm && platforms != desktop)",
-            "value": "$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms == android && platforms == ios && platforms != maccatalyst && platforms == wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-browserwasm;$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-browserwasm;$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms == android && platforms == ios && platforms != maccatalyst && platforms == wasm && platforms != desktop)",
-            "value": "$(DotNetVersion)-browserwasm;$(DotNetVersion)-android;$(DotNetVersion)-ios"
+            "value": "$baseTargetFramework$-browserwasm;$baseTargetFramework$-android;$baseTargetFramework$-ios"
           },
           {
             "condition": "(platforms == android && platforms == ios && platforms != maccatalyst && platforms != wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms == android && platforms == ios && platforms != maccatalyst && platforms != wasm && platforms != desktop)",
-            "value": "$(DotNetVersion)-android;$(DotNetVersion)-ios"
+            "value": "$baseTargetFramework$-android;$baseTargetFramework$-ios"
           },
           {
             "condition": "(platforms != android && platforms == ios && platforms == maccatalyst && platforms == wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-browserwasm;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst;$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-browserwasm;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst;$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms != android && platforms == ios && platforms == maccatalyst && platforms == wasm && platforms != desktop)",
-            "value": "$(DotNetVersion)-browserwasm;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-browserwasm;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms != android && platforms == ios && platforms == maccatalyst && platforms != wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst;$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst;$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms != android && platforms == ios && platforms == maccatalyst && platforms != wasm && platforms != desktop)",
-            "value": "$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms == android && platforms != ios && platforms == maccatalyst && platforms == wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-browserwasm;$(DotNetVersion)-android;$(DotNetVersion)-maccatalyst;$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-browserwasm;$baseTargetFramework$-android;$baseTargetFramework$-maccatalyst;$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms == android && platforms != ios && platforms == maccatalyst && platforms == wasm && platforms != desktop)",
-            "value": "$(DotNetVersion)-browserwasm;$(DotNetVersion)-android;$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-browserwasm;$baseTargetFramework$-android;$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms == android && platforms != ios && platforms == maccatalyst && platforms != wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-android;$(DotNetVersion)-maccatalyst;$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-android;$baseTargetFramework$-maccatalyst;$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms == android && platforms != ios && platforms == maccatalyst && platforms != wasm && platforms != desktop)",
-            "value": "$(DotNetVersion)-android;$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-android;$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms == android && platforms != ios && platforms != maccatalyst && platforms == wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-browserwasm;$(DotNetVersion)-android;$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-browserwasm;$baseTargetFramework$-android;$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms == android && platforms != ios && platforms != maccatalyst && platforms == wasm && platforms != desktop)",
-            "value": "$(DotNetVersion)-browserwasm;$(DotNetVersion)-android"
+            "value": "$baseTargetFramework$-browserwasm;$baseTargetFramework$-android"
           },
           {
             "condition": "(platforms == android && platforms != ios && platforms != maccatalyst && platforms != wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-android;$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-android;$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms == android && platforms != ios && platforms != maccatalyst && platforms != wasm && platforms != desktop)",
-            "value": "$(DotNetVersion)-android"
+            "value": "$baseTargetFramework$-android"
           },
           {
             "condition": "(platforms != android && platforms == ios && platforms != maccatalyst && platforms == wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-browserwasm;$(DotNetVersion)-ios;$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-browserwasm;$baseTargetFramework$-ios;$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms != android && platforms == ios && platforms != maccatalyst && platforms == wasm && platforms != desktop)",
-            "value": "$(DotNetVersion)-browserwasm;$(DotNetVersion)-ios"
+            "value": "$baseTargetFramework$-browserwasm;$baseTargetFramework$-ios"
           },
           {
             "condition": "(platforms != android && platforms == ios && platforms != maccatalyst && platforms != wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-ios;$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-ios;$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms != android && platforms == ios && platforms != maccatalyst && platforms != wasm && platforms != desktop)",
-            "value": "$(DotNetVersion)-ios"
+            "value": "$baseTargetFramework$-ios"
           },
           {
             "condition": "(platforms != android && platforms != ios && platforms == maccatalyst && platforms == wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-browserwasm;$(DotNetVersion)-maccatalyst;$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-browserwasm;$baseTargetFramework$-maccatalyst;$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms != android && platforms != ios && platforms == maccatalyst && platforms == wasm && platforms != desktop)",
-            "value": "$(DotNetVersion)-browserwasm;$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-browserwasm;$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms != android && platforms != ios && platforms == maccatalyst && platforms != wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-maccatalyst;$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-maccatalyst;$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms != android && platforms != ios && platforms == maccatalyst && platforms != wasm && platforms != desktop)",
-            "value": "$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms != android && platforms != ios && platforms != maccatalyst && platforms == wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-browserwasm;$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-browserwasm;$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms != android && platforms != ios && platforms != maccatalyst && platforms == wasm && platforms != desktop)",
-            "value": "$(DotNetVersion)-browserwasm"
+            "value": "$baseTargetFramework$-browserwasm"
           },
           {
             "condition": "(platforms != android && platforms != ios && platforms != maccatalyst && platforms != wasm && platforms == desktop)",
-            "value": "$(DotNetVersion)-desktop"
+            "value": "$baseTargetFramework$-desktop"
           },
           {
             "condition": "(platforms != android && platforms != ios && platforms != maccatalyst && platforms != wasm && platforms != desktop)",

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1350,49 +1350,6 @@
         ]
       }
     },
-    "mobileTargetFrameworks": {
-      "type": "generated",
-      "generator": "switch",
-      "replaces": "$mobileTargetFrameworks$",
-      "parameters": {
-        "evaluator": "C++",
-        "datatype": "string",
-        "cases": [
-          {
-            "condition": "(platforms == android && platforms == ios && platforms == maccatalyst)",
-            "value": "$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst"
-          },
-          {
-            "condition": "(platforms == android && platforms == ios && platforms != maccatalyst)",
-            "value": "$baseTargetFramework$-android;$baseTargetFramework$-ios"
-          },
-          {
-            "condition": "(platforms != android && platforms == ios && platforms == maccatalyst)",
-            "value": "$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst"
-          },
-          {
-            "condition": "(platforms == android && platforms != ios && platforms == maccatalyst)",
-            "value": "$baseTargetFramework$-android;$baseTargetFramework$-maccatalyst"
-          },
-          {
-            "condition": "(platforms == android && platforms != ios && platforms != maccatalyst)",
-            "value": "$baseTargetFramework$-android"
-          },
-          {
-            "condition": "(platforms != android && platforms == ios && platforms != maccatalyst)",
-            "value": "$baseTargetFramework$-ios"
-          },
-          {
-            "condition": "(platforms != android && platforms != ios && platforms == maccatalyst)",
-            "value": "$baseTargetFramework$-maccatalyst"
-          },
-          {
-            "condition": "(platforms != android && platforms != ios && platforms != maccatalyst)",
-            "value": ""
-          }
-        ]
-      }
-    },
     "unoTargetFrameworks": {
       "type": "generated",
       "generator": "switch",

--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup>
-    <DotNetVersion>$baseTargetFramework$</DotNetVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.DataContracts/MyExtensionsApp.1.DataContracts.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.DataContracts/MyExtensionsApp.1.DataContracts.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(DotNetVersion)</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 </Project>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/MyExtensionsApp.1.MauiControls.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/MyExtensionsApp.1.MauiControls.csproj
@@ -6,13 +6,20 @@
     <Nullable Condition="$(Nullable) == ''">enable</Nullable>
 
     <!--#endif-->
-    <!--#if (useWinAppSdk) -->
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$baseTargetFramework$-windows10.0.19041</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$;$mobileTargetFrameworks$</TargetFrameworks>
-    <!--#else -->
-    <TargetFrameworks>$baseTargetFramework$;$mobileTargetFrameworks$</TargetFrameworks>
-    <!--#endif -->
-    <TargetFrameworks Condition="'$(OverrideTargetFramework)'!=''">$(OverrideTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>
+      <!--#if (useAndroid)-->
+      $baseTargetFramework$-android;
+      <!--#endif-->
+      <!--#if (useiOS)-->
+      $baseTargetFramework$-ios;
+      <!--#endif-->
+      <!--#if (useMacCatalyst)-->
+      $baseTargetFramework$-maccatalyst;
+      <!--#endif-->
+      <!--#if (useWinAppSdk)-->
+      $baseTargetFramework$-windows10.0.19041;
+      <!--#endif-->
+    </TargetFrameworks>
 
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/MyExtensionsApp.1.MauiControls.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/MyExtensionsApp.1.MauiControls.csproj
@@ -2,16 +2,15 @@
 
   <PropertyGroup>
     <!--#if (unoMauiClassLibrary)-->
-    <DotNetVersion Condition="'$(DotNetVersion)'==''">$baseTargetFramework$</DotNetVersion>
     <ImplicitUsings Condition="$(ImplicitUsings) == ''">enable</ImplicitUsings>
     <Nullable Condition="$(Nullable) == ''">enable</Nullable>
 
     <!--#endif-->
     <!--#if (useWinAppSdk) -->
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);$(DotNetVersion);$mobileTargetFrameworks$</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$baseTargetFramework$-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$;$mobileTargetFrameworks$</TargetFrameworks>
     <!--#else -->
-    <TargetFrameworks>$(DotNetVersion);$mobileTargetFrameworks$</TargetFrameworks>
+    <TargetFrameworks>$baseTargetFramework$;$mobileTargetFrameworks$</TargetFrameworks>
     <!--#endif -->
     <TargetFrameworks Condition="'$(OverrideTargetFramework)'!=''">$(OverrideTargetFramework)</TargetFrameworks>
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Server/MyExtensionsApp.1.Server.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Server/MyExtensionsApp.1.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>$(DotNetVersion)</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--#if (useCsharpMarkup)-->
     <EnableUnoCSMUsings>false</EnableUnoCSMUsings>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <!--#if (useWasm)-->
     <ProjectReference Include="..\MyExtensionsApp.1\MyExtensionsApp.1.csproj"
-                      SetTargetFramework="TargetFramework=$(DotNetVersion)-browserwasm"
+                      SetTargetFramework="TargetFramework=$baseTargetFramework$-browserwasm"
                       AdditionalProperties="OutputPath=$(MSBuildProjectDirectory)\$(OutputPath)"
                       ReferenceOutputAssembly="false" />
     <!--#endif -->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Tests/MyExtensionsApp.1.Tests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Tests/MyExtensionsApp.1.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(DotNetVersion)</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/MyExtensionsApp.1.UITests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/MyExtensionsApp.1.UITests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(DotNetVersion)</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -2,25 +2,25 @@
   <PropertyGroup>
     <TargetFrameworks>
       <!--#if (useWasm)-->
-      $(DotNetVersion)-browserwasm;
+      $baseTargetFramework$-browserwasm;
       <!--#endif-->
       <!--#if (useAndroid)-->
-      $(DotNetVersion)-android;
+      $baseTargetFramework$-android;
       <!--#endif-->
       <!--#if (useiOS)-->
-      $(DotNetVersion)-ios;
+      $baseTargetFramework$-ios;
       <!--#endif-->
       <!--#if (useMacCatalyst)-->
-      $(DotNetVersion)-maccatalyst;
+      $baseTargetFramework$-maccatalyst;
       <!--#endif-->
       <!--#if (useWinAppSdk)-->
-      $(DotNetVersion)-windows10.0.19041;
+      $baseTargetFramework$-windows10.0.19041;
       <!--#endif-->
       <!--#if (useDesktop)-->
-      $(DotNetVersion)-desktop;
+      $baseTargetFramework$-desktop;
       <!--#endif-->
       <!--#if (useUnitTests)-->
-      $(DotNetVersion);
+      $baseTargetFramework$;
       <!--#endif-->
     </TargetFrameworks>
 

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/Directory.Build.props
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
 
   <PropertyGroup>
-    <DotNetVersion Condition=" $(DotNetVersion) == '' ">net8.0</DotNetVersion>
     <!--
     Force all projects of this folder to use a different output
     path to avoid intermediate output collisions

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Skia.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Skia.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(DotNetVersion)</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
     <IsPackable>false</IsPackable>
     <UnoRuntimeIdentifier>skia</UnoRuntimeIdentifier>
     <DefineConstants>$(DefineConstants);WINUI;__SKIA__</DefineConstants>

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Skia.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Skia.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFramework>$baseTargetFramework$</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <UnoRuntimeIdentifier>skia</UnoRuntimeIdentifier>
     <DefineConstants>$(DefineConstants);WINUI;__SKIA__</DefineConstants>

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Wasm.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Wasm.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFramework>$baseTargetFramework$</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);WINUI</DefineConstants>
     <OutputType>Library</OutputType>

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Wasm.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Wasm.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(DotNetVersion)</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);WINUI</DefineConstants>
     <OutputType>Library</OutputType>

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$baseTargetFramework$-windows10.0.19041</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$;$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <UnoRuntimeProjectReference Include="UnoCrossRuntimeLib.Skia.csproj" />

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);$(DotNetVersion);$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$baseTargetFramework$-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$;$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <UnoRuntimeProjectReference Include="UnoCrossRuntimeLib.Skia.csproj" />

--- a/src/Uno.Templates/content/unolib/CrossTargetedLibrary.csproj
+++ b/src/Uno.Templates/content/unolib/CrossTargetedLibrary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$baseTargetFramework$-windows10.0.19041</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst;$baseTargetFramework$-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-android</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Uno.Templates/content/unolib/CrossTargetedLibrary.csproj
+++ b/src/Uno.Templates/content/unolib/CrossTargetedLibrary.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <DotNetVersion Condition=" $(DotNetVersion) == '' ">net8.0</DotNetVersion>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);$(DotNetVersion);$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst;$(DotNetVersion)-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$baseTargetFramework$-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst;$baseTargetFramework$-android</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Uno.Templates/content/unomauilib/.template.config/template.json
+++ b/src/Uno.Templates/content/unomauilib/.template.config/template.json
@@ -121,31 +121,31 @@
         "cases": [
           {
             "condition": "(platforms == android && platforms == ios && platforms == maccatalyst)",
-            "value": "$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms == android && platforms == ios && platforms != maccatalyst)",
-            "value": "$(DotNetVersion)-android;$(DotNetVersion)-ios"
+            "value": "$baseTargetFramework$-android;$baseTargetFramework$-ios"
           },
           {
             "condition": "(platforms != android && platforms == ios && platforms == maccatalyst)",
-            "value": "$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms == android && platforms != ios && platforms == maccatalyst)",
-            "value": "$(DotNetVersion)-android;$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-android;$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms == android && platforms != ios && platforms != maccatalyst)",
-            "value": "$(DotNetVersion)-android"
+            "value": "$baseTargetFramework$-android"
           },
           {
             "condition": "(platforms != android && platforms == ios && platforms != maccatalyst)",
-            "value": "$(DotNetVersion)-ios"
+            "value": "$baseTargetFramework$-ios"
           },
           {
             "condition": "(platforms != android && platforms != ios && platforms == maccatalyst)",
-            "value": "$(DotNetVersion)-maccatalyst"
+            "value": "$baseTargetFramework$-maccatalyst"
           },
           {
             "condition": "(platforms != android && platforms != ios && platforms != maccatalyst)",

--- a/src/Uno.Templates/content/unomauilib/.template.config/template.json
+++ b/src/Uno.Templates/content/unomauilib/.template.config/template.json
@@ -110,49 +110,6 @@
           }
         ]
       }
-    },
-    "mobileTargetFrameworks": {
-      "type": "generated",
-      "generator": "switch",
-      "replaces": "$mobileTargetFrameworks$",
-      "parameters": {
-        "evaluator": "C++",
-        "datatype": "string",
-        "cases": [
-          {
-            "condition": "(platforms == android && platforms == ios && platforms == maccatalyst)",
-            "value": "$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst"
-          },
-          {
-            "condition": "(platforms == android && platforms == ios && platforms != maccatalyst)",
-            "value": "$baseTargetFramework$-android;$baseTargetFramework$-ios"
-          },
-          {
-            "condition": "(platforms != android && platforms == ios && platforms == maccatalyst)",
-            "value": "$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst"
-          },
-          {
-            "condition": "(platforms == android && platforms != ios && platforms == maccatalyst)",
-            "value": "$baseTargetFramework$-android;$baseTargetFramework$-maccatalyst"
-          },
-          {
-            "condition": "(platforms == android && platforms != ios && platforms != maccatalyst)",
-            "value": "$baseTargetFramework$-android"
-          },
-          {
-            "condition": "(platforms != android && platforms == ios && platforms != maccatalyst)",
-            "value": "$baseTargetFramework$-ios"
-          },
-          {
-            "condition": "(platforms != android && platforms != ios && platforms == maccatalyst)",
-            "value": "$baseTargetFramework$-maccatalyst"
-          },
-          {
-            "condition": "(platforms != android && platforms != ios && platforms != maccatalyst)",
-            "value": ""
-          }
-        ]
-      }
     }
   }
 }


### PR DESCRIPTION
This change restores the original netX.0 target framework in csproj, and removs the use of `$(DotnetVersion)`, given that most solutions will have only one project to start with.

It is done for few reasons:
- Familiarity with other non-uno projects, where projects are generally authored this way
- Smaller string to define targets
- Easier string lookup
- Less confusing `DotnetVersion` variable that users may not know where the definition is coming from

This change makes it a bit less easy to change the target framework for the whole solution, but it's a generally known process from developers that use find+replace to do so.