### PR TITLE
adding net9.0 support

### DIFF
--- a/build/.azure-pipelines.TemplateValidation.yml
+++ b/build/.azure-pipelines.TemplateValidation.yml
@@ -8,9 +8,9 @@ jobs:
     matrix:
       DefaultArguments:
         templateArgs: ''
-      DefaultArguments_net9:
-        templateArgs: '-tfm net9.0'
-        unocheckArguments: '--preview-major'
+      # DefaultArguments_net9:
+      #   templateArgs: '-tfm net9.0'
+      #   unocheckArguments: '--preview-major'
       Recommended:
         templateArgs: '-preset recommended'
       SkiaOnlyHeads:

--- a/build/.azure-pipelines.TemplateValidation.yml
+++ b/build/.azure-pipelines.TemplateValidation.yml
@@ -8,7 +8,7 @@ jobs:
     matrix:
       DefaultArguments:
         templateArgs: ''
-      DefaultArguments:
+      DefaultArguments_net9:
         templateArgs: '-tfm net9.0'
         unocheckArguments: '--pre-major'
       Recommended:

--- a/build/.azure-pipelines.TemplateValidation.yml
+++ b/build/.azure-pipelines.TemplateValidation.yml
@@ -8,6 +8,9 @@ jobs:
     matrix:
       DefaultArguments:
         templateArgs: ''
+      DefaultArguments:
+        templateArgs: '-tfm net9.0'
+        unocheckArguments: '--pre-major'
       Recommended:
         templateArgs: '-preset recommended'
       SkiaOnlyHeads:

--- a/build/.azure-pipelines.TemplateValidation.yml
+++ b/build/.azure-pipelines.TemplateValidation.yml
@@ -10,7 +10,7 @@ jobs:
         templateArgs: ''
       DefaultArguments_net9:
         templateArgs: '-tfm net9.0'
-        unocheckArguments: '--pre-major'
+        unocheckArguments: '--preview-major'
       Recommended:
         templateArgs: '-preset recommended'
       SkiaOnlyHeads:

--- a/build/templates/dotnet-install-windows.yml
+++ b/build/templates/dotnet-install-windows.yml
@@ -9,5 +9,6 @@ steps:
     inputs:
       packageType: sdk
       version: ${{ parameters.DotNetVersion }}
+      includePreviewVersions: true
 
   - template: jdk-setup.yml

--- a/build/templates/package-validation.yml
+++ b/build/templates/package-validation.yml
@@ -2,6 +2,9 @@ parameters:
 - name: arguments
   type: string
   default: ''
+- name: unocheckArguments
+  type: string
+  default: ''
 
 steps:
 - checkout: self
@@ -61,7 +64,7 @@ steps:
 - powershell: |
     & dotnet tool install --global Uno.Check --version $env:ValidationUnoCheckVersion
     cd UnoApp1
-    uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip androidemulator --skip androidsdk --skip vsmac --skip dotnetnewunotemplates
+    uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip androidemulator --skip androidsdk --skip vsmac --skip dotnetnewunotemplates  ${{ parameters.unocheckArguments }}
   displayName: Uno Check
   env:
     ValidationUnoCheckVersion: $(ValidationUnoCheckVersion)

--- a/build/templates/package-validation.yml
+++ b/build/templates/package-validation.yml
@@ -13,7 +13,7 @@ steps:
     $dotnetVersion = $env:TargetDotNetVersion
     if ($templateArgs -match 'net9.0')
     {
-        $dotnetVersion = '9.0.100-preview.1'
+        $dotnetVersion = '9.0.100-preview.2.24157.14'
     }
 
     Write-Host "DotNetVersion = $dotnetVersion"

--- a/build/templates/template-validation.yml
+++ b/build/templates/template-validation.yml
@@ -5,6 +5,9 @@ parameters:
 - name: arguments
   type: string
   default: ''
+- name: unocheckArguments
+  type: string
+  default: ''
 
 steps:
 - template: dotnet-install-windows.yml
@@ -46,7 +49,7 @@ steps:
 - powershell: |
     & dotnet tool install --global Uno.Check --version $env:ValidationUnoCheckVersion
     cd UnoTemplateValidation1
-    uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip androidemulator --skip androidsdk --skip vsmac --skip dotnetnewunotemplates
+    uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip androidemulator --skip androidsdk --skip vsmac --skip dotnetnewunotemplates ${{ parameters.unocheckArguments }}
   displayName: Uno Check
   env:
     ValidationUnoCheckVersion: $(ValidationUnoCheckVersion)

--- a/src/Uno.Templates/content/unoapp-uitest/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unoapp-uitest/.template.config/dotnetcli.host.json
@@ -1,6 +1,10 @@
 ﻿{
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
+    "tfm": {
+      "longName": "tfm",
+      "shortName": "tfm"
+    },
     "unoUITestHelpersVersion": {
       "isHidden": true
     }

--- a/src/Uno.Templates/content/unoapp-uitest/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp-uitest/.template.config/template.json
@@ -33,6 +33,27 @@
       "datatype": "text",
       "defaultValue": "DefaultUnoUITestHelpersVersion",
       "replaces": "$UnoUITestHelpersVersion$"
+    },
+    "tfm": {
+      "displayName": "Target Framework",
+      "type": "parameter",
+      "datatype": "choice",
+      "enableQuotelessLiterals": true,
+      "replaces": "$baseTargetFramework$",
+      "defaultValue": "net8.0",
+      "description": "Select the .NET version of your solution",
+      "choices": [
+        {
+          "choice": "net8.0",
+          "displayName": ".NET 8.0",
+          "description": "Target .NET 8.0 (Long Term Support)"
+        },
+        {
+          "choice": "net9.0",
+          "displayName": ".NET 9.0",
+          "description": "Target .NET 9.0 (Preview)"
+        }
+      ]
     }
   },
   "primaryOutputs": [

--- a/src/Uno.Templates/content/unoapp-uitest/UnoUITestsLibrary.csproj
+++ b/src/Uno.Templates/content/unoapp-uitest/UnoUITestsLibrary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Uno.Templates/content/unoapp-uwp/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unoapp-uwp/.template.config/dotnetcli.host.json
@@ -1,6 +1,10 @@
 ﻿{
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
+    "tfm": {
+      "longName": "tfm",
+      "shortName": "tfm"
+    },
     "WebAssembly": {
       "longName": "webassembly",
       "shortName": "wasm"

--- a/src/Uno.Templates/content/unoapp-uwp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp-uwp/.template.config/template.json
@@ -77,6 +77,27 @@
         "format": "N"
       }
     },
+    "tfm": {
+      "displayName": "Target Framework",
+      "type": "parameter",
+      "datatype": "choice",
+      "enableQuotelessLiterals": true,
+      "replaces": "$baseTargetFramework$",
+      "defaultValue": "net8.0",
+      "description": "Select the .NET version of your solution",
+      "choices": [
+        {
+          "choice": "net8.0",
+          "displayName": ".NET 8.0",
+          "description": "Target .NET 8.0 (Long Term Support)"
+        },
+        {
+          "choice": "net9.0",
+          "displayName": ".NET 9.0",
+          "description": "Target .NET 9.0 (Preview)"
+        }
+      ]
+    },
     "windowsPublisherName": {
       "type": "parameter",
       "datatype": "text",

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Mobile/UnoQuickStart.Mobile.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Mobile/UnoQuickStart.Mobile.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst</TargetFrameworks>
     <!-- Disabled because of https://github.com/xamarin/xamarin-macios/issues/16401-->
-    <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-macos</TargetFrameworks> -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$-macos</TargetFrameworks> -->
     <SingleProject>true</SingleProject>
     <OutputType>Exe</OutputType>
     <!-- Display name -->

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.Gtk/UnoQuickStart.Skia.Gtk.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.Gtk/UnoQuickStart.Skia.Gtk.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup Condition="exists('..\UnoQuickStart.UWP')">

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.Linux.FrameBuffer/UnoQuickStart.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.Linux.FrameBuffer/UnoQuickStart.Skia.Linux.FrameBuffer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
   </PropertyGroup>
   <ItemGroup Condition="exists('..\UnoQuickStart.UWP')">
     <EmbeddedResource Include="..\UnoQuickStart.UWP\Package.appxmanifest" LogicalName="Package.appxmanifest" />

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.WPF/UnoQuickStart.Skia.WPF.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Skia.WPF/UnoQuickStart.Skia.WPF.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>$baseTargetFramework$-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
     <NoWarn>$(NoWarn);NU1504;NU1505;NU1701</NoWarn>
     <!--#if (wasm-pwa-manifest)
     <WasmPWAManifestFile>manifest.webmanifest</WasmPWAManifestFile>

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -713,25 +713,6 @@
       "type": "parameter",
       "datatype": "text"
     },
-    "mauiVersion": {
-      "type": "generated",
-      "generator": "switch",
-      "replaces": "$DefaultMauiVersion$",
-      "parameters": {
-        "evaluator": "C++",
-        "datatype": "text",
-        "cases": [
-          {
-            "condition": "(tfm == 'net8.0')",
-            "value": "8.0.7"
-          },
-          {
-            "condition": "(tfm == 'net9.0')",
-            "value": "9.0.0-preview.1.9973"
-          }
-        ]
-      }
-    },
     "unoWasmBootstrapVersionDefault": {
       "type": "generated",
       "generator": "switch",

--- a/src/Uno.Templates/content/unoapp/AzurePipelines/steps/install-dependencies.yml
+++ b/src/Uno.Templates/content/unoapp/AzurePipelines/steps/install-dependencies.yml
@@ -20,6 +20,7 @@ steps:
     displayName: 'Use DotNet ${{ parameters.dotnetVersion }}'
     inputs:
       version: '${{ parameters.dotnetVersion }}'
+      includePreviewVersions: true
 
   # Install Windows SDK
   - task: PowerShell@2

--- a/src/Uno.Templates/content/unoapp/AzurePipelines/steps/install-dependencies.yml
+++ b/src/Uno.Templates/content/unoapp/AzurePipelines/steps/install-dependencies.yml
@@ -20,7 +20,6 @@ steps:
     displayName: 'Use DotNet ${{ parameters.dotnetVersion }}'
     inputs:
       version: '${{ parameters.dotnetVersion }}'
-      includePreviewVersions: true
 
   # Install Windows SDK
   - task: PowerShell@2

--- a/src/Uno.Templates/content/unolib-crossruntime/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unolib-crossruntime/.template.config/dotnetcli.host.json
@@ -1,6 +1,10 @@
 ﻿{
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
+    "tfm": {
+      "longName": "tfm",
+      "shortName": "tfm"
+    },
     "unoWinUIVersion": {
       "isHidden": true
     }

--- a/src/Uno.Templates/content/unolib-crossruntime/.template.config/template.json
+++ b/src/Uno.Templates/content/unolib-crossruntime/.template.config/template.json
@@ -34,6 +34,27 @@
     "3DDC01D0-8546-4FF6-8EFB-2E8D6B175A5B"  // UnoCrossRuntimeLib.Wasm
   ],
   "symbols": {
+    "tfm": {
+      "displayName": "Target Framework",
+      "type": "parameter",
+      "datatype": "choice",
+      "enableQuotelessLiterals": true,
+      "replaces": "$baseTargetFramework$",
+      "defaultValue": "net8.0",
+      "description": "Select the .NET version of your solution",
+      "choices": [
+        {
+          "choice": "net8.0",
+          "displayName": ".NET 8.0",
+          "description": "Target .NET 8.0 (Long Term Support)"
+        },
+        {
+          "choice": "net9.0",
+          "displayName": ".NET 9.0",
+          "description": "Target .NET 9.0 (Preview)"
+        }
+      ]
+    },
     "unoWinUIVersion": {
       "type": "parameter",
       "datatype": "text",

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Skia.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Skia.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
     <IsPackable>false</IsPackable>
     <UnoRuntimeIdentifier>skia</UnoRuntimeIdentifier>
     <DefineConstants>$(DefineConstants);WINUI;__SKIA__</DefineConstants>

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Wasm.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Wasm.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$baseTargetFramework$</TargetFramework>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);WINUI</DefineConstants>
     <OutputType>Library</OutputType>

--- a/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.csproj
+++ b/src/Uno.Templates/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$baseTargetFramework$-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$;$baseTargetFramework$-android;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <UnoRuntimeProjectReference Include="UnoCrossRuntimeLib.Skia.csproj" />

--- a/src/Uno.Templates/content/unolib/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unolib/.template.config/dotnetcli.host.json
@@ -1,6 +1,10 @@
 ﻿{
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
+    "tfm": {
+      "longName": "tfm",
+      "shortName": "tfm"
+    },
     "unoWinUIVersion": {
       "isHidden": true
     }

--- a/src/Uno.Templates/content/unolib/.template.config/template.json
+++ b/src/Uno.Templates/content/unolib/.template.config/template.json
@@ -36,6 +36,27 @@
     "2B1FDFB6-C93C-4CA1-A6AB-528C4B3654B9" // UWP
   ],
   "symbols": {
+    "tfm": {
+      "displayName": "Target Framework",
+      "type": "parameter",
+      "datatype": "choice",
+      "enableQuotelessLiterals": true,
+      "replaces": "$baseTargetFramework$",
+      "defaultValue": "net8.0",
+      "description": "Select the .NET version of your solution",
+      "choices": [
+        {
+          "choice": "net8.0",
+          "displayName": ".NET 8.0",
+          "description": "Target .NET 8.0 (Long Term Support)"
+        },
+        {
+          "choice": "net9.0",
+          "displayName": ".NET 9.0",
+          "description": "Target .NET 9.0 (Preview)"
+        }
+      ]
+    },
     "unoWinUIVersion": {
       "type": "parameter",
       "datatype": "text",

--- a/src/Uno.Templates/content/unolib/CrossTargetedLibrary.csproj
+++ b/src/Uno.Templates/content/unolib/CrossTargetedLibrary.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$baseTargetFramework$-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);$baseTargetFramework$;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst;$baseTargetFramework$-android</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Uno.Templates/content/unomauilib/.template.config/template.json
+++ b/src/Uno.Templates/content/unomauilib/.template.config/template.json
@@ -38,6 +38,11 @@
           "choice": "net8.0",
           "displayName": ".NET 8.0",
           "description": "Target .NET 8.0 (Long Term Support)"
+        },
+        {
+          "choice": "net9.0",
+          "displayName": ".NET 9.0",
+          "description": "Target .NET 9.0 (Preview)"
         }
       ]
     },


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #598 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Templates other than the main unoapp template only support net8.0

## What is the new behavior?

All templates now have the same tfm property to allow users to create a project with net8 or net9

