### PR TITLE
 fixing invalid reference for MauiVersion

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -807,7 +807,7 @@
         "cases": [
           {
             "condition": "(tfm == 'net8.0')",
-            "value": "8.0.5"
+            "value": "8.0.7"
           }
         ]
       }

--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <DotNetVersion>$baseTargetFramework$</DotNetVersion>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -26,14 +26,6 @@
     -->
     <NoWarn>$(NoWarn);NU1507;NETSDK1201;PRI257</NoWarn>
     <!--#endif-->
-    <!--#if (mauiEmbedding)-->
-
-    <MauiVersion Condition=" '$(MauiVersion)' == '' ">$DefaultMauiVersion$</MauiVersion>
-    <AndroidMaterialVersion  Condition=" '$(AndroidMaterialVersion)' == '' ">1.10.0.1</AndroidMaterialVersion>
-    <AndroidXNavigationVersion  Condition=" '$(AndroidXNavigationVersion)' == '' ">2.6.0.1</AndroidXNavigationVersion>
-    <AndroidXCollectionVersion  Condition=" '$(AndroidXCollectionVersion)' == '' ">1.3.0.1</AndroidXCollectionVersion>
-    <!--#endif-->
-
     <!-- Required for Hot Reload (See https://github.com/dotnet/sdk/issues/36666) -->
     <IncludeSourceRevisionInInformationalVersion Condition="'$(Configuration)'=='Debug'">false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/Directory.Build.targets
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.targets
@@ -1,4 +1,12 @@
 ﻿<Project>
+  <!--#if (mauiEmbedding)-->
+  <PropertyGroup>
+    <MauiVersion Condition=" '$(MauiVersion)' == '' ">$DefaultMauiVersion$</MauiVersion>
+    <AndroidMaterialVersion  Condition=" '$(AndroidMaterialVersion)' == '' ">1.10.0.1</AndroidMaterialVersion>
+    <AndroidXNavigationVersion  Condition=" '$(AndroidXNavigationVersion)' == '' ">2.6.0.1</AndroidXNavigationVersion>
+    <AndroidXCollectionVersion  Condition=" '$(AndroidXCollectionVersion)' == '' ">1.3.0.1</AndroidXCollectionVersion>
+  </PropertyGroup>
+  <!--#endif-->
 <!--#if (failBuildOnInvalidProjectName)-->
   <Target Name="InvalidProjectName"
           BeforeTargets="BeforeBuild">


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Versions are located in the Props file where the MauiVersion has not been set and we specify a version that isn't actually available on nuget.org

## What is the new behavior?

The versions are now in the targets and we've updated the MauiVersion to one that actually exists on NuGet.org