### PR TITLE
fix: uno-check parameter 'vswin' to '--skip vswin'

### DIFF
--- a/src/Uno.Templates/content/unoapp/GitHub/steps/install_dependencies/action.yml
+++ b/src/Uno.Templates/content/unoapp/GitHub/steps/install_dependencies/action.yml
@@ -39,7 +39,7 @@ runs:
           $target = $_.Replace("_win", "").Replace("_macos", "")
           if (![string]::IsNullOrEmpty($target)) {
             echo "target: $target"
-            uno-check -v --ci --non-interactive --fix --target $target vswin --skip vsmac --skip xcode --skip vswinworkloads --skip androidemulator --skip dotnetnewunotemplates
+            uno-check -v --ci --non-interactive --fix --target $target --skip vswin --skip vsmac --skip xcode --skip vswinworkloads --skip androidemulator --skip dotnetnewunotemplates
             echo "uno-check finished for target: $target "
           }
         })


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

Bugfix

## What is the current behavior?

CI step "Run Uno.Check" contains a wrong parameter:

Error: Unknown command 'vswin'.


## What is the new behavior?

fixed parameter

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
