### PR TITLE
Allow hiding the global json in the library template

### DIFF
--- a/src/Uno.Templates/content/unolib/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unolib/.template.config/dotnetcli.host.json
@@ -7,6 +7,10 @@
     },
     "unoWinUIVersion": {
       "isHidden": true
+    },
+    "globalJson": {
+      "shortName": "global-json",
+      "longName": "global-json"
     }
   }
 }

--- a/src/Uno.Templates/content/unolib/.template.config/template.json
+++ b/src/Uno.Templates/content/unolib/.template.config/template.json
@@ -62,6 +62,11 @@
       "datatype": "text",
       "defaultValue": "DefaultUnoWinUIVersion",
       "replaces": "$UnoWinUIVersion$"
+    },
+    "globalJson": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true"
     }
   },
   "primaryOutputs": [
@@ -72,6 +77,12 @@
   "sources": [
     {
       "modifiers": [
+        {
+          "condition": "(!globalJson)",
+          "exclude": [
+            "global.json"
+          ]
+        }
       ]
     }
   ]


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes unoplatform/uno-private#424

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

`global.json` is always included in the Library template

## What is the new behavior?

`global.json` is included by default, but there is a new template option that allows you to exclude the `global.json` so that you can easily add the library to an existing solution and use the `global.json` from your existing project.