### PR TITLE
fix: missing image assets

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -2159,8 +2159,14 @@
           "condition": "(!mauiEmbedding)",
           "exclude": [
             "MyExtensionsApp.1/Assets/Fonts/**",
-            "MyExtensionsApp.1/Assets/Images/**",
+            "MyExtensionsApp.1/Assets/Images/dotnet_bot.svg",
             "MyExtensionsApp.1.MauiControls/**"
+          ]
+        },
+        {
+          "condition": "(!useRegionsNav)",
+          "exclude": [
+            "MyExtensionsApp.1/Assets/Images/back.svg"
           ]
         },
         {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #636

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Images are missing

## What is the new behavior?

Images correctly show up

