### PR TITLE
SVG & Lottie Features

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -579,6 +579,20 @@
       "datatype": "bool",
       "defaultValue": "false"
     },
+    "unoSvg": {
+      "displayName": "Uno.WinUI.Svg",
+      "description": "Include Uno.WinUI.Svg for SVG support",
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false"
+    },
+    "unoLottie": {
+      "displayName": "Uno.WinUI.Lottie",
+      "description": "Include Uno.WinUI.Lottie for Lottie support",
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false"
+    },
     "dspGenerator": {
       "displayName": "Import DSP",
       "description": "Import a Design System Package (DSP) to override Material colors",

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -58,12 +58,16 @@
       <!--#endif-->
       <!--#if (useMaterial)-->
       Material;
-      <!--#endif-->
-      <!--#if (useCupertino)-->
+      <!--#elif (useCupertino)-->
       Cupertino;
+      <!--#elif (unoLottie)-->
+      Lottie
       <!--#endif-->
       <!--#if (mediaElement)-->
       MediaElement;
+      <!--#endif-->
+      <!--#if (unoSvg)-->
+      Svg;
       <!--#endif-->
       <!--#if (useDependencyInjection)-->
       Hosting;

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -114,7 +114,7 @@
       Navigation;
       <!--#endif-->
       <!--#if (themeService)-->
-      ThemeService;
+      ExtensionsCore;
       <!--#endif-->
     </UnoFeatures>
   </PropertyGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Incorrect Feature added for ThemeService. No feature flags exist for SVG and Lottie

## What is the new behavior?

The Correct `ExtensionsCore` Feature is added for the ThemeService. SVG and Lottie have been added as options. `Lottie` is only added when using the default Fluent from WinUI/Uno.WinUI. Both Material and Cupertino themes have dependencies on Lottie.