### PR TITLE
fix: Make windows10.0.19041 last in TargetFrameworks

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -10,9 +10,6 @@
       <!--#if (useMacCatalyst)-->
       $baseTargetFramework$-maccatalyst;
       <!--#endif-->
-      <!--#if (useWinAppSdk)-->
-      $baseTargetFramework$-windows10.0.19041;
-      <!--#endif-->
       <!--#if (useUnitTests)-->
       $baseTargetFramework$;
       <!--#endif-->
@@ -21,6 +18,9 @@
       <!--#endif-->
       <!--#if (useWasm)-->
       $baseTargetFramework$-browserwasm;
+      <!--#endif-->
+      <!--#if (useWinAppSdk)-->
+      $baseTargetFramework$-windows10.0.19041;
       <!--#endif-->
     </TargetFrameworks>
 


### PR DESCRIPTION
When making the project, if the mobile platforms are not selected, and only desktop, wasm, and WinUI are chosen, then windows10.0.19041 becomes first which then causes an UNOB0012 warning

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
