### PR TITLE
Remove unused xmlns for wasm

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.xaml
@@ -5,10 +5,7 @@
 <!--#else-->
 <Application x:Class="MyExtensionsApp._1.App"
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-       xmlns:wasm="http://platform.uno/wasm"$useThemesResourceNamespace$
-       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-       mc:Ignorable="wasm">
+       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"$useThemesResourceNamespace$>
 
   <Application.Resources>
     <ResourceDictionary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #664

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Recommended preset includes xmlns for wasm


## What is the new behavior?

We no longer reference the unused xmlns for wasm in any version of the template