### PR TITLE
Adding ScrollViewer to ensure all content is viewable

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MainPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MainPage.xaml
@@ -6,29 +6,31 @@
       xmlns:controls="using:MyExtensionsApp._1.MauiControls"
 <!--#endif-->
       Background="{ThemeResource $themeBackgroundBrush$}">
-  <StackPanel$toolkitSafeArea$
-        HorizontalAlignment="Center"
-        VerticalAlignment="Center">
-    <TextBlock AutomationProperties.AutomationId="HelloTextBlock"
-          Text="Hello Uno Platform"
-          HorizontalAlignment="Center" />
+  <ScrollViewer>
+    <StackPanel$toolkitSafeArea$
+          HorizontalAlignment="Center"
+          VerticalAlignment="Center">
+      <TextBlock AutomationProperties.AutomationId="HelloTextBlock"
+            Text="Hello Uno Platform"
+            HorizontalAlignment="Center" />
 <!--#if (mauiEmbedding)-->
 <!--#if (useNonMauiPlatforms)-->
-    <maui:Grid>
+      <maui:Grid>
+        <embed:MauiHost x:Name="MauiHostElement"
+                xmlns:embed="using:Uno.Extensions.Maui"
+                Source="controls:EmbeddedControl" />
+      </maui:Grid>
+      <not_maui:Grid>
+        <TextBlock AutomationProperties.AutomationId="NotMauiTextBlock"
+            Text="Alternative content for Non-Maui targets"
+            HorizontalAlignment="Center" />
+      </not_maui:Grid>
+<!--#else-->
       <embed:MauiHost x:Name="MauiHostElement"
               xmlns:embed="using:Uno.Extensions.Maui"
               Source="controls:EmbeddedControl" />
-    </maui:Grid>
-    <not_maui:Grid>
-      <TextBlock AutomationProperties.AutomationId="NotMauiTextBlock"
-           Text="Alternative content for Non-Maui targets"
-           HorizontalAlignment="Center" />
-    </not_maui:Grid>
-<!--#else-->
-    <embed:MauiHost x:Name="MauiHostElement"
-            xmlns:embed="using:Uno.Extensions.Maui"
-            Source="controls:EmbeddedControl" />
 <!--#endif-->
 <!--#endif-->
-  </StackPanel>
+    </StackPanel>
+  </ScrollViewer>
 </Page>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainPage.xaml
@@ -7,49 +7,50 @@
 <!--#endif-->
       NavigationCacheMode="Required"
       Background="{ThemeResource $themeBackgroundBrush$}">
-
-  <Grid$toolkitSafeArea$>
-    <Grid.RowDefinitions>
-      <RowDefinition Height="Auto" />
-      <RowDefinition />
-    </Grid.RowDefinitions>
+  <ScrollViewer>
+    <Grid$toolkitSafeArea$>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto" />
+        <RowDefinition />
+      </Grid.RowDefinitions>
 <!--#if (useToolkit)-->
-    <utu:NavigationBar Content="{Binding Title}" />
+      <utu:NavigationBar Content="{Binding Title}" />
 <!--#else-->
-    <TextBlock Text="{Binding Title}" HorizontalAlignment="Center" />
+      <TextBlock Text="{Binding Title}" HorizontalAlignment="Center" />
 <!--#endif-->
 
-    <StackPanel Grid.Row="1"
-          HorizontalAlignment="Center"
-          VerticalAlignment="Center"
-          Spacing="16">
+      <StackPanel Grid.Row="1"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Spacing="16">
 <!--#if (mauiEmbedding)-->
 <!--#if (useNonMauiPlatforms)-->
-      <maui:Grid>
+        <maui:Grid>
+          <embed:MauiHost x:Name="MauiHostElement"
+                  xmlns:embed="using:Uno.Extensions.Maui"
+                  Source="controls:EmbeddedControl" />
+        </maui:Grid>
+        <not_maui:Grid>
+          <TextBlock AutomationProperties.AutomationId="NotMauiTextBlock"
+            Text="Alternative content for Non-Maui targets"
+            HorizontalAlignment="Center" />
+        </not_maui:Grid>
+<!--#else-->
         <embed:MauiHost x:Name="MauiHostElement"
                 xmlns:embed="using:Uno.Extensions.Maui"
                 Source="controls:EmbeddedControl" />
-      </maui:Grid>
-      <not_maui:Grid>
-        <TextBlock AutomationProperties.AutomationId="NotMauiTextBlock"
-          Text="Alternative content for Non-Maui targets"
-          HorizontalAlignment="Center" />
-      </not_maui:Grid>
-<!--#else-->
-      <embed:MauiHost x:Name="MauiHostElement"
-              xmlns:embed="using:Uno.Extensions.Maui"
-              Source="controls:EmbeddedControl" />
 <!--#endif-->
 <!--#endif-->
-      <TextBox Text="{Binding Name, Mode=TwoWay}"
-          PlaceholderText="Enter your name:" />
-      <Button Content="Go to Second Page"
-          AutomationProperties.AutomationId="SecondPageButton"
-          Command="{Binding GoToSecond}" />
+        <TextBox Text="{Binding Name, Mode=TwoWay}"
+            PlaceholderText="Enter your name:" />
+        <Button Content="Go to Second Page"
+            AutomationProperties.AutomationId="SecondPageButton"
+            Command="{Binding GoToSecond}" />
 <!--#if (useAuthentication)-->
-      <Button Content="Logout"
-          Command="{Binding Logout}" />
+        <Button Content="Logout"
+            Command="{Binding Logout}" />
 <!--#endif-->
-    </StackPanel>
-  </Grid>
+      </StackPanel>
+    </Grid>
+  </ScrollViewer>
 </Page>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #649 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Page content is in a Grid/StackPanel


## What is the new behavior?

Page content is wrapped in a ScrollViewer to ensure that if you rotate the screen on a phone the content will still remain viewable.
