### PR TITLE
Use ThemeService alias for ThemeService template option

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -114,7 +114,7 @@
       Navigation;
       <!--#endif-->
       <!--#if (themeService)-->
-      ExtensionsCore;
+      ThemeService;
       <!--#endif-->
     </UnoFeatures>
   </PropertyGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

ThemeService template option is tied to the ExtensionsCore UnoFeature

## What is the new behavior?

ThemeService template option is now tied to the ExtensionsCore alias ThemeService