### PR TITLE
Update bug-report.yml to include Rider in Template Host

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -45,6 +45,7 @@ body:
       options:
         - dotnet new
         - Visual Studio
+        - Rider
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?
Added Rider as an option for a Template Host in the Bug Report template because latest Rider 2024.1 EAP now supports CLI templates
