### PR TITLE
Single Line TFMs for Single Project

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1354,38 +1354,1029 @@
         "datatype": "string",
         "cases": [
           {
-            "condition": "tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
             "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
             "value": "net8.0;net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android;net8.0-ios"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
             "value": "net8.0;net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-android;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android;net8.0-maccatalyst;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-android;net8.0-maccatalyst;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android;net8.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-android;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android;net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-android;net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android;net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-android;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-android;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-android"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
             "value": "net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-ios;net8.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-ios;net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-ios;net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-ios;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-ios;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-ios;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-ios"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-maccatalyst;net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-maccatalyst;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-maccatalyst;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0-android;net8.0-ios;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-android;net8.0-ios;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-android;net8.0-ios;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0-android;net8.0-ios"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0-android;net8.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0-android;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-android;net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-android;net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0-android;net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0-android;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-android;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-android;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0-android"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0-ios;net8.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-ios;net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0-ios;net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0-ios;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-ios;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-ios;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0-ios"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-maccatalyst;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-maccatalyst;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-windows10.0.19041;net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-windows10.0.19041;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net8.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net8.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": ""
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
             "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android;net9.0-ios"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-android;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android;net9.0-maccatalyst;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-android;net9.0-maccatalyst;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android;net9.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-android;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android;net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-android;net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android;net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-android;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-android;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-android"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-ios;net9.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-ios;net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-ios;net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-ios;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-ios;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-ios;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-ios"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-maccatalyst;net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-maccatalyst;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-maccatalyst;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0-android;net9.0-ios;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-android;net9.0-ios;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-android;net9.0-ios;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0-android;net9.0-ios"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0-android;net9.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0-android;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-android;net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-android;net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0-android;net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0-android;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-android;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-android;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0-android"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0-ios;net9.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-ios;net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0-ios;net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0-ios;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-ios;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-ios;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0-ios"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-maccatalyst;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-maccatalyst;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-windows10.0.19041;net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-windows10.0.19041;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "value": "net9.0-windows10.0.19041"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "value": "net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "value": "net9.0-browserwasm"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "value": "net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "value": ""
           }
-          // Additional combinations for net9.0 without unit tests
         ]
       }
     },

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1345,6 +1345,50 @@
         ]
       }
     },
+    "singleProjectTfms": {
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "$SingleProjectTFMs$",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
+            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
+            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
+            "value": "net8.0;net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
+            "value": "net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop",
+            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+          }
+          // Additional combinations for net9.0 without unit tests
+        ]
+      }
+    },
     "toolkitNamespace": {
       "type": "generated",
       "generator": "switch",

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -1,28 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>
-      <!--#if (useAndroid)-->
-      $baseTargetFramework$-android;
-      <!--#endif-->
-      <!--#if (useIOS)-->
-      $baseTargetFramework$-ios;
-      <!--#endif-->
-      <!--#if (useMacCatalyst)-->
-      $baseTargetFramework$-maccatalyst;
-      <!--#endif-->
-      <!--#if (useWinAppSdk)-->
-      $baseTargetFramework$-windows10.0.19041;
-      <!--#endif-->
-      <!--#if (useUnitTests)-->
-      $baseTargetFramework$;
-      <!--#endif-->
-      <!--#if (useDesktop)-->
-      $baseTargetFramework$-desktop;
-      <!--#endif-->
-      <!--#if (useWasm)-->
-      $baseTargetFramework$-browserwasm;
-      <!--#endif-->
-    </TargetFrameworks>
+    <TargetFrameworks>$SingleProjectTFMs$</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/tools/TemplateTfmSwitchGenerator/.gitignore
+++ b/tools/TemplateTfmSwitchGenerator/.gitignore
@@ -1,0 +1,1 @@
+template.json

--- a/tools/TemplateTfmSwitchGenerator/Platform.cs
+++ b/tools/TemplateTfmSwitchGenerator/Platform.cs
@@ -1,0 +1,12 @@
+namespace TemplateTfmSwitchGenerator;
+
+public record Platform(string TrueCondition, string FalseCondition, string? Runtime)
+{
+    public string GetTfm(string dotnetVersion)
+    {
+        if (string.IsNullOrEmpty(Runtime))
+            return dotnetVersion;
+
+        return $"{dotnetVersion}-{Runtime}";
+    }
+}

--- a/tools/TemplateTfmSwitchGenerator/Program.cs
+++ b/tools/TemplateTfmSwitchGenerator/Program.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using TemplateTfmSwitchGenerator;
+
+var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+{
+    WriteIndented = true,
+};
+Platform[] platforms = [
+    new Platform("useUnitTests == true", "useUnitTests == false", null),
+    new Platform("platforms == android", "platforms != android", "android"),
+    new Platform("platforms == ios", "platforms != ios", "ios"),
+    new Platform("platforms == maccatalyst", "platforms != maccatalyst", "maccatalyst"),
+    new Platform("platforms == windows", "platforms != windows", "windows10.0.19041"),
+    new Platform("platforms == wasm", "platforms != wasm", "browserwasm"),
+    new Platform("platforms == desktop", "platforms != desktop", "desktop")
+];
+
+string[] runtimes = ["net8.0", "net9.0"];
+
+var cases = new List<TemplateSwitchCase>();
+foreach (var runtime in runtimes)
+{
+    var results = GenerateTemplateSwitchCases(platforms, runtime);
+    cases.AddRange(results);
+}
+
+var json = JsonSerializer.Serialize(cases, options)
+    .Replace(@"\u0026", "&")
+    .Replace(@"\u0027", "'");
+File.WriteAllText("template.json", json);
+Console.WriteLine(json);
+
+static IEnumerable<TemplateSwitchCase> GenerateTemplateSwitchCases(Platform[] platforms, string runtime)
+{
+    var cases = new List<TemplateSwitchCase>();
+    var initialCondition = $"tfm == '{runtime}' && ";
+    GenerateCases(platforms, 0, initialCondition, "", cases, runtime);
+    return cases;
+}
+
+static void GenerateCases(Platform[] platforms, int index, string currentCondition, string currentTfm, List<TemplateSwitchCase> cases, string runtime)
+{
+    if (index == platforms.Length)
+    {
+        var finalizedCondition = $"({currentCondition.Trim(' ', '&')})";
+        cases.Add(new TemplateSwitchCase(finalizedCondition, currentTfm.TrimEnd(';', ' ')));
+        return;
+    }
+
+    string trueCondition = platforms[index].TrueCondition;
+    string falseCondition = platforms[index].FalseCondition;
+    string trueTfm = platforms[index].GetTfm(runtime) + ";";
+
+    // Include true condition
+    GenerateCases(platforms, index + 1, $"{currentCondition}{trueCondition} && ", $"{currentTfm}{trueTfm}", cases, runtime);
+
+    // Include false condition
+    GenerateCases(platforms, index + 1, $"{currentCondition}{falseCondition} && ", currentTfm, cases, runtime);
+}

--- a/tools/TemplateTfmSwitchGenerator/TemplateSwitchCase.cs
+++ b/tools/TemplateTfmSwitchGenerator/TemplateSwitchCase.cs
@@ -1,0 +1,5 @@
+using System.Text.Json.Serialization;
+
+namespace TemplateTfmSwitchGenerator;
+
+public record TemplateSwitchCase([property: JsonPropertyName("condition")]string Condition, [property: JsonPropertyName("value")] string Value);

--- a/tools/TemplateTfmSwitchGenerator/TemplateTfmSwitchGenerator.csproj
+++ b/tools/TemplateTfmSwitchGenerator/TemplateTfmSwitchGenerator.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #654

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Target Frameworks are each provided on a new line

## What is the new behavior?

Target Frameworks are each provided on a single line. This additionally adds a CLI tool that we can use to add additional Target Frameworks for instance if we wanted to bring back Tizen support in the future, as well as the ability to add/modify the supported TFMs such as when .NET 10 is introduced next year. This will quickly regenerate the TFM conditions making this easier to maintain over time.