### PR TITLE
Update Appxmanifest

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -2,7 +2,7 @@
   <Import Project="Directory.UnoMetadata.targets" />
 
   <PropertyGroup>
-    <UnoVersion Condition="'$(UnoVersion)' == ''">5.3.0-dev.708</UnoVersion>
+    <UnoVersion Condition="'$(UnoVersion)' == ''">5.3.0-dev.1451</UnoVersion>
     <UnoExtensionsVersion Condition="'$(UnoExtensionsVersion)' == ''">4.2.0-dev.36</UnoExtensionsVersion>
     <UnoThemesVersion Condition="'$(UnoThemesVersion)' == ''">5.1.0-dev.19</UnoThemesVersion>
     <UnoToolkitVersion Condition="'$(UnoToolkitVersion)' == ''">6.1.0-dev.11</UnoToolkitVersion>
@@ -24,7 +24,7 @@
 
     <!-- UWP Legacy Templates -->
     <MicrosoftWindowsSDKBuildToolsVersion Condition="'$(MicrosoftWindowsSDKBuildToolsVersion)' == ''">10.0.22621.3233</MicrosoftWindowsSDKBuildToolsVersion>
-    <MicrosoftWindowsAppSDKVersion Condition="'$(MicrosoftWindowsAppSDKVersion)' == ''">1.5.240227000</MicrosoftWindowsAppSDKVersion>
+    <MicrosoftWindowsAppSDKVersion Condition="'$(MicrosoftWindowsAppSDKVersion)' == ''">1.5.240428000</MicrosoftWindowsAppSDKVersion>
     <UnoUniversalImageLoaderVersion Condition="'$(UnoUniversalImageLoaderVersion)' == ''">1.9.36</UnoUniversalImageLoaderVersion>
     <XamarinGoogleAndroidMaterialVersion Condition="'$(XamarinGoogleAndroidMaterialVersion)' == ''">1.10.0.2</XamarinGoogleAndroidMaterialVersion>
   </PropertyGroup>

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -144,28 +144,12 @@
       "type": "parameter",
       "datatype": "string"
     },
-    "publisherDefault": {
-      "type": "generated",
-      "generator": "join",
-      "parameters": {
-        "symbols": [
-          {
-            "type": "const",
-            "value": "O="
-          },
-          {
-            "type": "ref",
-            "value": "name"
-          }
-        ]
-      }
-    },
     "publisherEvaluator": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
         "sourceVariableName": "publisher",
-        "fallbackVariableName": "publisherDefault"
+        "fallbackVariableName": "name"
       }
     },
     "publisherEvaluatorSanitizer": {

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -12,6 +12,10 @@
     <!-- Versions -->
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>
+    <!-- Package Publisher -->
+    <ApplicationPublisher>$appPublisher$</ApplicationPublisher>
+    <!-- Package Description -->
+    <Description>MyExtensionsApp.1 powered by Uno Platform.</Description>
     <!--#if (useWinAppSdk) -->
     <!--
       If you encounter this error message:

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Package.appxmanifest
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Package.appxmanifest
@@ -1,25 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
+<?xml version="1.0" encoding="utf-8"?>
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
-
-  <Identity
-    Name="$identityName$"
-    Publisher="$appPublisher$"
-    Version="1.0.0.0" />
-
-  <Properties>
-    <DisplayName>MyExtensionsApp.1</DisplayName>
-    <PublisherDisplayName>MyExtensionsApp.1</PublisherDisplayName>
-  </Properties>
-
-  <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-  </Dependencies>
 
   <Resources>
     <Resource Language="x-generate"/>
@@ -29,11 +13,6 @@
     <Application Id="App"
       Executable="$targetnametoken$.exe"
       EntryPoint="$targetentrypoint$">
-      <uap:VisualElements
-        DisplayName="MyExtensionsApp.1"
-        Description="MyExtensionsApp.1">
-        <uap:SplashScreen />
-      </uap:VisualElements>
 <!--#if (useProtocolRedirect)-->
       <Extensions>
       <uap:Extension Category="windows.protocol">


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes unoplatform/uno#16618

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature

## What is the current behavior?

Package.appxmanifest explicitly sets a number of properties that should be set by existing MSBuild properties for Single Project.

## What is the new behavior?

Package.appxmanifest has now been simplified with the Single Project MSBuild properties being used to properly set values like the App Name, Title, Description, Version, supported version ranges for Windows and package publisher.