### PR TITLE
chore: Remove the "Design System Package" term for Uno DSP

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -579,7 +579,7 @@
     },
     "dspGenerator": {
       "displayName": "Import Uno DSP",
-      "description": "Import a Uno DSP (Design System Package) theme file to override Material colors",
+      "description": "Import a Uno DSP theme file to override Material colors",
       "type": "parameter",
       "datatype": "bool"
     },


### PR DESCRIPTION
Removing the "Design System Package" term for Uno DSP.
Related issue: https://github.com/unoplatform/private/issues/442