### PR TITLE
fix: Don't include the azure workload suggestion

### DIFF
--- a/src/Uno.Templates/content/unoapp/.vsconfig
+++ b/src/Uno.Templates/content/unoapp/.vsconfig
@@ -16,8 +16,6 @@
     "Microsoft.VisualStudio.Component.Web",
     "Microsoft.VisualStudio.ComponentGroup.Web.Client",
     "Microsoft.VisualStudio.Workload.NetWeb",
-    "Microsoft.VisualStudio.ComponentGroup.Azure.Prerequisites",
-    "Microsoft.VisualStudio.Workload.Azure",
     "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.TemplateEngine",
 #//#endif
 #//#if (useWinAppSdk)


### PR DESCRIPTION
This workload is not needed to build wasm apps.