### PR TITLE
Private feed Fix

### DIFF
--- a/tools/Uno.Sdk.Updater/Program.cs
+++ b/tools/Uno.Sdk.Updater/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Compression;
+using System.IO.Compression;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -38,6 +38,7 @@ if (!versions.Any())
 }
 
 var unoVersion = versions.OrderByDescending(x => x).First();
+client.UnoVersion = unoVersion;
 
 Console.WriteLine($"Found Uno Version: {unoVersion}");
 Console.WriteLine($"Downloading {UnoSdkPackageId}");
@@ -268,11 +269,12 @@ static async Task<ManifestGroup> UpdateGroup(ManifestGroup group, NuGetVersion u
 
     var preview = unoVersion.IsPreview;
     string[] stableOnlyGroups = [
-    "CoreLogging",
-    "OSLogging",
-    "UniversalImageLoading",
-    "WasmBootstrap"
-];
+        "CoreLogging",
+        "OSLogging",
+        "UniversalImageLoading",
+        "WasmBootstrap"
+    ];
+
     if (stableOnlyGroups.Any(x => x == group.Group))
     {
         preview = false;

--- a/tools/Uno.Sdk.Updater/Services/NuGetClient.cs
+++ b/tools/Uno.Sdk.Updater/Services/NuGetClient.cs
@@ -15,6 +15,8 @@ internal class NuGetApiClient : IDisposable
 		BaseAddress = new Uri("https://pkgs.dev.azure.com")
 	};
 
+	public NuGetVersion? UnoVersion { get; set; }
+
 	public async Task<Stream> DownloadPackageAsync(string packageId, string version)
 	{
 		var downloadUrl = $"/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_apis/packaging/feeds/e7ce08df-613a-41a3-8449-d42784dd45ce/nuget/packages/{packageId}/versions/{version}/content";
@@ -36,9 +38,13 @@ internal class NuGetApiClient : IDisposable
 	{
 		var allVersions = new List<string>();
 		var publicVersions = await GetPublicPackageVersions(packageId);
-		var privateVersions = await GetPrivatePackageVersions(packageId);
 		allVersions.AddRange(publicVersions);
-		allVersions.AddRange(privateVersions);
+
+		if (!UnoVersion.HasValue || !UnoVersion.Value.IsPreview)
+		{
+			var privateVersions = await GetPrivatePackageVersions(packageId);
+			allVersions.AddRange(privateVersions);
+		}
 
 		var output = new List<NuGetVersion>();
 		foreach (var version in allVersions.Distinct())


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes #764

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Project automation

## What is the current behavior?

The Updater is always using the Private Feed to lookup available packages


## What is the new behavior?

The Updater will only use the Private Feed to lookup available packages if the UnoVersion has not been set or the UnoVersion is for a Stable branch.

This ensures that the latest available version selected in dev is always publicly available.