### PR TITLE
fix: Use jsonc for global.json in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "global.json": "jsonc"
+    }
+}

--- a/src/Uno.Templates/content/unoapp/.vscode/settings.json
+++ b/src/Uno.Templates/content/unoapp/.vscode/settings.json
@@ -3,5 +3,8 @@
   "explorer.fileNesting.expand": false,
   "explorer.fileNesting.patterns": {
     "*.xaml": "$(capture).xaml.cs"
+  },
+  "files.associations": {
+    "global.json": "jsonc"
   }
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.templates/issues/767, closes https://github.com/unoplatform/uno.templates/pull/768