### PR TITLE
fix: Don't allow prerelease by default

### DIFF
--- a/build/.azure-pipelines.TemplateValidation.yml
+++ b/build/.azure-pipelines.TemplateValidation.yml
@@ -38,7 +38,7 @@ jobs:
             "CustomAuthMvux;;-preset=recommended -auth=custom",
             "CustomAuthMvvm;;-preset=recommended -presentation mvvm -auth=custom",
             "CustomAuthMvuxCSharp;;-preset=recommended -auth=custom -markup csharp",
-            "CustomAuthMvvmCSharp;-preset=recommended -presentation mvvm -auth=custom -markup csharp",
+            "CustomAuthMvvmCSharp;;-preset=recommended -presentation mvvm -auth=custom -markup csharp",
             "WebAuthMvux;;-preset=recommended -auth=web",
             "WebAuthMvvm;;-preset=recommended -presentation mvvm -auth=web",
             "WebAuthMvuxCSharp;;-preset=recommended -auth=web -markup csharp",

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -321,6 +321,7 @@
     "AllowPrereleaseNetSdk": {
       "type": "generated",
       "generator": "switch",
+      "replaces": "$AllowPrereleaseNetSdk$",
       "parameters": {
         "evaluator": "C++",
         "datatype": "string",

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -318,6 +318,24 @@
         }
       ]
     },
+    "AllowPrereleaseNetSdk": {
+      "type": "generated",
+      "generator": "switch",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "(tfm == 'net8.0')",
+            "value": "false"
+          },
+          {
+            "condition": "(tfm == 'net9.0')",
+            "value": "true"
+          }
+        ]
+      }
+    },
     "presetTestsDefault": {
       "type": "generated",
       "generator": "switch",

--- a/src/Uno.Templates/content/unoapp/global.json
+++ b/src/Uno.Templates/content/unoapp/global.json
@@ -1,6 +1,9 @@
-{
+{ 
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
     "Uno.Sdk": "$UnoSdkVersion$"
+  },
+  "sdk":{
+    "allowPrerelease": false
   }
 }

--- a/src/Uno.Templates/content/unoapp/global.json
+++ b/src/Uno.Templates/content/unoapp/global.json
@@ -1,4 +1,4 @@
-{ 
+{
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
     "Uno.Sdk": "$UnoSdkVersion$"

--- a/src/Uno.Templates/content/unoapp/global.json
+++ b/src/Uno.Templates/content/unoapp/global.json
@@ -4,6 +4,6 @@
     "Uno.Sdk": "$UnoSdkVersion$"
   },
   "sdk":{
-    "allowPrerelease": false
+    "allowPrerelease": $AllowPrereleaseNetSdk$
   }
 }


### PR DESCRIPTION
This will prevent getting started issues when having .NET 9 installed.