### PR TITLE
fix: Remove unused vsconfig dependencies

### DIFF
--- a/src/Uno.Templates/content/unoapp/.vsconfig
+++ b/src/Uno.Templates/content/unoapp/.vsconfig
@@ -19,15 +19,11 @@
     "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.TemplateEngine",
 #//#endif
 #//#if (useWinAppSdk)
-    "Microsoft.VisualStudio.Component.Windows10SDK.19041",
     "Microsoft.VisualStudio.ComponentGroup.MSIX.Packaging",
 #//#endif
     "Microsoft.VisualStudio.Component.ManagedDesktop.Prerequisites",
     "Microsoft.VisualStudio.Component.Debugger.JustInTime",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
-    "Microsoft.Component.NetFX.Native",
-    "Microsoft.VisualStudio.Component.Graphics",
-    "Microsoft.VisualStudio.Component.Merq",
 #//#if (useIOS)
     "Component.Xamarin.RemotedSimulator",
 #//#endif
@@ -37,7 +33,6 @@
 #//#endif
 #//#if (useAndroid)
     "Component.Android.SDK34",
-    "Component.Android.SDK33",
     "Component.OpenJDK",
 #//#endif
     "Microsoft.VisualStudio.Workload.NetCrossPlat",

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.sln
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.sln
@@ -41,6 +41,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.targets = Directory.Build.targets
 		global.json = global.json
 		Directory.Packages.props = Directory.Packages.props
+		.vsconfig = .vsconfig
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
The Windows SDK is not used when building apps, it's only needed when packaging an app for the store.

Related to https://github.com/unoplatform/uno/issues/17265.