### PR TITLE
Sdk Updater - Uno Version Validation

### DIFF
--- a/tools/Uno.Sdk.Updater/Program.cs
+++ b/tools/Uno.Sdk.Updater/Program.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using Uno.Sdk.Models;
 using Uno.Sdk.Services;
 using Uno.Sdk.Updater;
+using Uno.Sdk.Updater.Utils;
 
 const string UnoSdkPackageId = "Uno.Sdk.Private";
 
@@ -288,7 +289,8 @@ static async Task<ManifestGroup> UpdateGroup(ManifestGroup group, NuGetVersion u
         preview = false;
     }
 
-    var packageId = group.Packages.First();
+    var packageId = group.Packages.FirstOrDefault(x => x.Contains("WinUI", StringComparison.InvariantCultureIgnoreCase) && x.Contains("Uno", StringComparison.InvariantCultureIgnoreCase)) ??
+        group.Packages.First();
 
     var version = await client.GetVersionAsync(packageId, preview);
     var newGroup = group with { Version = version };

--- a/tools/Uno.Sdk.Updater/Program.cs
+++ b/tools/Uno.Sdk.Updater/Program.cs
@@ -293,6 +293,7 @@ static async Task<ManifestGroup> UpdateGroup(ManifestGroup group, NuGetVersion u
         group.Packages.First();
 
     var version = await client.GetVersionAsync(packageId, preview);
+    version = !string.IsNullOrEmpty(group.Version) && NuGetVersion.Parse(version) < NuGetVersion.Parse(group.Version) ? group.Version : version;
     var newGroup = group with { Version = version };
 
     if (group.Version != newGroup.Version)
@@ -316,6 +317,8 @@ static async Task<ManifestGroup> UpdateGroup(ManifestGroup group, NuGetVersion u
             {
                 Console.WriteLine($"Updated Version Override for '{group.Group}' - '{key}' to '{version}'.");
             }
+
+            version = NuGetVersion.Parse(version) < versionOverride ? versionOverrideString : version;
             updatedOverrides.Add(key, version);
         }
 

--- a/tools/Uno.Sdk.Updater/Services/NuGetClient.cs
+++ b/tools/Uno.Sdk.Updater/Services/NuGetClient.cs
@@ -111,7 +111,7 @@ internal class NuGetApiClient : IDisposable
     private bool RequiresValidation(string packageId) =>
         UnoVersion is not null && 
         packageId.Contains("Uno", StringComparison.InvariantCultureIgnoreCase) &&
-        !packageId.Contains("Sdk", StringComparison.InvariantCultureIgnoreCase);
+        !packageId.StartsWith("Uno.Sdk", StringComparison.InvariantCultureIgnoreCase);
 
     private async Task<bool> ValidatePackage(string packageId, NuGetVersion version)
     {

--- a/tools/Uno.Sdk.Updater/Services/NuGetClient.cs
+++ b/tools/Uno.Sdk.Updater/Services/NuGetClient.cs
@@ -1,109 +1,237 @@
+#nullable enable
 using System.Net.Http.Json;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
 using Uno.Sdk.Models;
+using Uno.Sdk.Updater.Utils;
 
 namespace Uno.Sdk.Services;
 
 internal class NuGetApiClient : IDisposable
 {
-	private HttpClient PublicNuGetClient { get; } = new HttpClient
-	{
-		BaseAddress = new Uri("https://api.nuget.org")
-	};
+    private const string UnoWinUIPackageId = "Uno.WinUI";
+    private static PackageValidationRecord _validation = new ();
 
-	private HttpClient PrivateNuGetClient { get; } = new HttpClient
-	{
-		BaseAddress = new Uri("https://pkgs.dev.azure.com")
-	};
+    private HttpClient PublicNuGetClient { get; } = new HttpClient
+    {
+        BaseAddress = new Uri("https://api.nuget.org")
+    };
 
-	public NuGetVersion? UnoVersion { get; set; }
+    private HttpClient PrivateNuGetClient { get; } = new HttpClient
+    {
+        BaseAddress = new Uri("https://pkgs.dev.azure.com")
+    };
 
-	public async Task<Stream> DownloadPackageAsync(string packageId, string version)
-	{
-		var downloadUrl = $"/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_apis/packaging/feeds/e7ce08df-613a-41a3-8449-d42784dd45ce/nuget/packages/{packageId}/versions/{version}/content";
-		using var response = await PrivateNuGetClient.GetAsync(downloadUrl);
+    public NuGetVersion? UnoVersion { get; set; }
 
-		if (!response.IsSuccessStatusCode)
-			return Stream.Null;
+    public async Task<Stream> DownloadPackageAsync(string packageId, string version)
+    {
+        var downloadUrl = $"/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_apis/packaging/feeds/e7ce08df-613a-41a3-8449-d42784dd45ce/nuget/packages/{packageId}/versions/{version}/content";
+        using var response = await PrivateNuGetClient.GetAsync(downloadUrl);
 
-		using var tempStream = await response.Content.ReadAsStreamAsync();
-		var memoryStream = new MemoryStream();
-		await tempStream.CopyToAsync(memoryStream);
+        if (!response.IsSuccessStatusCode)
+            return Stream.Null;
 
-		return memoryStream;
-	}
+        using var tempStream = await response.Content.ReadAsStreamAsync();
+        var memoryStream = new MemoryStream();
+        await tempStream.CopyToAsync(memoryStream);
 
-	internal record VersionsResponse(string[] Versions);
+        return memoryStream;
+    }
 
-	public async Task<IEnumerable<NuGetVersion>> GetPackageVersions(string packageId)
-	{
-		var allVersions = new List<string>();
-		var publicVersions = await GetPublicPackageVersions(packageId);
-		allVersions.AddRange(publicVersions);
+    internal record VersionsResponse(string[] Versions);
 
-		if (!UnoVersion.HasValue || !UnoVersion.Value.IsPreview)
-		{
-			var privateVersions = await GetPrivatePackageVersions(packageId);
-			allVersions.AddRange(privateVersions);
-		}
+    public async Task<IEnumerable<NuGetVersion>> GetPackageVersions(string packageId)
+    {
+        var allVersions = new List<string>();
+        var publicVersions = await GetPublicPackageVersions(packageId);
+        allVersions.AddRange(publicVersions);
 
-		var output = new List<NuGetVersion>();
-		foreach (var version in allVersions.Distinct())
-		{
-			if (NuGetVersion.TryParse(version, out var nugetVersion))
-			{
-				output.Add(nugetVersion);
-			}
-		}
+        if (!UnoVersion.HasValue || !UnoVersion.Value.IsPreview)
+        {
+            var privateVersions = await GetPrivatePackageVersions(packageId);
+            allVersions.AddRange(privateVersions);
+        }
 
-		return output.OrderByDescending(x => x);
-	}
+        var output = new List<NuGetVersion>();
+        foreach (var version in allVersions.Distinct())
+        {
+            if (NuGetVersion.TryParse(version, out var nugetVersion))
+            {
+                output.Add(nugetVersion);
+            }
+        }
 
-	private async Task<IEnumerable<string>> GetPrivatePackageVersions(string packageId)
-	{
-		try
-		{
-			var response = await PrivateNuGetClient.GetFromJsonAsync<VersionsResponse>($"/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/e7ce08df-613a-41a3-8449-d42784dd45ce/nuget/v3/flat2/{packageId.ToLowerInvariant()}/index.json");
-			return response?.Versions ?? [];
-		}
-		catch
-		{
-			return [];
-		}
-	}
+        var latestVersions = output
+            .GroupBy(x => GetGroupVersion(packageId, x))
+            .Select(g => g.OrderByDescending(x => x).First())
+            .OrderByDescending(x => x)
+            .ToArray();
 
-	private async Task<IEnumerable<string>> GetPublicPackageVersions(string packageId)
-	{
-		try
-		{
-			var response = await PublicNuGetClient.GetFromJsonAsync<VersionsResponse>($"/v3-flatcontainer/{packageId.ToLowerInvariant()}/index.json");
-			return response?.Versions ?? [];
-		}
-		catch
-		{
-			return [];
-		}
-	}
+        if (!RequiresValidation(packageId))
+        {
+            return latestVersions;
+        }
 
-	public async Task<string> GetVersionAsync(string packageId, bool preview, string? minimumVersionString = null)
-	{
-		var versions = await GetPackageVersions(packageId);
-		versions = versions.Where(x => x.IsPreview == preview);
+        var validatedOutput = new List<NuGetVersion>();
+        foreach(var version in latestVersions)
+        {
+            if (await ValidatePackage(packageId, version))
+            {
+                validatedOutput.Add(version);
+                continue;
+            }
 
-		if (NuGetVersion.TryParse(minimumVersionString, out var minimumVersion))
-		{
-			versions = versions.Where(x => minimumVersion.Version <= x.Version);
-		}
+            break;
+        }
 
-		if (!versions.Any())
-		{
-			return string.Empty;
-		}
+        return validatedOutput;
+    }
 
-		return versions.OrderByDescending(x => x).First().OriginalVersion;
-	}
+    private static NuGetVersion GetGroupVersion(string packageId, NuGetVersion packageVersion)
+    {
+        if (packageId.StartsWith("Uno", StringComparison.InvariantCultureIgnoreCase))
+        {
+            return NuGetVersion.Parse($"{packageVersion.Version.Major}.{packageVersion.Version.Minor}.0");
+        }
 
-	public void Dispose()
-	{
-		PublicNuGetClient.Dispose();
-	}
+        return NuGetVersion.Parse($"{packageVersion.Version.Major}.{packageVersion.Version.Minor}.{packageVersion.Version.Build}");
+    }
+
+    private bool RequiresValidation(string packageId) =>
+        UnoVersion is not null && 
+        packageId.Contains("Uno", StringComparison.InvariantCultureIgnoreCase) &&
+        !packageId.Contains("Sdk", StringComparison.InvariantCultureIgnoreCase);
+
+    private async Task<bool> ValidatePackage(string packageId, NuGetVersion version)
+    {
+        if (_validation.HasBeenChecked(packageId, version))
+        {
+            return _validation.IsValid(packageId, version);
+        }
+
+        var nuspecUrl = $"/v3-flatcontainer/{packageId.ToLowerInvariant()}/{version.OriginalVersion}/{packageId.ToLowerInvariant()}.nuspec";
+        using var response = PublicNuGetClient.GetAsync(nuspecUrl).Result;
+        if (!response.IsSuccessStatusCode)
+        {
+            // This could happen if the package we are checking is not publicly available.
+            return true;
+        }
+
+        var packageResponse = await response.Content.ReadAsStringAsync();
+        var xDocument = XDocument.Parse(packageResponse);
+
+        // Define the namespace manager
+        var namespaceManager = new XmlNamespaceManager(new NameTable());
+        namespaceManager.AddNamespace("ns", "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd");
+
+        // Select dependency groups
+        var dependencyGroups = xDocument.XPathSelectElements("//ns:dependencies/ns:group", namespaceManager);
+
+        foreach (var group in dependencyGroups)
+        {
+            if (_validation.HasBeenChecked(packageId, version))
+                continue;
+
+            _validation.AddResult(packageId, version, await IsCompatibleWithUnoWinUI(group));
+        }
+
+        _validation.AddResult(packageId, version, true);
+        return _validation.IsValid(packageId, version);
+    }
+
+    private async Task<bool> IsCompatibleWithUnoWinUI(XElement group)
+    {
+        var dependencies = group.Elements().Where(e => e.Name.LocalName == "dependency").ToList();
+        var unoWinUIDependency = dependencies.FirstOrDefault(d => d.Attribute("id")?.Value == UnoWinUIPackageId);
+
+        // We don't have a dependency on Uno.WinUI
+        if (unoWinUIDependency is null)
+        {
+            var unoDependencies = dependencies.Where(x => x.Attribute("id")?.Value.Contains("Uno", StringComparison.InvariantCultureIgnoreCase) ?? false);
+
+            // Check for Transitive Dependency
+            if (unoDependencies.Any())
+            {
+                var transitiveDependencies = unoDependencies.ToDictionary(x => x.Attribute("id")!.Value, x => NuGetVersion.Parse(x.Attribute("version")!.Value));
+                foreach((var packageId, var version) in transitiveDependencies)
+                {
+                    if (_validation.HasBeenChecked(packageId, version))
+                    {
+                        continue;
+                    }
+                    else if (!await ValidatePackage(packageId, version))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        if (!NuGetVersion.TryParse(unoWinUIDependency.Attribute("version")?.Value, out var unoWinUIVersion))
+        {
+            // This shouldn't happen
+            return false;
+        }
+
+        if (!_validation.HasBeenChecked(UnoWinUIPackageId, unoWinUIVersion))
+        {
+            _validation.AddResult(UnoWinUIPackageId, unoWinUIVersion, UnoVersion >= unoWinUIVersion);
+        }
+
+        return _validation.IsValid(UnoWinUIPackageId, unoWinUIVersion);
+    }
+
+    private async Task<IEnumerable<string>> GetPrivatePackageVersions(string packageId)
+    {
+        try
+        {
+            var response = await PrivateNuGetClient.GetFromJsonAsync<VersionsResponse>($"/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/e7ce08df-613a-41a3-8449-d42784dd45ce/nuget/v3/flat2/{packageId.ToLowerInvariant()}/index.json");
+            return response?.Versions ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private async Task<IEnumerable<string>> GetPublicPackageVersions(string packageId)
+    {
+        try
+        {
+            var response = await PublicNuGetClient.GetFromJsonAsync<VersionsResponse>($"/v3-flatcontainer/{packageId.ToLowerInvariant()}/index.json");
+            return response?.Versions ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    public async Task<string> GetVersionAsync(string packageId, bool preview, string? minimumVersionString = null)
+    {
+        var versions = await GetPackageVersions(packageId);
+        versions = versions.Where(x => x.IsPreview == preview);
+
+        // https://api.nuget.org/v3-flatcontainer/uno.extensions.hosting.winui/4.2.0-dev.137/uno.extensions.hosting.winui.nuspec
+        if (NuGetVersion.TryParse(minimumVersionString, out var minimumVersion))
+        {
+            versions = versions.Where(x => minimumVersion.Version <= x.Version);
+        }
+
+        if (!versions.Any())
+        {
+            return string.Empty;
+        }
+
+        return versions.OrderByDescending(x => x).First().OriginalVersion;
+    }
+
+    public void Dispose()
+    {
+        PublicNuGetClient.Dispose();
+    }
 }

--- a/tools/Uno.Sdk.Updater/Utils/LocalFileSystem.cs
+++ b/tools/Uno.Sdk.Updater/Utils/LocalFileSystem.cs
@@ -1,6 +1,6 @@
 ﻿using Uno.Sdk.Models;
 
-namespace Uno.Sdk.Updater;
+namespace Uno.Sdk.Updater.Utils;
 
 internal static class UpdaterBuildContext
 {

--- a/tools/Uno.Sdk.Updater/Utils/PackageValidationRecord.cs
+++ b/tools/Uno.Sdk.Updater/Utils/PackageValidationRecord.cs
@@ -24,6 +24,11 @@ internal sealed class PackageValidationRecord
             _validated[packageId] = [];
         }
 
+        if (!validated)
+        {
+            Console.WriteLine($"{packageId} {version} is not a valid dependency.");
+        }
+
         _validated[packageId].Add(new VersionValidationResult(version, validated));
     }
 

--- a/tools/Uno.Sdk.Updater/Utils/PackageValidationRecord.cs
+++ b/tools/Uno.Sdk.Updater/Utils/PackageValidationRecord.cs
@@ -1,0 +1,34 @@
+﻿#nullable enable
+using Uno.Sdk.Models;
+
+namespace Uno.Sdk.Updater.Utils;
+
+internal sealed class PackageValidationRecord
+{
+    private readonly Dictionary<string, List<VersionValidationResult>> _validated = [];
+
+    internal bool HasBeenChecked(string packageId, NuGetVersion version) =>
+        GetResult(packageId, version) is not null;
+
+    internal bool IsValid(string packageId, NuGetVersion version) =>
+        GetResult(packageId, version)?.IsValid ?? throw new InvalidOperationException($"Package {packageId} - {version}, has not been checked");
+
+    internal void AddResult(string packageId, NuGetVersion version, bool validated)
+    {
+        if (HasBeenChecked(packageId, version))
+        {
+            return;
+        }
+        else if (!_validated.ContainsKey(packageId))
+        {
+            _validated[packageId] = [];
+        }
+
+        _validated[packageId].Add(new VersionValidationResult(version, validated));
+    }
+
+    private VersionValidationResult? GetResult(string packageId, NuGetVersion version) =>
+        _validated.TryGetValue(packageId, out List<VersionValidationResult>? value) ? value.FirstOrDefault(x => x.Version == version) : null;
+
+    private record VersionValidationResult(NuGetVersion Version, bool IsValid);
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Feature
- Project automation

## What is the current behavior?

When updating for a stable branch, the Updater will always pick the latest dependencies. 

## What is the new behavior?

When updating for a stable branch, the Updater will now validate that the available versions are compatible with the version of Uno.WinUI that we are packing for.