### PR TITLE
Sync Hello Uno Platform string

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MainPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MainPage.xaml
@@ -11,7 +11,7 @@
           HorizontalAlignment="Center"
           VerticalAlignment="Center">
       <TextBlock AutomationProperties.AutomationId="HelloTextBlock"
-            Text="Hello Uno Platform"
+            Text="Hello Uno Platform!"
             HorizontalAlignment="Center" />
 <!--#if (mauiEmbedding)-->
 <!--#if (useNonMauiPlatforms)-->


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #835

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

C# Markup and XAML Blank Page use slightly different strings

## What is the new behavior?

C# Markup and XAML Blank Page now both use `Hello Uno Platform!`