### PR TITLE
Make Android Component dynamic based on selected TFM

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -337,6 +337,26 @@
         ]
       }
     },
+    "vsAndroidSdkComponent": {
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "$VSAndroidSdkComponent$",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "(tfm == 'net8.0')",
+            "value": "Component.Android.SDK34"
+          },
+          {
+            // This could become 35 when net9.0 launches
+            "condition": "(tfm == 'net9.0')",
+            "value": "Component.Android.SDK34"
+          }
+        ]
+      }
+    },
     "presetTestsDefault": {
       "type": "generated",
       "generator": "switch",

--- a/src/Uno.Templates/content/unoapp/.vsconfig
+++ b/src/Uno.Templates/content/unoapp/.vsconfig
@@ -32,7 +32,7 @@
     "Microsoft.VisualStudio.ComponentGroup.Maui.All",
 #//#endif
 #//#if (useAndroid)
-    "Component.Android.SDK34",
+    "$VSAndroidSdkComponent$",
     "Component.OpenJDK",
 #//#endif
     "Microsoft.VisualStudio.Workload.NetCrossPlat",


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes #760

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

The VS Component is hard coded and may not be the correct value in the future based on the selected TFM

## What is the new behavior?

We now can control this component based on which TFM is selected.