### PR TITLE
Place netX.0 last

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1335,1027 +1335,1027 @@
         "datatype": "string",
         "cases": [
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-browserwasm;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android;net8.0-ios"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android;net8.0-maccatalyst;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-maccatalyst;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android;net8.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android;net8.0-windows10.0.19041;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-windows10.0.19041;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android;net8.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-browserwasm;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-android;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-android"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-ios;net8.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-ios;net8.0-windows10.0.19041;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-ios;net8.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-ios;net8.0-browserwasm;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-ios;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-ios;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-ios"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-maccatalyst;net8.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-maccatalyst;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-maccatalyst;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-windows10.0.19041;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-windows10.0.19041;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-browserwasm;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net8.0;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net8.0;net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.19041;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-maccatalyst;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-maccatalyst;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-windows10.0.19041;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-windows10.0.19041;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-windows10.0.19041;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-windows10.0.19041;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-maccatalyst;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-windows10.0.19041;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-windows10.0.19041;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-windows10.0.19041;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-windows10.0.19041;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-maccatalyst;net8.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-maccatalyst;net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-maccatalyst;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-maccatalyst;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-maccatalyst;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-maccatalyst;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-windows10.0.19041;net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-windows10.0.19041;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-windows10.0.19041;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-windows10.0.19041;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-windows10.0.19041;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0-browserwasm;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": ""
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-browserwasm;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android;net9.0-ios"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android;net9.0-maccatalyst;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-maccatalyst;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android;net9.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android;net9.0-windows10.0.19041;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-windows10.0.19041;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android;net9.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-browserwasm;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-android;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-android"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-ios;net9.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-ios;net9.0-windows10.0.19041;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-ios;net9.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-ios;net9.0-browserwasm;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-ios;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-ios;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-ios"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-maccatalyst;net9.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-maccatalyst;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-maccatalyst;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-windows10.0.19041;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-windows10.0.19041;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-windows10.0.19041"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-browserwasm;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
-            "value": "net9.0;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
-            "value": "net9.0;net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == true && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
-            "value": "net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.19041;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-maccatalyst;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-maccatalyst;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-windows10.0.19041;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-windows10.0.19041;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-windows10.0.19041;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-windows10.0.19041;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-maccatalyst;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-windows10.0.19041;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-windows10.0.19041;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-windows10.0.19041;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-windows10.0.19041;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-maccatalyst;net9.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-maccatalyst;net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-maccatalyst;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-maccatalyst;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-maccatalyst;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-maccatalyst;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-windows10.0.19041;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-windows10.0.19041;net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-windows10.0.19041;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-windows10.0.19041;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-windows10.0.19041;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-windows10.0.19041;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-windows10.0.19041"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0-browserwasm;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
             "value": "net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && useUnitTests == false && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
+            "value": "net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": ""
           }
         ]

--- a/tools/TemplateTfmSwitchGenerator/Program.cs
+++ b/tools/TemplateTfmSwitchGenerator/Program.cs
@@ -6,13 +6,13 @@ var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
     WriteIndented = true,
 };
 Platform[] platforms = [
-    new Platform("useUnitTests == true", "useUnitTests == false", null),
     new Platform("platforms == android", "platforms != android", "android"),
     new Platform("platforms == ios", "platforms != ios", "ios"),
     new Platform("platforms == maccatalyst", "platforms != maccatalyst", "maccatalyst"),
     new Platform("platforms == windows", "platforms != windows", "windows10.0.19041"),
     new Platform("platforms == wasm", "platforms != wasm", "browserwasm"),
-    new Platform("platforms == desktop", "platforms != desktop", "desktop")
+    new Platform("platforms == desktop", "platforms != desktop", "desktop"),
+    new Platform("useUnitTests == true", "useUnitTests == false", null)
 ];
 
 string[] runtimes = ["net8.0", "net9.0"];


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- related unoplatform/private#485

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

net8.0/net9.0 is always placed first in the TFMs if it is used.

## What is the new behavior?

net8.0/net9.0 is always placed last in the TFMs if it is used.