### PR TITLE
Fixing location of Add Resources note

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.xaml
@@ -50,10 +50,11 @@
         <!--#endif-->
         <!--#endif-->
       </ResourceDictionary.MergedDictionaries>
+
+      <!-- Add resources here -->
+
     </ResourceDictionary>
   </Application.Resources>
-
-  <!-- Add resources here -->
 
 <!--#endif-->
 </Application>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #852

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The 'Add Resources Here' note is in the wrong location outside of the Resource Dictionary.

## What is the new behavior?

The comment has been moved to the correct location.