### PR TITLE
WASM Multi-Threading

### DIFF
--- a/build/.azure-pipelines.TemplateValidation.yml
+++ b/build/.azure-pipelines.TemplateValidation.yml
@@ -30,6 +30,7 @@ jobs:
             "NoServerNoHttp;;-preset recommended -server false -http false",
             "NoTests;;-preset recommended -tests none",
             "FrameNavigation;; -preset recommended --navigation blank",
+            "WasmMultiThreading;;-wasm-multi-threading true",
 
             # Disabling this test for now as it was specific to net7
             # https://github.com/unoplatform/uno.templates/issues/22

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -103,6 +103,17 @@
       ThemeService;
       <!--#endif-->
     </UnoFeatures>
+    <!--#if (useWasmMultiThreading)-->
+
+    <!--
+      Enable WebAssembly Threads
+      https://aka.platform.uno/wasm-threading
+
+      NOTE: This feature is still considered experimental by the dotnet team
+    -->
+    <WasmShellEnableThreads>true</WasmShellEnableThreads>
+    <WasmShellPThreadsPoolSize>8</WasmShellPThreadsPoolSize>
+    <!--#endif-->
   </PropertyGroup>
   <!--#if (useUITests)-->
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes #848

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

WASM Multi-Threading properties were lost during the migration to SingleProject

## What is the new behavior?

We've re-introduced the WASM Multi-Threading properties to the SingleProject when the Multi-Threading option is selected in the template.