### PR TITLE
Visual Studio fails to load the AppxManifest

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Package.appxmanifest
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Package.appxmanifest
@@ -5,6 +5,14 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
+  <Identity />
+  <Properties />
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+  </Dependencies>
+
   <Resources>
     <Resource Language="x-generate"/>
   </Resources>
@@ -13,6 +21,7 @@
     <Application Id="App"
       Executable="$targetnametoken$.exe"
       EntryPoint="$targetentrypoint$">
+      <uap:VisualElements />
 <!--#if (useProtocolRedirect)-->
       <Extensions>
       <uap:Extension Category="windows.protocol">


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #876

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When trying to open the Package.appxmanifest in the Visual Editor in Visual Studio it fails to load due to missing elements.

## What is the new behavior?

We now have placeholder elements that keep Visual Studio happy with what is actually required while still allowing Uno.Resizetizer to properly provide these values from the MSBuild properties that are part of Single Project.