### PR TITLE
limit updates for stable to the current Major.Minor

### DIFF
--- a/tools/Uno.Sdk.Updater/Program.cs
+++ b/tools/Uno.Sdk.Updater/Program.cs
@@ -85,10 +85,16 @@ foreach(var entry in sdkZip.Entries)
         relativePackagesJsonPath = entry.FullName;
         packagesJsonPath = outputPath;
         using var packageStream = entry.Open();
-        var inputManifest = await JsonSerializer.DeserializeAsync<IEnumerable<ManifestGroup>>(packageStream);
+        var inputManifest = await JsonSerializer.DeserializeAsync<IEnumerable<ManifestGroup>>(packageStream)
+            ?? throw new InvalidOperationException("Unable to parse the packages.json from the Sdk.");
+
+        if (!unoVersion.IsPreview)
+        {
+            inputManifest = MergeLocalManifest(inputManifest, outputPath);
+        }
 
         var manifest = new List<ManifestGroup>();
-        foreach(var group in inputManifest!)
+        foreach(var group in inputManifest)
         {
             var updated = await UpdateGroup(group, unoVersion, client);
             manifest.Add(updated);
@@ -153,6 +159,24 @@ else
 }
 
 Console.WriteLine("Finished Uno.Sdk update.");
+
+static IEnumerable<ManifestGroup> MergeLocalManifest(IEnumerable<ManifestGroup> sdkManifest, string packagesJsonPath)
+{
+    var localManifest = JsonSerializer.Deserialize<IEnumerable<ManifestGroup>>(File.ReadAllText(packagesJsonPath))
+            ?? throw new InvalidOperationException("Unable to parse the packages.json from the Sdk.");
+    var mergedManifest = new List<ManifestGroup>(localManifest);
+    foreach (var group in sdkManifest)
+    {
+        if (mergedManifest.Any(x => x.Group == group.Group))
+        {
+            continue;
+        }
+
+        mergedManifest.Add(group);
+    }
+
+    return mergedManifest;
+}
 
 static void WriteIfDifferent(string filePath, string content, ref bool didWriteChanges)
 {

--- a/tools/Uno.Sdk.Updater/Program.cs
+++ b/tools/Uno.Sdk.Updater/Program.cs
@@ -292,7 +292,7 @@ static async Task<ManifestGroup> UpdateGroup(ManifestGroup group, NuGetVersion u
     var packageId = group.Packages.FirstOrDefault(x => x.Contains("WinUI", StringComparison.InvariantCultureIgnoreCase) && x.Contains("Uno", StringComparison.InvariantCultureIgnoreCase)) ??
         group.Packages.First();
 
-    var version = await client.GetVersionAsync(packageId, preview);
+    var version = await client.GetVersionAsync(packageId, preview, group.Version);
     version = !string.IsNullOrEmpty(group.Version) && NuGetVersion.Parse(version) < NuGetVersion.Parse(group.Version) ? group.Version : version;
     var newGroup = group with { Version = version };
 

--- a/tools/Uno.Sdk.Updater/ReadMe.md
+++ b/tools/Uno.Sdk.Updater/ReadMe.md
@@ -9,7 +9,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | UnoToolkitVersion | $Toolkit$ |
 | UnoThemesVersion | $Themes$ |
 | UnoCSharpMarkupVersion | $CSharpMarkup$ |
-| UnoWasmBootstrapVersion** | $WasmBootstrapVersion$ |
+| UnoWasmBootstrapVersion** | $WasmBootstrap$ |
 | UnoLoggingVersion | $OSLogging$ |
 | UnoCoreLoggingSingletonVersion | $CoreLogging$ |
 | UnoUniversalImageLoaderVersion | $UniversalImageLoading$ |

--- a/tools/Uno.Sdk.Updater/Services/NuGetClient.cs
+++ b/tools/Uno.Sdk.Updater/Services/NuGetClient.cs
@@ -229,6 +229,12 @@ internal class NuGetApiClient : IDisposable
         if (!string.IsNullOrEmpty(minimumVersionString) && NuGetVersion.TryParse(minimumVersionString, out var minimumVersion))
         {
             versions = versions.Where(x => minimumVersion.Version <= x.Version);
+
+            if (UnoVersion.HasValue && !UnoVersion.Value.IsPreview)
+            {
+                var maxVersion = NuGetVersion.Parse($"{minimumVersion.Version.Major}.{minimumVersion.Version.Minor + 1}.0");
+                versions = versions.Where(x => x < maxVersion);
+            }
         }
 
         if (!versions.Any())

--- a/tools/Uno.Sdk.Updater/Services/NuGetClient.cs
+++ b/tools/Uno.Sdk.Updater/Services/NuGetClient.cs
@@ -92,8 +92,10 @@ internal class NuGetApiClient : IDisposable
                 validatedOutput.Add(version);
                 continue;
             }
-
-            break;
+            else if (UnoVersion.HasValue && UnoVersion.Value.IsPreview)
+            {
+                break;
+            }
         }
 
         _cachedVersions[packageId] = validatedOutput;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes #880 

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Refactoring (no functional changes, no api changes)
- Project automation

## What is the current behavior?

The updater will always get the latest stable version while updating

## What is the new behavior?

The updater will force updates to be patches/service releases in the same Major.Minor release channel from when the stable release was made. The latest release will be picked for main branch/dev builds.