### PR TITLE
Invalid reference to Material Toolkit

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -2405,6 +2405,10 @@
         "evaluator": "C++",
         "cases": [
           {
+            "condition": "(appThemeEvaluator == 'fluent')",
+            "value": ""
+          },
+          {
             "condition": "(appThemeEvaluator == 'material' && (useToolkit == 'true' || useToolkit == true))",
             "value": "\n       xmlns:utum=\"using:Uno.Toolkit.UI.Material\""
           },

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.xaml
@@ -38,16 +38,17 @@
           </um:MaterialTheme.FontOverrideDictionary> -->
         </um:MaterialTheme>
         <!--#endif-->
-        <!--#else-->
-        <!--#if (useCupertino)-->
+        <!--#elif (useCupertino)-->
         <uc:CupertinoColors />
         <uc:CupertinoFonts />
         <uc:CupertinoResources />
-        <!--#endif-->
         <!--#if (useToolkit)-->
         <!-- Load Uno.UI.Toolkit resources -->
         <ToolkitResources xmlns="using:Uno.Toolkit.UI" />
         <!--#endif-->
+        <!--#elif (useToolkit)-->
+        <!-- Load Uno.UI.Toolkit resources -->
+        <ToolkitResources xmlns="using:Uno.Toolkit.UI" />
         <!--#endif-->
       </ResourceDictionary.MergedDictionaries>
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #726

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When selecting Toolkit and using the Fluent theme a reference to the Material Toolkit is added in the App.xaml

## What is the new behavior?

This is corrected so that no xmlns is added when using the Fluent theme... because apparently `&&` doesn't mean the same thing to dotnet templates 🤷‍♂️ 
