### PR TITLE
Skip Maui update on Release branch

### DIFF
--- a/tools/Uno.Sdk.Updater/Program.cs
+++ b/tools/Uno.Sdk.Updater/Program.cs
@@ -291,7 +291,10 @@ static async Task<ManifestGroup> UpdateGroup(ManifestGroup group, NuGetVersion u
         Console.WriteLine($"Setting Core group to: {unoVersion.OriginalVersion}");
         return group with { Version = unoVersion };
     }
-    else if (group.Packages.Any(x => x.StartsWith("Xamarin")))
+    // Skip AndroidX packages to avoid Java misalignment
+    else if (group.Packages.Any(x => x.StartsWith("Xamarin")) 
+        // Skip Maui on Release branch to avoid AndroidX package misalignment
+        || (!unoVersion.IsPreview && group.Group == "Maui"))
     {
         Console.WriteLine("Leaving group as is: " + group.Group);
         return group;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- Addresses automated update in #887

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Maui packages are always updated


## What is the new behavior?

Maui packages are only updated in Dev to avoid AndroidX misalignment in Release branches.