### PR TITLE
Allow Prism stable updates

### DIFF
--- a/tools/Uno.Sdk.Updater/Program.cs
+++ b/tools/Uno.Sdk.Updater/Program.cs
@@ -312,10 +312,6 @@ static async Task<ManifestGroup> UpdateGroup(ManifestGroup group, NuGetVersion u
     {
         preview = false;
     }
-    else if (group.Group == "Prism")
-    {
-        preview = true;
-    }
     else if (!group.Packages.Any(x => x.StartsWith("Uno.")))
     {
         preview = false;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Other... Prism is stable

## What is the current behavior?

Updater will only use preview version of Prism

## What is the new behavior?

Updater will use stable version of Prism