### PR TITLE
Adding missing template parameters

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
@@ -121,10 +121,21 @@
       "longName": "wasm-multi-threading",
       "shortName": "wasm-multi-threading"
     },
+    "unoSvg": {
+      "longName": "svg",
+      "shortName": "svg"
+    },
+    "unoLottie": {
+      "longName": "lottie",
+      "shortName": "lottie"
+    },
     "unoWinUIVersion": {
       "isHidden": true
     },
     "unoSdkVersion": {
+      "isHidden": true
+    },
+    "unoWasmBootstrapVersion": {
       "isHidden": true
     },
     "unoUITestHelpersVersion": {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

there are 3 template properties that are not defined in the CLI configuration which causes one hidden flag to show up and 2 other properties to use the auto assigned values which aren't desirable.

## What is the new behavior?

We now define these 3 properties so that the Bootstrap Version is hidden from the CLI and we have a better flag for Lottie and SVG.