### PR TITLE
Cleaning up unnecessary bloat

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -2517,63 +2517,6 @@
         ]
       }
     },
-    "mainDataContext": {
-      "type": "generated",
-      "generator": "switch",
-      "datatype": "string",
-      "replaces": "$mainDataContext$",
-      "parameters": {
-        "evaluator": "C++",
-        "cases": [
-          {
-            "condition": "(architectureEvaluator == 'mvux')",
-            "value": "MainViewModel"
-          },
-          {
-            "condition": "(architectureEvaluator == 'mvvm')",
-            "value": "MainViewModel"
-          }
-        ]
-      }
-    },
-    "secondDataContext": {
-      "type": "generated",
-      "generator": "switch",
-      "datatype": "string",
-      "replaces": "$secondDataContext$",
-      "parameters": {
-        "evaluator": "C++",
-        "cases": [
-          {
-            "condition": "(architectureEvaluator == 'mvux')",
-            "value": "SecondViewModel"
-          },
-          {
-            "condition": "(architectureEvaluator == 'mvvm')",
-            "value": "SecondViewModel"
-          }
-        ]
-      }
-    },
-    "loginDataContext": {
-      "type": "generated",
-      "generator": "switch",
-      "datatype": "string",
-      "replaces": "$loginDataContext$",
-      "parameters": {
-        "evaluator": "C++",
-        "cases": [
-          {
-            "condition": "(architectureEvaluator == 'mvux')",
-            "value": "LoginViewModel"
-          },
-          {
-            "condition": "(architectureEvaluator == 'mvvm')",
-            "value": "LoginViewModel"
-          }
-        ]
-      }
-    },
     "presetNavigationDefault": {
       "type": "generated",
       "generator": "switch",

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/LoginPage.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/LoginPage.xaml.cs
@@ -7,7 +7,7 @@ public sealed partial class LoginPage : Page
     {
 //+:cnd:noEmit
 #if useCsharpMarkup
-        this.DataContext<$loginDataContext$>((page, vm) => page
+        this.DataContext<LoginViewModel>((page, vm) => page
             .NavigationCacheMode(NavigationCacheMode.Required)
 #if useMaterial
             .Background(Theme.Brushes.Background.Default)

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainPage.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainPage.xaml.cs
@@ -7,7 +7,7 @@ public sealed partial class MainPage : Page
     {
 //+:cnd:noEmit
 #if useCsharpMarkup
-        this.DataContext<$mainDataContext$>((page, vm) => page
+        this.DataContext<MainViewModel>((page, vm) => page
             .NavigationCacheMode(NavigationCacheMode.Required)
 #if useMaterial
             .Background(Theme.Brushes.Background.Default)

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/SecondPage.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/SecondPage.xaml.cs
@@ -7,7 +7,7 @@ public sealed partial class SecondPage : Page
     {
 //+:cnd:noEmit
 #if useCsharpMarkup
-        this.DataContext<$secondDataContext$>((page, vm) => page
+        this.DataContext<SecondViewModel>((page, vm) => page
 #if useMaterial
             .Background(Theme.Brushes.Background.Default)
 #else


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

We have logic to set the ViewModel name for C# Markup that is different depending on whether you are using MVUX or MVVM

## What is the new behavior?

With the recent changes to the MVUX generator we now have consistent naming across MVUX and MVVM therefore the unnecessary logic in the template.json is being removed