### PR TITLE
fix: C# Markup Recommended Template uses .All Instead of .VisibleBounds for SafeArea

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/LoginPage.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/LoginPage.xaml.cs
@@ -16,7 +16,7 @@ public sealed partial class LoginPage : Page
 #endif
             .Content(new Grid()
 #if useToolkit
-                .SafeArea(SafeArea.InsetMask.All)
+                .SafeArea(SafeArea.InsetMask.VisibleBounds)
 #endif
                 .RowDefinitions("Auto,*")
                 .Children(

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainPage.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainPage.xaml.cs
@@ -16,7 +16,7 @@ public sealed partial class MainPage : Page
 #endif
             .Content(new Grid()
 #if useToolkit
-                .SafeArea(SafeArea.InsetMask.All)
+                .SafeArea(SafeArea.InsetMask.VisibleBounds)
 #endif
                 .RowDefinitions("Auto,*")
                 .Children(

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/SecondPage.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/SecondPage.xaml.cs
@@ -15,7 +15,7 @@ public sealed partial class SecondPage : Page
 #endif
             .Content(new Grid()
 #if useToolkit
-                .SafeArea(SafeArea.InsetMask.All)
+                .SafeArea(SafeArea.InsetMask.VisibleBounds)
 #endif
                 .Children(
 #if useToolkit


### PR DESCRIPTION
GitHub Issue (If applicable): closes #934 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

C# Markup Recommended Template uses .All for SafeArea

## What is the new behavior?

C# Markup Recommended Template uses .VisibleBounds for SafeArea

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
