### PR TITLE
chore: Default spacing to 4 spaces for XML-based files

### DIFF
--- a/src/Uno.Templates/content/unoapp/.editorconfig
+++ b/src/Uno.Templates/content/unoapp/.editorconfig
@@ -31,40 +31,40 @@ indent_style = tab
 indent_size = 2
 
 [*.{csproj,proj,projitems,shproj}]
-indent_size = 2
+indent_size = 4
 
 [*.{json,slnf}]
 indent_size = 2
 end_of_line = lf
 
 [*.{props,targets}]
-indent_size = 2
+indent_size = 4
 
 [*.xaml]
-indent_size = 2
+indent_size = 4
 charset = utf-8-bom
 
 [*.xml]
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 
 [*.plist]
-indent_size = 2
+indent_size = 4
 indent_style = tab
 end_of_line = lf
 
 [*.manifest]
-indent_size = 2
+indent_size = 4
 
 [*.appxmanifest]
-indent_size = 2
+indent_size = 4
 
 [*.{json,css,webmanifest}]
 indent_size = 2
 end_of_line = lf
 
 [web.config]
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 
 [*.sh]


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

Using 2 spaces


## What is the new behavior?

Using 4 to match the default spacing for XML formats in Visual Studio

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
