### PR TITLE
fix: Add AnyCPU publish file for winui

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Properties/PublishProfiles/win-AnyCPU.pubxml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Properties/PublishProfiles/win-AnyCPU.pubxml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<PublishProtocol>FileSystem</PublishProtocol>
+		<PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+		<SelfContained>true</SelfContained>
+		<PublishSingleFile>False</PublishSingleFile>
+		<PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+		<PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+		<PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
+		<PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
+	</PropertyGroup>
+</Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/18212

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Add an AnyCPU pub file, which does not contain a runtime identifier.
