### PR TITLE
fix: CSWinRT-related compilation issues

### DIFF
--- a/src/Uno.Templates/content/unoapp/Directory.Build.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Build.props
@@ -3,6 +3,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CsWinRTAotOptimizerEnabled>false</CsWinRTAotOptimizerEnabled>
 
     <!--#if (mauiEmbedding)-->
     <!--


### PR DESCRIPTION
This one could be reverted when this issue is fixed -> https://github.com/microsoft/CsWinRT/issues/1809
Decided to use CsWinRTAotOptimizerEnabled instead of AllowUnsafeBlocks since it seems that there are other related issues to WinRT.SourceGenerator