### PR TITLE
fix: Downgrade to 10.0.22621 for Build Tools compatibility

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -18,7 +18,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | SkiaSharpVersion | 2.88.9-preview.2.2 |
 | SvgSkiaVersion | 2.0.0.2 |
 | WinAppSdkVersion | 1.6.241114003 |
-| WinAppSdkBuildToolsVersion | 10.0.26100.1742 |
+| WinAppSdkBuildToolsVersion | 10.0.22621.1742 |
 | MicrosoftLoggingVersion** | 8.0.1 |
 | WindowsCompatibilityVersion** | 8.0.11 |
 | MicrosoftIdentityClientVersion | 4.66.2 |
@@ -162,7 +162,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "WinAppSdkBuildTools",
-    "version": "10.0.26100.1742",
+    "version": "10.0.22621.1742",
     "packages": [
       "Microsoft.Windows.SDK.BuildTools"
     ]

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -121,7 +121,7 @@
   },
   {
     "group": "WinAppSdkBuildTools",
-    "version": "10.0.26100.1742",
+    "version": "10.0.22621.3233", // Keep this version until https://github.com/microsoft/WindowsAppSDK/issues/4480 is resolved
     "packages": [
       "Microsoft.Windows.SDK.BuildTools"
     ]

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -121,7 +121,7 @@
   },
   {
     "group": "WinAppSdkBuildTools",
-    "version": "10.0.22621.3233", // Keep this version until https://github.com/microsoft/WindowsAppSDK/issues/4480 is resolved
+    "version": "10.0.22621.3233",
     "packages": [
       "Microsoft.Windows.SDK.BuildTools"
     ]

--- a/src/Uno.Templates/content/unoapp/.run/MyExtensionsApp.1.run.xml
+++ b/src/Uno.Templates/content/unoapp/.run/MyExtensionsApp.1.run.xml
@@ -51,7 +51,7 @@
   <!--#if (useWinAppSdk)-->
   <configuration default="false" name="MyExtensionsApp.1 (WinAppSDK Unpackaged)" type="LaunchSettings" factoryName=".NET Launch Settings Profile">
     <option name="LAUNCH_PROFILE_PROJECT_FILE_PATH" value="$PROJECT_DIR$/MyExtensionsApp.1/MyExtensionsApp.1.csproj" />
-    <option name="LAUNCH_PROFILE_TFM" value="$baseTargetFramework$-windows10.0.26100.0" />
+    <option name="LAUNCH_PROFILE_TFM" value="$baseTargetFramework$-windows10.0.22621.0" />
     <option name="LAUNCH_PROFILE_NAME" value="MyExtensionsApp.1 (WinAppSDK Unpackaged)" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />
     <option name="USE_MONO" value="0" />

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1381,35 +1381,35 @@
         "cases": [
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm"
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop"
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0"
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100"
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
@@ -1445,35 +1445,35 @@
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm"
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.22621;net8.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.22621;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0-desktop"
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.22621;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0"
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.22621;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100"
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
@@ -1509,35 +1509,35 @@
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm"
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop"
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0"
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100"
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
@@ -1573,35 +1573,35 @@
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
+            "value": "net8.0-android;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
+            "value": "net8.0-android;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
+            "value": "net8.0-android;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-windows10.0.26100;net8.0-browserwasm"
+            "value": "net8.0-android;net8.0-windows10.0.22621;net8.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+            "value": "net8.0-android;net8.0-windows10.0.22621;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-windows10.0.26100;net8.0-desktop"
+            "value": "net8.0-android;net8.0-windows10.0.22621;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-android;net8.0-windows10.0.26100;net8.0"
+            "value": "net8.0-android;net8.0-windows10.0.22621;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-android;net8.0-windows10.0.26100"
+            "value": "net8.0-android;net8.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
@@ -1637,35 +1637,35 @@
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm"
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop"
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0"
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100"
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
@@ -1701,35 +1701,35 @@
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
+            "value": "net8.0-ios;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
+            "value": "net8.0-ios;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
+            "value": "net8.0-ios;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm"
+            "value": "net8.0-ios;net8.0-windows10.0.22621;net8.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-ios;net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+            "value": "net8.0-ios;net8.0-windows10.0.22621;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-ios;net8.0-windows10.0.26100;net8.0-desktop"
+            "value": "net8.0-ios;net8.0-windows10.0.22621;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-ios;net8.0-windows10.0.26100;net8.0"
+            "value": "net8.0-ios;net8.0-windows10.0.22621;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-ios;net8.0-windows10.0.26100"
+            "value": "net8.0-ios;net8.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
@@ -1765,35 +1765,35 @@
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm"
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop"
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0"
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.22621;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-maccatalyst;net8.0-windows10.0.26100"
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
@@ -1829,35 +1829,35 @@
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
+            "value": "net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
+            "value": "net8.0-windows10.0.22621;net8.0-browserwasm;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
+            "value": "net8.0-windows10.0.22621;net8.0-browserwasm;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-windows10.0.26100;net8.0-browserwasm"
+            "value": "net8.0-windows10.0.22621;net8.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+            "value": "net8.0-windows10.0.22621;net8.0-desktop;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net8.0-windows10.0.26100;net8.0-desktop"
+            "value": "net8.0-windows10.0.22621;net8.0-desktop"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net8.0-windows10.0.26100;net8.0"
+            "value": "net8.0-windows10.0.22621;net8.0"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net8.0-windows10.0.26100"
+            "value": "net8.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
@@ -1893,35 +1893,35 @@
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm"
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop"
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0"
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100"
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
@@ -1957,35 +1957,35 @@
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm"
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.22621;net9.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.22621;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0-desktop"
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.22621;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0"
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.22621;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100"
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
@@ -2021,35 +2021,35 @@
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm"
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop"
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0"
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100"
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
@@ -2085,35 +2085,35 @@
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
+            "value": "net9.0-android;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
+            "value": "net9.0-android;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
+            "value": "net9.0-android;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-windows10.0.26100;net9.0-browserwasm"
+            "value": "net9.0-android;net9.0-windows10.0.22621;net9.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+            "value": "net9.0-android;net9.0-windows10.0.22621;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-windows10.0.26100;net9.0-desktop"
+            "value": "net9.0-android;net9.0-windows10.0.22621;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-android;net9.0-windows10.0.26100;net9.0"
+            "value": "net9.0-android;net9.0-windows10.0.22621;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-android;net9.0-windows10.0.26100"
+            "value": "net9.0-android;net9.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
@@ -2149,35 +2149,35 @@
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm"
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop"
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0"
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100"
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
@@ -2213,35 +2213,35 @@
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
+            "value": "net9.0-ios;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
+            "value": "net9.0-ios;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
+            "value": "net9.0-ios;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm"
+            "value": "net9.0-ios;net9.0-windows10.0.22621;net9.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-ios;net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+            "value": "net9.0-ios;net9.0-windows10.0.22621;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-ios;net9.0-windows10.0.26100;net9.0-desktop"
+            "value": "net9.0-ios;net9.0-windows10.0.22621;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-ios;net9.0-windows10.0.26100;net9.0"
+            "value": "net9.0-ios;net9.0-windows10.0.22621;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-ios;net9.0-windows10.0.26100"
+            "value": "net9.0-ios;net9.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
@@ -2277,35 +2277,35 @@
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm"
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop"
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0"
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.22621;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-maccatalyst;net9.0-windows10.0.26100"
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
@@ -2341,35 +2341,35 @@
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
+            "value": "net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
+            "value": "net9.0-windows10.0.22621;net9.0-browserwasm;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
+            "value": "net9.0-windows10.0.22621;net9.0-browserwasm;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-windows10.0.26100;net9.0-browserwasm"
+            "value": "net9.0-windows10.0.22621;net9.0-browserwasm"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
-            "value": "net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+            "value": "net9.0-windows10.0.22621;net9.0-desktop;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
-            "value": "net9.0-windows10.0.26100;net9.0-desktop"
+            "value": "net9.0-windows10.0.22621;net9.0-desktop"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
-            "value": "net9.0-windows10.0.26100;net9.0"
+            "value": "net9.0-windows10.0.22621;net9.0"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
-            "value": "net9.0-windows10.0.26100"
+            "value": "net9.0-windows10.0.22621"
           },
           {
             "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/MyExtensionsApp.1.MauiControls.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.MauiControls/MyExtensionsApp.1.MauiControls.csproj
@@ -8,7 +8,7 @@
 
     <!--#endif-->
     <!--#if (useWinAppSdk)-->
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$baseTargetFramework$-windows10.0.26100</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$baseTargetFramework$-windows10.0.22621</TargetFrameworks>
     <!--#endif-->
     <TargetFrameworks>
       $baseTargetFramework$;

--- a/src/Uno.Templates/content/unolib/CrossTargetedLibrary.csproj
+++ b/src/Uno.Templates/content/unolib/CrossTargetedLibrary.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$baseTargetFramework$;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst;$baseTargetFramework$-android;$baseTargetFramework$-windows10.0.26100;$baseTargetFramework$-browserwasm;$baseTargetFramework$-desktop</TargetFrameworks>
+    <TargetFrameworks>$baseTargetFramework$;$baseTargetFramework$-ios;$baseTargetFramework$-maccatalyst;$baseTargetFramework$-android;$baseTargetFramework$-windows10.0.22621;$baseTargetFramework$-browserwasm;$baseTargetFramework$-desktop</TargetFrameworks>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->

--- a/tools/TemplateTfmSwitchGenerator/Program.cs
+++ b/tools/TemplateTfmSwitchGenerator/Program.cs
@@ -9,7 +9,7 @@ Platform[] platforms = [
     new Platform("platforms == android", "platforms != android", "android"),
     new Platform("platforms == ios", "platforms != ios", "ios"),
     new Platform("platforms == maccatalyst", "platforms != maccatalyst", "maccatalyst"),
-    new Platform("platforms == windows", "platforms != windows", "windows10.0.26100"),
+    new Platform("platforms == windows", "platforms != windows", "windows10.0.22621"),
     new Platform("platforms == wasm", "platforms != wasm", "browserwasm"),
     new Platform("platforms == desktop", "platforms != desktop", "desktop"),
     new Platform("useUnitTests == true", "useUnitTests == false", null)

--- a/tools/Uno.Sdk.Updater/Program.cs
+++ b/tools/Uno.Sdk.Updater/Program.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO.Compression;
 using System.Text;
 using System.Text.Json;
@@ -296,7 +297,13 @@ static async Task<ManifestGroup> UpdateGroup(ManifestGroup group, NuGetVersion u
         // Skip Maui on Release branch to avoid AndroidX package misalignment
         || (!unoVersion.IsPreview && group.Group == "Maui"))
     {
-        Console.WriteLine("Leaving group as is: " + group.Group);
+        Console.WriteLine("Skipping " + group.Group + " to avoid Java misalignment.");
+        return group;
+    }
+    // Skip WinAppSdkBuildTools group due to https://github.com/unoplatform/uno/issues/18840
+    else if (string.Equals(group.Group, "WinAppSdkBuildTools", StringComparison.InvariantCultureIgnoreCase))
+    {
+        Console.WriteLine("Skipping " + group.Group + "to avoid issues caused by https://github.com/unoplatform/uno/issues/18840");
         return group;
     }
 


### PR DESCRIPTION
GitHub Issue (If applicable): related to https://github.com/unoplatform/uno/issues/18840

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The latest version of Build Tools is unsupported by Microsoft Store and block users from publishing their apps


## What is the new behavior?

Downgraded until support is added

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
