### PR TITLE
fix: Remove Uno Platform extension from .vsconfig

### DIFF
--- a/src/Uno.Templates/content/unoapp/.vsconfig
+++ b/src/Uno.Templates/content/unoapp/.vsconfig
@@ -37,8 +37,5 @@
 #//#endif
     "Microsoft.VisualStudio.Workload.NetCrossPlat",
     "Microsoft.VisualStudio.Workload.NetCoreTools"
-  ],
-  "extensions": [
-    "https://marketplace.visualstudio.com/items?itemName=unoplatform.uno-platform-addin-2022"
   ]
 }


### PR DESCRIPTION
Due to https://developercommunity.visualstudio.com/t/vsconfig-extension-always-displayed-as/10823565 we cannot currently include our extension in .vsconfig, otherwise false-positive warnings are showed

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
