### PR TITLE
Revert "fix(vs): Adjust tfm order for vs17.12"

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1380,1027 +1380,1027 @@
         "datatype": "string",
         "cases": [
           {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm"
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios;net8.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios;net8.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios;net8.0-browserwasm;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-ios"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-maccatalyst;net8.0-browserwasm;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-maccatalyst;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-maccatalyst;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-windows10.0.26100;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-windows10.0.26100;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-browserwasm;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-android;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-android"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-ios;net8.0-maccatalyst;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-ios;net8.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-ios;net8.0-windows10.0.26100;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-ios;net8.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-ios;net8.0-browserwasm;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-ios;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-ios;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-ios"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-maccatalyst;net8.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-maccatalyst;net8.0-browserwasm;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-maccatalyst;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-maccatalyst;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-windows10.0.26100;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-windows10.0.26100;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0-browserwasm;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net8.0-desktop;net8.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net8.0-desktop;net8.0"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net8.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-ios;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0-ios;net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-ios;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-ios;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0-ios;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-ios"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-maccatalyst;net8.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0-maccatalyst;net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-maccatalyst;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-maccatalyst;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0-maccatalyst;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-windows10.0.26100;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-windows10.0.26100;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0-windows10.0.26100;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-android;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-android;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-android;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-android"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-maccatalyst;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-ios;net8.0-maccatalyst;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-ios;net8.0-maccatalyst;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-windows10.0.26100;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-ios;net8.0-windows10.0.26100;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-ios;net8.0-windows10.0.26100;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-ios;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-ios;net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-ios;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-ios;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-ios;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-ios"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-maccatalyst;net8.0-windows10.0.26100;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-maccatalyst;net8.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-maccatalyst;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-maccatalyst;net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-maccatalyst;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-maccatalyst;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-maccatalyst;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-maccatalyst;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-windows10.0.26100;net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-windows10.0.26100;net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-windows10.0.26100;net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-windows10.0.26100;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-windows10.0.26100;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-windows10.0.26100;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-browserwasm;net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-browserwasm;net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0-browserwasm;net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net8.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net8.0-desktop;net8.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net8.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net8.0"
           },
           {
-            "condition": "(tfm == 'net8.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": ""
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm"
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios;net9.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios;net9.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios;net9.0-browserwasm;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-ios"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-maccatalyst;net9.0-browserwasm;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-maccatalyst;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-maccatalyst;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-windows10.0.26100;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-windows10.0.26100;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-browserwasm;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-android;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-android"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-ios;net9.0-maccatalyst;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-ios;net9.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-ios;net9.0-windows10.0.26100;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-ios;net9.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-ios;net9.0-browserwasm;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-ios;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-ios;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-ios"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-maccatalyst;net9.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-maccatalyst;net9.0-browserwasm;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-maccatalyst;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-maccatalyst;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-maccatalyst"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-windows10.0.26100;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-windows10.0.26100;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-windows10.0.26100"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0-browserwasm;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
-            "value": "net9.0-desktop;net9.0-browserwasm"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
-            "value": "net9.0-desktop;net9.0"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms == desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
-            "value": "net9.0-desktop"
-          },
-          {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-ios;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0-ios;net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-ios;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-ios;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0-ios;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-ios"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-maccatalyst;net9.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0-maccatalyst;net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-maccatalyst;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-maccatalyst;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0-maccatalyst;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-windows10.0.26100;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-windows10.0.26100;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0-windows10.0.26100;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-android;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-android;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-android;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms == android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-android"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-maccatalyst;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-ios;net9.0-maccatalyst;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-ios;net9.0-maccatalyst;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-ios;net9.0-windows10.0.26100;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-ios;net9.0-windows10.0.26100;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-ios;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-ios;net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-ios;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-ios;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-ios;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms == ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-ios"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-maccatalyst;net9.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-maccatalyst;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-maccatalyst;net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-maccatalyst;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-maccatalyst;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-maccatalyst;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-maccatalyst;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms == maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-maccatalyst"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-windows10.0.26100;net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-windows10.0.26100;net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-windows10.0.26100;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-windows10.0.26100;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-windows10.0.26100;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms == windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-windows10.0.26100"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-browserwasm;net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-browserwasm;net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0-browserwasm;net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms == wasm && platforms != desktop && useUnitTests == false)",
             "value": "net9.0-browserwasm"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == true)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == true)",
+            "value": "net9.0-desktop;net9.0"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms == desktop && useUnitTests == false)",
+            "value": "net9.0-desktop"
+          },
+          {
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == true)",
             "value": "net9.0"
           },
           {
-            "condition": "(tfm == 'net9.0' && platforms != desktop && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && useUnitTests == false)",
+            "condition": "(tfm == 'net9.0' && platforms != android && platforms != ios && platforms != maccatalyst && platforms != windows && platforms != wasm && platforms != desktop && useUnitTests == false)",
             "value": ""
           }
         ]

--- a/tools/TemplateTfmSwitchGenerator/Program.cs
+++ b/tools/TemplateTfmSwitchGenerator/Program.cs
@@ -6,12 +6,12 @@ var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
     WriteIndented = true,
 };
 Platform[] platforms = [
-    new Platform("platforms == desktop", "platforms != desktop", "desktop"),
     new Platform("platforms == android", "platforms != android", "android"),
     new Platform("platforms == ios", "platforms != ios", "ios"),
     new Platform("platforms == maccatalyst", "platforms != maccatalyst", "maccatalyst"),
     new Platform("platforms == windows", "platforms != windows", "windows10.0.26100"),
     new Platform("platforms == wasm", "platforms != wasm", "browserwasm"),
+    new Platform("platforms == desktop", "platforms != desktop", "desktop"),
     new Platform("useUnitTests == true", "useUnitTests == false", null)
 ];
 


### PR DESCRIPTION
Reverts unoplatform/uno.templates#1184

Placing desktop first breaks the WinAppSDK debugging.