### PR TITLE
chore: Update allowPrerelease for .NET 9 and remove unnecessary quotes in global.json

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -332,7 +332,7 @@
           },
           {
             "condition": "(tfm == 'net9.0')",
-            "value": "true"
+            "value": "false"
           }
         ]
       }

--- a/src/Uno.Templates/content/unoapp/global.json
+++ b/src/Uno.Templates/content/unoapp/global.json
@@ -4,6 +4,6 @@
     "Uno.Sdk": "$UnoSdkVersion$"
   },
   "sdk":{
-    "allowPrerelease": "$AllowPrereleaseNetSdk$"
+    "allowPrerelease": $AllowPrereleaseNetSdk$
   }
 }


### PR DESCRIPTION
This PR updates the allowPrerelease setting in global.json for .NET 9 now that it is officially released. Additionally, it removes unnecessary quotes around the boolean value to conform to proper JSON syntax.

 As per the official [Microsoft documentation](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#examples):

![image](https://github.com/user-attachments/assets/a43d217b-d36f-4610-b1c2-14ea43810900)
