### PR TITLE
fix: Use "new" android bridge by default

### DIFF
--- a/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Mobile/Android/environment.conf
+++ b/src/Uno.Templates/content/unoapp-uwp/UnoQuickStart.Mobile/Android/environment.conf
@@ -1,2 +1,2 @@
 # See this for more details: http://developer.xamarin.com/guides/android/advanced_topics/garbage_collection/
-MONO_GC_PARAMS=bridge-implementation=tarjan,nursery-size=32m,soft-heap-limit=256m
+MONO_GC_PARAMS=bridge-implementation=new,nursery-size=32m,soft-heap-limit=256m

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/Android/environment.conf
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/Android/environment.conf
@@ -1,2 +1,2 @@
 # See this for more details: http://developer.xamarin.com/guides/android/advanced_topics/garbage_collection/
-MONO_GC_PARAMS=bridge-implementation=tarjan,nursery-size=32m,soft-heap-limit=256m
+MONO_GC_PARAMS=bridge-implementation=new,nursery-size=32m,soft-heap-limit=256m


### PR DESCRIPTION
Follows the recommendation from https://github.com/dotnet/runtime/issues/106410#issuecomment-2291508507