### PR TITLE
fix: Fixing build error NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -332,7 +332,7 @@
           },
           {
             "condition": "(tfm == 'net9.0')",
-            "value": "true"
+            "value": "false"
           }
         ]
       }


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

When creating app targeting net9 and with vs preview installed (ie so that preview net9 is installed)

1>C:\Program Files\dotnet\sdk\9.0.200-preview.0.25057.12\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.targets(262,5): error NETSDK1216: Package Microsoft.Net.Sdk.Compilers.Toolset is not downloaded but it is needed because your MSBuild and SDK versions are mismatched. Ensure version 9.0.200-preview.0.25057.12 of the package is available in your NuGet source feeds and then run NuGet package restore from Visual Studio or MSBuild.
1>Done building project "UnoApp35.csproj" -- FAILED.

## What is the new behavior?

No build errors

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
