### PR TITLE
feat(vscode): Add Edge debugging config to launch.json for Uno template

### DIFF
--- a/src/Uno.Templates/content/unoapp/.vscode/launch.json
+++ b/src/Uno.Templates/content/unoapp/.vscode/launch.json
@@ -36,6 +36,29 @@
       }
     },
 //#endif
+//#if (useWasm)
+    {
+      // Use IntelliSense to find out which attributes exist for C# debugging
+      // Use hover for the description of the existing attributes
+      // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+      "name": "Uno Platform WebAssembly Debug (Edge)",
+      "type": "msedge",
+      "request": "launch",
+      "url": "http://localhost:5000",
+      "webRoot": "${workspaceFolder}/MyExtensionsApp.1",
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "timeout": 30000,
+      "preLaunchTask": "build-wasm",
+      "server": {
+        "runtimeExecutable": "dotnet",
+        "program": "run",
+        "args": ["--no-build","-f","$baseTargetFramework$-browserwasm","--launch-profile", "MyExtensionsApp.1 (WebAssembly)"],
+        "outputCapture": "std",
+        "timeout": 30000,
+        "cwd": "${workspaceFolder}/MyExtensionsApp.1"
+      }
+    },
+//#endif
 //#if (useDesktop)
     {
       // Use IntelliSense to find out which attributes exist for C# debugging


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Feature

## Current Behavior

Currently, only **Google Chrome** is available in `launch.json` for VS Code.

## New Behavior

Added support for **Microsoft Edge (Chromium-based)** in `launch.json`, as it is also supported by VS Code.
(Reference: https://github.com/microsoft/vscode-js-debug/blob/main/OPTIONS.md)

