### PR TITLE
fix: Make ScrollViewer a tab stop

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MainPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MainPage.xaml
@@ -6,7 +6,7 @@
       xmlns:controls="using:MyExtensionsApp._1.MauiControls"
 <!--#endif-->
       Background="{ThemeResource $themeBackgroundBrush$}">
-  <ScrollViewer>
+  <ScrollViewer IsTabStop="True">
     <Grid$toolkitSafeArea$>
       <StackPanel
         HorizontalAlignment="Center"

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainPage.xaml
@@ -7,7 +7,7 @@
 <!--#endif-->
       NavigationCacheMode="Required"
       Background="{ThemeResource $themeBackgroundBrush$}">
-  <ScrollViewer>
+  <ScrollViewer IsTabStop="True">
     <Grid$toolkitSafeArea$>
       <Grid.RowDefinitions>
         <RowDefinition Height="Auto" />


### PR DESCRIPTION
GitHub Issue (If applicable): related to https://github.com/unoplatform/uno-private/issues/919

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The page's `ScrollViewer` is not a tab stop, which means tapping on blank area of the screen won't unfocus input fields

## What is the new behavior?

Fixed

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
