### PR TITLE
use RelayCommandAttribute in uno templates when using the MVVM pattern

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/LoginPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/LoginPage.xaml
@@ -33,7 +33,7 @@
             HorizontalAlignment="Stretch" />
 <!--#endif-->
       <Button Content="Login"
-          Command="{Binding Login}"
+          Command="{Binding DoLoginCommand}"
           HorizontalAlignment="Stretch" />
     </StackPanel>
   </Grid>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/LoginPage.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/LoginPage.xaml.cs
@@ -47,7 +47,7 @@ public sealed partial class LoginPage : Page
                             new Button()
                                 .Content("Login")
                                 .HorizontalAlignment(HorizontalAlignment.Stretch)
-                                .Command(() => vm.Login)))));
+                                .Command(() => vm.DoLoginCommand)))));
 #else
         this.InitializeComponent();
 #endif

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/LoginViewModel.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/LoginViewModel.cs
@@ -26,9 +26,9 @@ public partial class LoginViewModel : ObservableObject
         _dispatcher = dispatcher;
         _navigator = navigator;
         _authentication = authentication;
-        Login = new AsyncRelayCommand(DoLogin);
     }
-
+    
+    [RelayCommand]
     private async Task DoLogin()
     {
 #if useCustomAuthentication
@@ -45,5 +45,4 @@ public partial class LoginViewModel : ObservableObject
 
     public string Title { get; } = "Login";
 
-    public ICommand Login { get; }
 }

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainPage.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainPage.xaml
@@ -45,10 +45,10 @@
             PlaceholderText="Enter your name:" />
         <Button Content="Go to Second Page"
             AutomationProperties.AutomationId="SecondPageButton"
-            Command="{Binding GoToSecond}" />
+            Command="{Binding GoToSecondViewCommand}" />
 <!--#if (useAuthentication)-->
         <Button Content="Logout"
-            Command="{Binding Logout}" />
+            Command="{Binding DoLogoutCommand}" />
 <!--#endif-->
       </StackPanel>
     </Grid>

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainPage.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//-:cnd:noEmit
+//-:cnd:noEmit
 namespace MyExtensionsApp._1.Presentation;
 
 public sealed partial class MainPage : Page
@@ -40,13 +40,13 @@ public sealed partial class MainPage : Page
                                 .Content("Go to Second Page")
                                 .AutomationProperties(automationId: "SecondPageButton")
 #if !useAuthentication
-                                .Command(() => vm.GoToSecond)
+                                .Command(() => vm.GoToSecondViewCommand)
 #else
-                                .Command(() => vm.GoToSecond),
+                                .Command(() => vm.GoToSecondViewCommand),
                             new Button()
                                 .Content("Logout")
                                 .AutomationProperties(automationId: "LogoutButton")
-                                .Command(() => vm.Logout)
+                                .Command(() => vm.DoLogoutCommand)
 #endif
                                 ))));
 #else

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainViewModel.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/MainViewModel.cs
@@ -43,33 +43,16 @@ public partial class MainViewModel : ObservableObject
 #if useConfiguration
         Title += $" - {appInfo?.Value?.Environment}";
 #endif
-        GoToSecond = new AsyncRelayCommand(GoToSecondView);
-#if mauiEmbedding
-        Counter = new RelayCommand(OnCount);
-#endif
-#if useAuthentication
-        Logout = new AsyncRelayCommand(DoLogout);
-#endif
     }
     public string? Title { get; }
-
-    public ICommand GoToSecond { get; }
-#if mauiEmbedding
-
-    public ICommand Counter { get; }
-#endif
-
-#if useAuthentication
-    public ICommand Logout { get; }
-
-#endif
+    [RelayCommand]
     private async Task GoToSecondView()
     {
         await _navigator.NavigateViewModelAsync<SecondViewModel>(this, data: new Entity(Name!));
     }
 
 #if mauiEmbedding
-
+    [RelayCommand]
     private void OnCount()
     {
         CounterText = ++count switch
@@ -80,6 +63,7 @@ public partial class MainViewModel : ObservableObject
     }
 #endif
 #if useAuthentication
+    [RelayCommand]
     public async Task DoLogout(CancellationToken token)
     {
         await _authentication.LogoutAsync(token);


### PR DESCRIPTION
GitHub Issue (If applicable): -

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the current behavior?
Currently the ICommand properties are not source generated.


## What is the new behavior?
The ICommand properties are being source generated.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Associated with an issue (GitHub or internal)

## Other information

I recently created an uno project using the templates you guys provide via https://new.platform.uno/.
I noticed when selecting the `MVVM` pattern, it does not utilize the [RelayCommandAttribute](https://learn.microsoft.com/en-us/dotnet/communitytoolkit/mvvm/generators/relaycommand) from the [CommunityToolkit.Mvvm](https://www.nuget.org/packages/CommunityToolkit.Mvvm).
Unless there are uno specific limitations or guidelines I'm not aware of, I don't see a reason to not use the source generated property.

I'm new to uno, so bear with me if what I'm proposing is total nonsense.