### PR TITLE
chore: Uno.Sdk Update - release/stable/5.6

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -6,7 +6,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 |----------------|:---------------:|
 | UnoVersion* | 5.6.99 |
 | UnoExtensionsVersion | 5.2.7 |
-| UnoToolkitVersion | 6.4.5 |
+| UnoToolkitVersion | 6.4.6 |
 | UnoThemesVersion | 5.4.0 |
 | UnoCSharpMarkupVersion | 5.6.7 |
 | UnoWasmBootstrapVersion** | 8.0.23 |
@@ -337,7 +337,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "Toolkit",
-    "version": "6.4.5",
+    "version": "6.4.6",
     "packages": [
       "Uno.Toolkit.WinUI",
       "Uno.Toolkit.WinUI.Cupertino",

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -88,7 +88,7 @@
   },
   {
     "group": "hotdesign",
-    "version": "1.8.13",
+    "version": "1.9.1",
     "packages": [
       "Uno.UI.HotDesign"
     ]
@@ -296,7 +296,7 @@
   },
   {
     "group": "Toolkit",
-    "version": "6.4.5",
+    "version": "6.4.6",
     "packages": [
       "Uno.Toolkit.WinUI",
       "Uno.Toolkit.WinUI.Cupertino",


### PR DESCRIPTION
This updates Uno.Sdk to the latest available version. Addressing previously missed latest versions for:
- Uno.UI.HotDesign
- Uno.Toolkit