### PR TITLE
Version bump after 6.0 release branch

### DIFF
--- a/.github/workflows/uno-updater.yml
+++ b/.github/workflows/uno-updater.yml
@@ -22,6 +22,7 @@ jobs:
         branch:
           - main
           - release/stable/5.6
+          - release/stable/6.0
 
     steps:
     - name: Checkout

--- a/version.json
+++ b/version.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.0-dev.{height}",
-  "versionHeightOffset": 86,
+  "version": "6.1-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
This updates the Uno.Sdk to the latest available version.
This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/6.0, based on #1376