### PR TITLE
fix(iOS): Use the console logging to log to the VS debug output

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.blank.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.blank.cs
@@ -129,6 +129,9 @@ $$EnableDeveloperMode_Frame_MainWindowContent$$
             builder.AddProvider(new global::Uno.Extensions.Logging.WebAssembly.WebAssemblyConsoleLoggerProvider());
 #elif __IOS__
             builder.AddProvider(new global::Uno.Extensions.Logging.OSLogLoggerProvider());
+
+            // Log to the Visual Studio Debug console
+            builder.AddConsole();
 #else
             builder.AddConsole();
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/19878

Ensures logging also goes to the output windows in VS for iOS debugging.