### PR TITLE
Version bump after 6.1 release branch

### DIFF
--- a/.github/workflows/uno-updater.yml
+++ b/.github/workflows/uno-updater.yml
@@ -23,6 +23,7 @@ jobs:
           - main
           - release/stable/5.6
           - release/stable/6.0
+          - release/stable/6.1
 
     steps:
     - name: Checkout

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.1-dev.{height}",
+  "version": "6.2-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
This updates the Uno.Sdk to the latest available version.
This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/6.1, based on #1628