### PR TITLE
feat(AssertionLibrary): Add assertion library choice to templates

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -8,6 +8,7 @@
     <NUnitVersion Condition="'$(NUnitVersion)' == ''">4.1.0</NUnitVersion>
     <NUnit3TestAdapterVersion Condition="'$(NUnit3TestAdapterVersion)' == ''">4.5.0</NUnit3TestAdapterVersion>
     <FluentAssertionsVersion Condition="'$(FluentAssertionsVersion)' == ''">6.12.0</FluentAssertionsVersion>
+    <ShouldlyVersion Condition="'$(ShouldlyVersion)' == ''">4.3.0</ShouldlyVersion>
     <CoverletCollectorVersion Condition="'$(CoverletCollectorVersion)' == ''">6.0.2</CoverletCollectorVersion>
     <NewtonsoftJsonVersion Condition="'$(NewtonsoftJsonVersion)' == ''">13.0.3</NewtonsoftJsonVersion>
     <XamarinUITestVersion Condition="'$(XamarinUITestVersion)' == ''">4.3.4</XamarinUITestVersion>

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -46,6 +46,7 @@
 		<ReplaceFileText Filename="%(_VersionableFile.Identity)" MatchExpression="$NUnit$" ReplacementText="$(NUnitVersion)" />
 		<ReplaceFileText Filename="%(_VersionableFile.Identity)" MatchExpression="$NUnit3TestAdapter$" ReplacementText="$(NUnit3TestAdapterVersion)" />
 		<ReplaceFileText Filename="%(_VersionableFile.Identity)" MatchExpression="$FluentAssertions$" ReplacementText="$(FluentAssertionsVersion)" />
+		<ReplaceFileText Filename="%(_VersionableFile.Identity)" MatchExpression="$Shouldly$" ReplacementText="$(ShouldlyVersion)" />
 		<ReplaceFileText Filename="%(_VersionableFile.Identity)" MatchExpression="$CoverletCollector$" ReplacementText="$(CoverletCollectorVersion)" />
 		<ReplaceFileText Filename="%(_VersionableFile.Identity)" MatchExpression="$NewtonsoftJson$" ReplacementText="$(NewtonsoftJsonVersion)" />
 		<ReplaceFileText Filename="%(_VersionableFile.Identity)" MatchExpression="$XamarinUITest$" ReplacementText="$(XamarinUITestVersion)" />

--- a/src/Uno.Templates/content/unoapp/.template.config/TemplateWizard.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/TemplateWizard.json
@@ -97,6 +97,7 @@
 					"server": "false",
 					"skipRestore": "true",
 					"tests": "none",
+					"assertionLibrary": "none",
 					"tfm": "net9.0",
 					"toolkit": "false",
 					"vscode": "true",
@@ -112,7 +113,7 @@
 					"renderer": "skia"
 				},
 				"Features": [
-					".NET 8",
+					".NET 9",
 					"XAML"
 				]
 			},
@@ -139,6 +140,7 @@
 					"server": "false",
 					"skipRestore": "true",
 					"tests": "none",
+					"assertionLibrary": "none",
 					"tfm": "net9.0",
 					"toolkit": "true",
 					"vscode": "true",
@@ -154,7 +156,7 @@
 					"renderer": "skia"
 				},
 				"Features": [
-					".NET 8",
+					".NET 9",
 					"XAML",
 					"MVUX",
 					"Material",
@@ -293,6 +295,13 @@
 				"SectionType": "MultiSelect",
 				"SymbolId": "tests",
 				"Choices": [ "unit", "ui" ]
+			},
+			{
+				"Title": "Assertion Library",
+				"SectionType": "SingleSelect",
+				"SymbolId": "assertionLibrary",
+				"Choices": [ "none", "Shouldly", "FluentAssertions" ],
+				"NestedIn": "tests"
 			}
 		],
 		"Theme": [
@@ -653,6 +662,31 @@
 
 			"Icon": "/Assets/Test.UnitTest.svg"
 		},
+		"tests.ui.assertion": {
+			"NoValue": "none"
+		},
+		"tests.ui.assertion.shouldly": {
+			// "Icon": "/Assets/Test.UiTest.Shouldly.svg" TODO: Add icon
+			"Sequence": 1,
+			"Tag":{
+				"Requires": {
+					"tests": {
+						"RequiredValues": [ "!none" ],
+						"MoreInformation": "Test selection is required to use Shouldly Assertion library"
+					}
+			}
+		}
+		},
+		"tests.ui.assertion.fluentAssertions": {
+			// "Icon": "/Assets/Test.UiTest.FluentAssertions.svg" TODO: Add icon
+			"Sequence": 2,
+			"Requires": {
+				"tests": {
+					"RequiredValues": [ "!none" ],
+					"MoreInformation": "Test selection is required to use Fluent Assertions library"
+				}
+			}
+		},
 		"tfm.net6.0": {
 			"Sequence": 1,
 			"Icon": "/Assets/Framework.NET6.svg"
@@ -756,6 +790,7 @@
 		"appTheme",
 		"platforms",
 		"tests",
+		"assertionLibrary",
 		"server",
 		"dependencyInjection",
 		"configuration",

--- a/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
@@ -49,6 +49,10 @@
       "longName": "tests",
       "shortName": "tests"
     },
+    "assertionLibrary": {
+      "longName": "assertion-library",
+      "shortName": "assertion"
+    },
     "toolkit": {
       "longName": "toolkit",
       "shortName": "toolkit"

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -307,6 +307,39 @@
         }
       ]
     },
+    "assertionLibrary": {
+      "displayName": "Assertion Library",
+      "type": "parameter",
+      "datatype": "choice",
+      "defaultValue": "none",
+      "allowMultipleValues": false,
+      "description": "Choose the assertion library for tests",
+      "enableQuotelessLiterals": true,
+      "isEnabled": "tests != none",
+      "onlyIf": [
+        {
+          "symbol": "tests",
+          "value":"unit|ui"
+        }
+      ],
+      "choices": [
+        {
+          "choice": "none",
+          "displayName": "No Assertion Library",
+          "description": "Do not use any specific assertion library and only use the built-in assertions provided by the test framework"
+        },
+        {
+          "choice": "Shouldly",
+          "displayName": "Shouldly",
+          "description": "Use Shouldly for assertions in tests"
+        },
+        {
+          "choice": "FluentAssertions",
+          "displayName": "Fluent Assertions",
+          "description": "Use Fluent Assertions for assertions in tests"
+        }
+      ]
+    },
     "AllowPrereleaseNetSdk": {
       "type": "generated",
       "generator": "switch",
@@ -1189,6 +1222,14 @@
         "source": "testsEvaluator",
         "pattern": ".*ui.*"
       }
+    },
+    "useFluentAssertions": {
+      "type": "computed",
+      "value": "(assertionLibrary == FluentAssertions)"
+    },
+    "useShouldly": {
+      "type": "computed",
+      "value": "(assertionLibrary == Shouldly)"
     },
     "useServer": {
       "type": "computed",

--- a/src/Uno.Templates/content/unoapp/Directory.Packages.props
+++ b/src/Uno.Templates/content/unoapp/Directory.Packages.props
@@ -8,7 +8,12 @@
   <ItemGroup>
     <!--#if (useTestSolutionFolder)-->
     <PackageVersion Include="coverlet.collector" Version="$CoverletCollector$" />
+    <!--#if (useFluentAssertions)-->
     <PackageVersion Include="FluentAssertions" Version="$FluentAssertions$" />
+    <!--#endif-->
+    <!--#if (useShouldly)-->
+    <PackageVersion Include="Shouldly" Version="$ShouldlyVersion$" />
+    <!--#endif-->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="$MicrosoftTestSdk$" />
     <PackageVersion Include="NUnit" Version="$NUnit$" />
     <PackageVersion Include="NUnit3TestAdapter" Version="$NUnit3TestAdapter$" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Tests/AppInfoTests.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Tests/AppInfoTests.cs
@@ -12,8 +12,16 @@ public class AppInfoTests
     public void AppInfoCreation()
     {
         var appInfo = new AppConfig { Environment = "Test" };
-
+#if(useFluentAssertions)
         appInfo.Should().NotBeNull();
         appInfo.Environment.Should().Be("Test");
+#endif
+#if(useShouldly)
+            appInfo.ShouldNotBeNull();
+            appInfo.Environment.ShouldBe("Test");
+#else
+        Assert.That(appInfo,Is.Not.Null);
+        Assert.That(appInfo.Environment, Is.EqualTo("Test"));
+#endif
     }
 }

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Tests/GlobalUsings.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Tests/GlobalUsings.cs
@@ -1,6 +1,11 @@
-//+:cnd:noEmit
-global using FluentAssertions;
+//-:cnd:noEmit
 #if useBusinessModelsNamespace
 global using MyExtensionsApp._1.Models;
+#endif
+#if(useFluentAssertions)
+global using FluentAssertions;
+#endif
+#if(useShouldly)
+global using Shouldly;
 #endif
 global using NUnit.Framework;

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Tests/MyExtensionsApp.1.Tests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.Tests/MyExtensionsApp.1.Tests.csproj
@@ -7,7 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!--#if (useFluentAssertions)-->
     <PackageReference Include="FluentAssertions" />
+    <!--#endif-->
+    <!--#if (useShouldly)-->
+    <PackageReference Include="Shouldly" />
+    <!--#endif-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/MyExtensionsApp.1.UITests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/MyExtensionsApp.1.UITests.csproj
@@ -6,9 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--#if (assertionLibrary == "FluentAssertions")-->
+    <!--#if (useFluentAssertions)-->
     <PackageReference Include="FluentAssertions" />
-    <!--#elif (assertionLibrary == "Shouldly")-->
+    <!--#endif-->
+    <!--#if(useShouldly)-->
     <PackageReference Include="Shouldly" />
     <!--#endif-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/MyExtensionsApp.1.UITests.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1.UITests/MyExtensionsApp.1.UITests.csproj
@@ -6,7 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!--#if (assertionLibrary == "FluentAssertions")-->
     <PackageReference Include="FluentAssertions" />
+    <!--#elif (assertionLibrary == "Shouldly")-->
+    <PackageReference Include="Shouldly" />
+    <!--#endif-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NUnit" />

--- a/src/Uno.Templates/content/unolib-uitest/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unolib-uitest/.template.config/dotnetcli.host.json
@@ -7,6 +7,10 @@
     },
     "unoUITestHelpersVersion": {
       "isHidden": true
+    },
+    "assertionLibrary": {
+      "longName": "assertionLibrary",
+      "shortName": "assertion"
     }
   }
 }

--- a/src/Uno.Templates/content/unolib-uitest/.template.config/template.json
+++ b/src/Uno.Templates/content/unolib-uitest/.template.config/template.json
@@ -55,13 +55,15 @@
       "type": "parameter",
       "datatype": "choice",
       "defaultValue": "none",
-      "replaces": "$assertionLibrary$",
+      "enableQuotelessLiterals": true,
+      "allowMultipleValues": false,
+      "isEnabled": "tests != none",
       "description": "Choose the assertion library for tests",
       "choices": [
         {
           "choice": "none",
           "displayName": "No Assertion Library",
-          "description": "Do not use any specific assertion library"
+          "description": "Do not use any specific assertion library and only use the built-in assertions provided by the test framework"
         },
         {
           "choice": "Shouldly",
@@ -74,6 +76,14 @@
           "description": "Use Fluent Assertions for assertions in tests"
         }
       ]
+    },
+    "useFluentAssertions": {
+      "type": "computed",
+      "value": "(assertionLibrary == FluentAssertions)"
+    },
+    "useShouldly": {
+      "type": "computed",
+      "value": "(assertionLibrary == Shouldly)"
     }
   },
   "primaryOutputs": [

--- a/src/Uno.Templates/content/unolib-uitest/.template.config/template.json
+++ b/src/Uno.Templates/content/unolib-uitest/.template.config/template.json
@@ -49,6 +49,31 @@
           "description": "Target .NET 9.0 (Standard Term Support)"
         }
       ]
+    },
+    "assertionLibrary": {
+      "displayName": "Assertion Library",
+      "type": "parameter",
+      "datatype": "choice",
+      "defaultValue": "none",
+      "replaces": "$assertionLibrary$",
+      "description": "Choose the assertion library for tests",
+      "choices": [
+        {
+          "choice": "none",
+          "displayName": "No Assertion Library",
+          "description": "Do not use any specific assertion library"
+        },
+        {
+          "choice": "Shouldly",
+          "displayName": "Shouldly",
+          "description": "Use Shouldly for assertions in tests"
+        },
+        {
+          "choice": "FluentAssertions",
+          "displayName": "Fluent Assertions",
+          "description": "Use Fluent Assertions for assertions in tests"
+        }
+      ]
     }
   },
   "primaryOutputs": [

--- a/src/Uno.Templates/content/unolib-uitest/Constants.cs
+++ b/src/Uno.Templates/content/unolib-uitest/Constants.cs
@@ -1,19 +1,12 @@
-﻿//-:cnd:noEmit
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Uno.UITest.Helpers.Queries;
-
-namespace UnoUITestsLibrary;
+﻿namespace UnoUITestsLibrary;
 
 public class Constants
 {
-	public readonly static string WebAssemblyDefaultUri = "http://localhost:64555/";
-	public readonly static string iOSAppName = "com.example.app";
-	public readonly static string AndroidAppName = "com.example.app";
-	public readonly static string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (3rd generation)";
+    public readonly static string WebAssemblyDefaultUri = "http://localhost:5000/";
+    public readonly static string iOSAppName = "com.companyname.myextensionsapp";
+    public readonly static string AndroidAppName = "com.companyname.myextensionsapp";
+    public readonly static string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (3rd generation)";
 
-	public readonly static Platform CurrentPlatform = Platform.Browser;
+    public readonly static Platform CurrentPlatform = Platform.Browser;
+    public readonly static Browser WebAssemblyBrowser = Browser.Chrome;
 }

--- a/src/Uno.Templates/content/unolib-uitest/Constants.cs
+++ b/src/Uno.Templates/content/unolib-uitest/Constants.cs
@@ -1,4 +1,5 @@
-﻿namespace UnoUITestsLibrary;
+﻿//-:cnd:noEmit
+namespace UnoUITestsLibrary;
 
 public class Constants
 {

--- a/src/Uno.Templates/content/unolib-uitest/Given_MainPage.cs
+++ b/src/Uno.Templates/content/unolib-uitest/Given_MainPage.cs
@@ -1,12 +1,4 @@
 ﻿//-:cnd:noEmit
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NUnit.Framework;
-using Uno.UITest.Helpers.Queries;
-using Query = System.Func<Uno.UITest.IAppQuery, Uno.UITest.IAppQuery>;
 
 namespace UnoUITestsLibrary;
 

--- a/src/Uno.Templates/content/unolib-uitest/GlobalUsings.cs
+++ b/src/Uno.Templates/content/unolib-uitest/GlobalUsings.cs
@@ -1,0 +1,6 @@
+//-:cnd:noEmit
+global using NUnit.Framework;
+global using Uno.UITest;
+global using Uno.UITest.Helpers.Queries;
+global using Uno.UITests.Helpers;
+global using Query = System.Func<Uno.UITest.IAppQuery, Uno.UITest.IAppQuery>;

--- a/src/Uno.Templates/content/unolib-uitest/GlobalUsings.cs
+++ b/src/Uno.Templates/content/unolib-uitest/GlobalUsings.cs
@@ -1,4 +1,10 @@
 //-:cnd:noEmit
+#if (useFluentAssertions)
+global using FluentAssertions;
+#endif
+#if (useShouldly)
+global using Shouldly;
+#endif
 global using NUnit.Framework;
 global using Uno.UITest;
 global using Uno.UITest.Helpers.Queries;

--- a/src/Uno.Templates/content/unolib-uitest/TestBase.cs
+++ b/src/Uno.Templates/content/unolib-uitest/TestBase.cs
@@ -1,10 +1,4 @@
 ﻿//-:cnd:noEmit
-using System;
-using System.IO;
-using NUnit.Framework;
-using Uno.UITest;
-using Uno.UITest.Selenium;
-using Uno.UITests.Helpers;
 
 namespace UnoUITestsLibrary;
 

--- a/src/Uno.Templates/content/unolib-uitest/UnoUITestsLibrary.csproj
+++ b/src/Uno.Templates/content/unolib-uitest/UnoUITestsLibrary.csproj
@@ -8,7 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!--#if (assertionLibrary == "FluentAssertions")-->
     <PackageReference Include="FluentAssertions" VersionOverride="$FluentAssertions$" />
+    <!--#elif (assertionLibrary == "Shouldly")-->
+    <PackageReference Include="Shouldly" VersionOverride="$ShouldlyVersion$" />
+    <!--#endif-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" VersionOverride="$MicrosoftTestSdk$" />
     <PackageReference Include="Newtonsoft.Json" VersionOverride="$NewtonsoftJson$" />
     <PackageReference Include="NUnit" VersionOverride="$NUnit$" />

--- a/src/Uno.Templates/content/unolib-uitest/UnoUITestsLibrary.csproj
+++ b/src/Uno.Templates/content/unolib-uitest/UnoUITestsLibrary.csproj
@@ -8,9 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--#if (assertionLibrary == "FluentAssertions")-->
+    <!--#if (useFluentAssertions)-->
     <PackageReference Include="FluentAssertions" VersionOverride="$FluentAssertions$" />
-    <!--#elif (assertionLibrary == "Shouldly")-->
+    <!--#endif-->
+    <!--#if (useShouldly)-->
     <PackageReference Include="Shouldly" VersionOverride="$ShouldlyVersion$" />
     <!--#endif-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" VersionOverride="$MicrosoftTestSdk$" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1607

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Feature
- Enhancement of User-Expirience

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Creating a new Project from template, will always include FluentAssertions Package, which is up from v8.0 commercial and paid.
for more information about the reason this should be made available to activly select, see the linked issues.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
This PR should enable us users to activly choose IF and WHICH assertion Library we want to use.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->
Partially about Parent issue of 1607 : #1605
@MartinZikmund @jeromelaban 
Its likly, as this is my first time with dotnet templates, that there will be some issues made so would be great to get some help ❤️ I tryed my best to follow the templating wiki of the CLI

Would add an xUnit Testing project option at some later point in a seperate PR to improve it for #1258 

## This PR needs help on:

- implementing it to the Visual Studion Wizard
  as there is no schema for the TemplateWizard.json available, I would assume, that uses a internal flow. I added a Property "NestedIn" for the assertionLibrary symbols, but would need someone from the team to implement or update this. Maybe if it is a own schema you are using (and this file is overall used) it would be great if you could add such schema reference in the repository
- The choice of the assertionLibrary at least for the vsix templates could be made available per Test project, but I am not sure how to do that exactly, but would be nice to have!

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
