### PR TITLE
chore(FluentAssertions): Update provided Version to latest free and pin it there

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -7,7 +7,7 @@
     <MicrosoftTestSdkVersion Condition="'$(MicrosoftTestSdkVersion)' == ''">17.9.0</MicrosoftTestSdkVersion>
     <NUnitVersion Condition="'$(NUnitVersion)' == ''">4.1.0</NUnitVersion>
     <NUnit3TestAdapterVersion Condition="'$(NUnit3TestAdapterVersion)' == ''">4.5.0</NUnit3TestAdapterVersion>
-    <FluentAssertionsVersion Condition="'$(FluentAssertionsVersion)' == ''">6.12.0</FluentAssertionsVersion>
+    <FluentAssertionsVersion Condition="'$(FluentAssertionsVersion)' == ''">[7.2.0]</FluentAssertionsVersion>
     <CoverletCollectorVersion Condition="'$(CoverletCollectorVersion)' == ''">6.0.2</CoverletCollectorVersion>
     <NewtonsoftJsonVersion Condition="'$(NewtonsoftJsonVersion)' == ''">13.0.3</NewtonsoftJsonVersion>
     <XamarinUITestVersion Condition="'$(XamarinUITestVersion)' == ''">4.3.4</XamarinUITestVersion>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1625 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)

- Project automation
- Other... Please describe:

-->
- Dependency update for the provided Templates
- User/Consumer Expirience improvement
- Build or CI related changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Package Version is lower than needed
- Using the provided github actions dependabot routine, the user of the template could get into licensing trouble, when not checking that version for now be payed license

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
- Updated the Version to the latest free (Apache2.0) version
- pinning the version of this particular Package

   By pinning that version, the user still has the active choice, to remove the Brackets, if he might want to pay for newer versions, but those who may don't want to, but using GitHub actions and dependabot, will not run into licensing problems by accident. This results also in a better user experience

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->
Maybe there should be added a note in the documentation thats informing the user about this, but kind of all testing documentation are in contribution section, which makes it not clearly visible for non-contributor users
Maybe that should get added in the templating docs, but those are not on this Repository => can not be included in this PR by that. maybe move the #1606 issue to the appropriate repo, which holds that docs and resolve it there?

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
