### PR TITLE
Improve editor config for two intendation files

### DIFF
--- a/src/Uno.Templates/content/unoapp/.editorconfig
+++ b/src/Uno.Templates/content/unoapp/.editorconfig
@@ -23,7 +23,7 @@ charset = utf-8
 indent_size = 2
 indent_style = space
 
-[.{vsconfig,csproj,proj,projitems,sh,shproj,props,targets,xml,json,slnf,css,webmanifest,manifest,plist}]
+[.{vsconfig,csproj,proj,projitems,sh,shproj,props,targets,json,slnf,css,webmanifest,manifest,plist}]
 end_of_line = lf
 
 [*.xaml]
@@ -36,6 +36,10 @@ indent_style = tab
 [web.config]
 indent_size = 4
 end_of_line = lf
+
+[*.{xml,xaml,json}]
+# EOL should be normalized by Git. Setting to lf seems to mess up on Windows Hosts sometimes. See https://github.com/unoplatform/uno.templates/issues/1501
+end_of_line = unset
 
 [*.cs]
 # EOL should be normalized by Git. See https://github.com/dotnet/format/issues/1099

--- a/src/Uno.Templates/content/unoapp/.editorconfig
+++ b/src/Uno.Templates/content/unoapp/.editorconfig
@@ -19,56 +19,22 @@ charset = utf-8
 # File Extension Settings
 ##########################################
 
-[*.{yml,yaml}]
+[*.{xaml,xml,yml,yaml,slnf,sln,csproj,proj,projitems,shproj,props,targets,appxmanifest,json,html,cshtml,webmanifest,manifest,css,vsconfig,sh,md,markdown}]
 indent_size = 2
+indent_style = space
 
-[.vsconfig]
-indent_size = 2
+[.{vsconfig,csproj,proj,projitems,sh,shproj,props,targets,xml,json,slnf,css,webmanifest,manifest,plist}]
 end_of_line = lf
-
-[*.sln]
-indent_style = tab
-indent_size = 2
-
-[*.{csproj,proj,projitems,shproj}]
-indent_size = 4
-
-[*.{json,slnf}]
-indent_size = 2
-end_of_line = lf
-
-[*.{props,targets}]
-indent_size = 4
 
 [*.xaml]
-indent_size = 4
 charset = utf-8-bom
-
-[*.xml]
-indent_size = 4
-end_of_line = lf
 
 [*.plist]
 indent_size = 4
 indent_style = tab
-end_of_line = lf
-
-[*.manifest]
-indent_size = 4
-
-[*.appxmanifest]
-indent_size = 4
-
-[*.{json,css,webmanifest}]
-indent_size = 2
-end_of_line = lf
 
 [web.config]
 indent_size = 4
-end_of_line = lf
-
-[*.sh]
-indent_size = 2
 end_of_line = lf
 
 [*.cs]


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1501

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- unset eol for xml xaml and json, so the eol warnings may disappear on Windows host VS2022 in the templates in the future
- editing xml and xaml files in my app with by default using tab for intending was resulting in 4 intentendations instead of the actually pre provided 2 space intendations in all of them (also props and targets and csproj files!) which of course does resulting of this messing up when I were using intellicode suggestions, copilot or Hot Design Feature. If they are correctly behaved looking at the editorconfig, I were not expecting this configuration and got annoyed from the time having to spend to delete the not wanted intendations.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
- unset eol for xml xaml and json, so the eol warnings may disappear on Windows host VS2022 in the templates in the future
- update indent_size and indent_style settings

    xml and xaml based language files should not be provided with 2 indent spaces but when edited with using of tab or HD add 4 spaces. That disturbed the layout in the file messes up when using copilot completion accepting ect.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->
there might be other related open issues (HD) which could be helped with this as a base config thats already messing the styling up is not very helpful if you want to build on it (sand compared to rocks ;) )

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
