### PR TITLE
fix(globaljson): missing space character at global.json file caused the file to be filed for refactoring from the very beginning after app creation

### DIFF
--- a/src/Uno.Templates/content/unoapp/global.json
+++ b/src/Uno.Templates/content/unoapp/global.json
@@ -3,7 +3,7 @@
   "msbuild-sdks": {
     "Uno.Sdk": "$UnoSdkVersion$"
   },
-  "sdk":{
+  "sdk": {
     "allowPrerelease": $AllowPrereleaseNetSdk$
   }
 }


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno.templates/issues/1632

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Code style update (formatting)
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature

- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
opening the global.json file resulted in editorconfig caused adding of the missing space or the suggestion to do this, as a json file does normally have there a space character.
If I as user who got this annoying issue, did manually add this or my IDE did add this automatically, this were causing uno.check to fail with the error you can inspect in the linked issue

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

Added the missing character, which is automatically added if the local IDE Settings in VS 2022 e.g. are set to auto-fix those styling issues.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->
> [!IMPORTANT]
> Adding this character does cause uno-check to fail, so marking this PR as breaking change, as I am sure, that until someone would fix the expected missing space character in Uno.Check, this will potentially cause failing of this.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
