### PR TITLE
ci: remove explicit packages-microsoft-prod.deb

### DIFF
--- a/.github/actions/ci/run-tests/action.yml
+++ b/.github/actions/ci/run-tests/action.yml
@@ -135,9 +135,6 @@ runs:
     shell: bash
     run: |
       sudo rm -fR /usr/lib/jvm
-      ubuntu_release=`lsb_release -rs` 
-      wget  https://packages.microsoft.com/config/ubuntu/${ubuntu_release}/packages-microsoft-prod.deb -O packages-microsoft-prod.deb 
-      sudo dpkg -i packages-microsoft-prod.deb 
       sudo apt-get install apt-transport-https 
       sudo apt-get update 
       sudo apt-get install -y msopenjdk-11


### PR DESCRIPTION
The GitHub Ubuntu runner-images already include the microsoft-packages.deb by default