### PR TITLE
feat(Uno.Sdk.Updater): Add CLI exclude-file support and improve manifest merge logic

### DIFF
--- a/.github/actions/sdk-update/action.yml
+++ b/.github/actions/sdk-update/action.yml
@@ -27,6 +27,4 @@ runs:
 
     - name: Run Uno Sdk Updater
       shell: pwsh
-      env:
-        UNO_SDK_EXCLUDE_FILE: ${{ inputs['exclude-file'] }}
-      run: dotnet run -c Release --project tools/Uno.Sdk.Updater
+      run: dotnet run -c Release --project tools/Uno.Sdk.Updater -- --exclude-file "${{ inputs['exclude-file'] }}"

--- a/.github/actions/sdk-update/action.yml
+++ b/.github/actions/sdk-update/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'base branch'
     required: true
     default: 'main'
+  exclude-file:  # packages to exclude for the update
+    description: 'Path to the JSON exclude file'
+    required: false
+    default: '.github/sdk-update-exclude.json'
 
 runs:
   using: "composite"
@@ -22,5 +26,7 @@ runs:
         setAllVars: true
 
     - name: Run Uno Sdk Updater
-      run: dotnet run -c Release --project tools/Uno.Sdk.Updater
       shell: pwsh
+      env:
+        UNO_SDK_EXCLUDE_FILE: ${{ inputs['exclude-file'] }}
+      run: dotnet run -c Release --project tools/Uno.Sdk.Updater

--- a/.github/sdk-update-exclude.json
+++ b/.github/sdk-update-exclude.json
@@ -1,0 +1,6 @@
+{
+  "exclude": [
+    "SvgSkia"
+  ]
+}
+

--- a/tools/Uno.Sdk.Updater/Config/ExcludeConfig.cs
+++ b/tools/Uno.Sdk.Updater/Config/ExcludeConfig.cs
@@ -1,0 +1,57 @@
+﻿namespace Uno.Sdk.Updater.Config
+{
+    // Exclusions (JSON via --exclude-file)
+    internal static class ExcludeConfig
+    {
+        public static string? ExcludeFilePath { get; set; }
+
+        private static readonly Lazy<HashSet<string>> _excluded = new(() => Load());
+        public static HashSet<string> Excluded => _excluded.Value;
+
+        private static HashSet<string> Load()
+        {
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            var path = ExcludeFilePath;
+            if (string.IsNullOrWhiteSpace(path))
+                return set; // no exclusions when not provided
+
+            // Normalize relative path
+            if (!Path.IsPathRooted(path))
+                path = Path.GetFullPath(path);
+
+            if (!File.Exists(path))
+            {
+                Console.WriteLine($"Exclude file not found: {path}");
+                return set;
+            }
+
+            try
+            {
+                using var fs = File.OpenRead(path);
+                using var doc = System.Text.Json.JsonDocument.Parse(fs);
+                if (doc.RootElement.TryGetProperty("exclude", out var arr) &&
+                    arr.ValueKind == System.Text.Json.JsonValueKind.Array)
+                {
+                    foreach (var el in arr.EnumerateArray())
+                    {
+                        if (el.ValueKind == System.Text.Json.JsonValueKind.String)
+                        {
+                            var s = el.GetString();
+                            if (!string.IsNullOrWhiteSpace(s))
+                                set.Add(s);
+                        }
+                    }
+                }
+
+                Console.WriteLine($"Loaded {set.Count} exclusion(s) from {path}");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to read exclude file: {ex.Message}");
+            }
+
+            return set;
+        }
+    }
+}

--- a/tools/Uno.Sdk.Updater/Program.cs
+++ b/tools/Uno.Sdk.Updater/Program.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using Uno.Sdk.Models;
 using Uno.Sdk.Services;
 using Uno.Sdk.Updater;
+using Uno.Sdk.Updater.Config;
 using Uno.Sdk.Updater.Utils;
 
 const string UnoSdkPackageId = "Uno.Sdk.Private";
@@ -15,6 +16,9 @@ Console.WriteLine($"Base Version: {UpdaterBuildContext.TemplateVersion}");
 Console.WriteLine($"Minimum Search Version: {UpdaterBuildContext.MinVersion}");
 Console.WriteLine($"Maximum Search Version: {UpdaterBuildContext.MaxVersion}");
 WriteBreak();
+
+// Minimal CLI parsing for --exclude-file
+ExcludeConfig.ExcludeFilePath = Cli.GetArgValue("--exclude-file");
 
 var jsonOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
 {
@@ -53,7 +57,7 @@ string? description = null;
 string? tags = null;
 bool wroteChanges = false;
 
-foreach(var entry in sdkZip.Entries)
+foreach (var entry in sdkZip.Entries)
 {
     var extension = Path.GetExtension(entry.FullName);
     string[] allowedExtensions = [".md", ".json", ".nuspec"];
@@ -88,13 +92,12 @@ foreach(var entry in sdkZip.Entries)
         var inputManifest = await JsonSerializer.DeserializeAsync<IEnumerable<ManifestGroup>>(packageStream)
             ?? throw new InvalidOperationException("Unable to parse the packages.json from the Sdk.");
 
-        if (!unoVersion.IsPreview)
-        {
-            inputManifest = MergeLocalManifest(inputManifest, outputPath);
-        }
+        inputManifest = unoVersion.IsPreview
+        ? MergeLocalOverridesOnly(inputManifest, outputPath)  // keep only local VersionOverride entries
+        : MergeLocalManifest(inputManifest, outputPath);      // full merge as before
 
         var manifest = new List<ManifestGroup>();
-        foreach(var group in inputManifest)
+        foreach (var group in inputManifest)
         {
             var updated = await UpdateGroup(group, unoVersion, client);
             manifest.Add(updated);
@@ -135,7 +138,7 @@ if (!string.IsNullOrEmpty(readMePath) && File.Exists(readMePath) &&
     var manifestJson = File.ReadAllText(packagesJsonPath);
     var manifest = JsonSerializer.Deserialize<IEnumerable<ManifestGroup>>(manifestJson) ?? [];
 
-    foreach(var group in manifest)
+    foreach (var group in manifest)
     {
         readMe = Regex.Replace(readMe, Regex.Escape($"${group.Group}$"), group.Version);
     }
@@ -175,6 +178,49 @@ static IEnumerable<ManifestGroup> MergeLocalManifest(IEnumerable<ManifestGroup> 
     }
 
     return mergedManifest;
+}
+
+// Keep local versions as baseline. Only ensure local VersionOverride are present,
+// and bring in any brand-new groups that exist in the SDK manifest.
+static IEnumerable<ManifestGroup> MergeLocalOverridesOnly(IEnumerable<ManifestGroup> sdkManifest, string packagesJsonPath)
+{
+    var local = JsonSerializer.Deserialize<IEnumerable<ManifestGroup>>(File.ReadAllText(packagesJsonPath))
+               ?? throw new InvalidOperationException($"Unable to parse local packages.json at '{packagesJsonPath}'.");
+
+    // Start from LOCAL manifest -> prevents downgrades of existing groups
+    var map = local.ToDictionary(g => g.Group, g => g, StringComparer.OrdinalIgnoreCase);
+
+    // Keep local versions as the baseline to prevent downgrades.
+    // For groups that have local VersionOverride entries, merge them over the
+    // existing overrides in the map (local wins). This preserves any SDK overrides
+    // that local did not specify, and ensures a case-insensitive dictionary.
+    foreach (var lg in local)
+    {
+        if (lg.VersionOverride is { Count: > 0 } && map.TryGetValue(lg.Group, out var existing))
+        {
+            // Start from existing overrides so we don't drop SDK-provided keys
+            var merged = existing.VersionOverride is null
+                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(existing.VersionOverride, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var kv in lg.VersionOverride)
+            {
+                // Local overrides win (overwrite)
+                merged[kv.Key] = kv.Value;
+            }
+
+            map[lg.Group] = existing with { VersionOverride = merged };
+        }
+    }
+
+    // Add brand-new groups that exist in SDK but not locally
+    foreach (var sg in sdkManifest)
+    {
+        if (!map.ContainsKey(sg.Group))
+            map[sg.Group] = sg;
+    }
+
+    return map.Values;
 }
 
 static void WriteIfDifferent(string filePath, string content, ref bool didWriteChanges)
@@ -279,7 +325,7 @@ static string GetManifestGroupVersionOverride(IEnumerable<ManifestGroup> manifes
         return group.VersionOverride[overrideKey];
     }
 
-throw new InvalidOperationException($"No Version Overrides were found for {groupId} or the key {overrideKey}.");
+    throw new InvalidOperationException($"No Version Overrides were found for {groupId} or the key {overrideKey}.");
 }
 
 static async Task<ManifestGroup> UpdateGroup(ManifestGroup group, NuGetVersion unoVersion, NuGetApiClient client)
@@ -355,21 +401,33 @@ static async Task<ManifestGroup> UpdateGroup(ManifestGroup group, NuGetVersion u
     if (group.VersionOverride is not null && group.VersionOverride.Count != 0)
     {
         var updatedOverrides = new Dictionary<string, string>();
-        foreach((var key, var versionOverrideString) in group.VersionOverride)
+        foreach ((var key, var versionOverrideString) in group.VersionOverride)
         {
             if (!NuGetVersion.TryParse(versionOverrideString, out var versionOverride))
             {
-                Console.WriteLine($"Could not parse version '{versionOverrideString} for {group.Group}.");
+                Console.WriteLine($"Could not parse version '{versionOverrideString}' for group '{group.Group}', package '{packageId}'.");
                 continue;
             }
 
-            version = await client.GetVersionAsync(packageId, versionOverride.IsPreview, noMajorUpgrade, versionOverride.OriginalVersion);
+            // Explicit VersionOverrides should always allow major upgrades
+            version = await client.GetVersionAsync(packageId, versionOverride.IsPreview, false, versionOverride.OriginalVersion);
             if (version != versionOverrideString)
             {
                 Console.WriteLine($"Updated Version Override for '{group.Group}' - '{key}' to '{version}'.");
             }
 
-            version = NuGetVersion.Parse(version) < versionOverride ? versionOverrideString : version;
+            if (!NuGetVersion.TryParse(version, out var parsedVersion))
+            {
+                Console.WriteLine($"Could not parse version '{version}' for {group.Group}.");
+                // Fall back to the local override as a safe default
+                version = versionOverride.OriginalVersion;
+            }
+            else if (parsedVersion < versionOverride)
+            {
+                // Keep the local override (e.g., 10.0.0-preview) if the feed returns a lower version (e.g., 9.x)
+                version = versionOverride.OriginalVersion;
+            }
+
             updatedOverrides.Add(key, version);
         }
 
@@ -392,56 +450,5 @@ internal record MsBuildItem(string Include, IDictionary<string, string> Attribut
         var attributeList = Attributes.Select(x => $"{x.Key}=\"{x.Value}\"");
         var attributes = string.Join(" ", attributeList);
         return $"<{ItemType} Include=\"{Include}\" {attributes} />";
-    }
-}
-
-static class ExcludeConfig
-{
-    private static readonly Lazy<HashSet<string>> _excluded = new(() => Load());
-    public static HashSet<string> Excluded => _excluded.Value;
-
-    private static HashSet<string> Load()
-    {
-        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        var path = Environment.GetEnvironmentVariable("UNO_SDK_EXCLUDE_FILE");
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            // Nothing passed -> no exclusions
-            return set;
-        }
-
-        if (!File.Exists(path))
-        {
-            Console.WriteLine($"Exclude file not found: {path}");
-            return set;
-        }
-
-        try
-        {
-            using var fs = File.OpenRead(path);
-            using var doc = System.Text.Json.JsonDocument.Parse(fs);
-            if (doc.RootElement.TryGetProperty("exclude", out var arr) &&
-                arr.ValueKind == System.Text.Json.JsonValueKind.Array)
-            {
-                foreach (var el in arr.EnumerateArray())
-                {
-                    if (el.ValueKind == System.Text.Json.JsonValueKind.String)
-                    {
-                        var s = el.GetString();
-                        if (!string.IsNullOrWhiteSpace(s))
-                            set.Add(s!);
-                    }
-                }
-            }
-
-            Console.WriteLine($"Loaded {set.Count} exclusion(s) from {path}");
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Failed to read exclude file: {ex.Message}");
-        }
-
-        return set;
     }
 }

--- a/tools/Uno.Sdk.Updater/ReadMe.md
+++ b/tools/Uno.Sdk.Updater/ReadMe.md
@@ -37,7 +37,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | MauiVersion** | $Maui$ |
 
 \* UnoVersion cannot be changed via MSBuild. You must change the SDK Version to change the UnoVersion.
-\*\* This version may have a different version for .NET 9.0.
+\*\* This version may have a different version for .NET 10.0.
 
 ```json
 $PackagesJson$

--- a/tools/Uno.Sdk.Updater/Utils/Cli.cs
+++ b/tools/Uno.Sdk.Updater/Utils/Cli.cs
@@ -1,0 +1,17 @@
+﻿namespace Uno.Sdk.Updater.Utils
+{
+    /// Minimal helper to retrieve a CLI argument value (e.g. --exclude-file).
+    internal static class Cli
+    {
+        public static string? GetArgValue(string name)
+        {
+            var av = Environment.GetCommandLineArgs();
+            for (int i = 0; i < av.Length; i++)
+            {
+                if (string.Equals(av[i], name, StringComparison.OrdinalIgnoreCase) && i + 1 < av.Length)
+                    return av[i + 1];
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
GitHub Issue (If applicable): related to https://github.com/unoplatform/uno/issues/21372

## PR Type

What kind of change does this PR introduce?

- Feature
- Improvement

## What is the current behavior?

The Uno.Sdk.Updater tool and CI workflow:
- Update all package groups unconditionally.  
- Merge manifests in a way that can cause unwanted downgrades.  
- Preserve local `VersionOverride` entries inconsistently, sometimes removing them.
- ReaMe.md still mentions .NET 9 for the override note

## What is the new behavior?

- Added support for excluding package groups from automatic updates using a JSON configuration file (`.github/sdk-update-exclude.json`) passed via a new CLI argument (`--exclude-file`).
- Adjusted merge logic to prevent **downgrades of local versions**.  
- Ensured local `VersionOverride` entries are always preserved and take precedence.  
- Added clear logging to confirm when exclusions and overrides are applied.
- ReaMe.md now mentions .NET 10 for the override note, as we added .NET 10 support

This gives finer control over dependency updates, avoids regressions, and simplifies local testing.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Associated with an issue (GitHub or internal)

## Other information

The default exclude file is located at `.github/sdk-update-exclude.json`.  
For local testing, the CLI can be run as:
```bash
dotnet run -c Release --project tools/Uno.Sdk.Updater -- --exclude-file .github/sdk-update-exclude.json
