### PR TITLE
chore(Svg.Skia): Pin Svg.Skia to 3.0.3 in templates/sdk to avoid breaking changes introduced with version ≥ 3.0.4

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -16,7 +16,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | UnoDspTasksVersion | 1.4.0 |
 | UnoResizetizerVersion | 1.11.0-dev.17 |
 | SkiaSharpVersion | 3.119.0 |
-| SvgSkiaVersion | 3.0.6 |
+| SvgSkiaVersion | 3.0.3 |
 | WinAppSdkVersion | 1.7.250606001 |
 | WinAppSdkBuildToolsVersion | 10.0.26100.4948 |
 | MicrosoftLoggingVersion** | 9.0.8 |
@@ -157,7 +157,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "SvgSkia",
-    "version": "3.0.6",
+    "version": "3.0.3",
     "packages": [
       "Svg.Skia"
     ]

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -115,7 +115,7 @@
   },
   {
     "group": "SvgSkia",
-    "version": "3.0.6",
+    "version": "3.0.3",
     "packages": [
       "Svg.Skia"
     ]


### PR DESCRIPTION
GitHub Issue: fixes https://github.com/unoplatform/uno/issues/21372  
Tracking issue for missing API support: https://github.com/unoplatform/uno/issues/21378  

## PR Type
- Bugfix

## What is the current behavior?
Svg.Skia was updated automatically to versions **≥ 3.0.4**, which introduces new `ISvgAssetLoader` APIs (`GetFontMetrics`, `MeasureText`, `GetTextPath`).  
Uno’s current [`SkiaAssetLoader`](https://github.com/unoplatform/uno/blob/master/src/AddIns/Uno.UI.Svg/External/SkiaAssetLoader.cs) does not implement these methods yet, leading to a `TypeLoadException` and broken SVG rendering.

## What is the new behavior?
Pin Svg.Skia to **3.0.3** in templates/sdk to avoid the regression.  
This unblocks apps until Uno’s [`SkiaAssetLoader`](https://github.com/unoplatform/uno/blob/master/src/AddIns/Uno.UI.Svg/External/SkiaAssetLoader.cs) is updated to support the new APIs.  

## PR Checklist
- [x] Linked to an issue (GitHub or internal)
- [x] Includes context for why the version is pinned

## Other information
- Svg.Skia is also excluded from automatic dependency updates by the updater tool (see https://github.com/unoplatform/uno.templates/pull/1752).  
