### PR TITLE
chore: Update Svg.Skia version to 3.0.6 following merge of unoplatform/uno#21380

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -16,7 +16,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | UnoDspTasksVersion | 1.4.0 |
 | UnoResizetizerVersion | 1.11.0-dev.17 |
 | SkiaSharpVersion | 3.119.0 |
-| SvgSkiaVersion | 3.0.3 |
+| SvgSkiaVersion | 3.0.6 |
 | WinAppSdkVersion | 1.7.250606001 |
 | WinAppSdkBuildToolsVersion | 10.0.26100.4948 |
 | MicrosoftLoggingVersion** | 9.0.8 |
@@ -157,7 +157,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "SvgSkia",
-    "version": "3.0.3",
+    "version": "3.0.6",
     "packages": [
       "Svg.Skia"
     ]

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -115,7 +115,7 @@
   },
   {
     "group": "SvgSkia",
-    "version": "3.0.3",
+    "version": "3.0.6",
     "packages": [
       "Svg.Skia"
     ]


### PR DESCRIPTION
### Description

Related issue: https://github.com/unoplatform/uno/issues/21378
Previous related issue where the exception was identified: https://github.com/unoplatform/uno/issues/21372

This PR updates the **Svg.Skia** package to version **3.0.6**, now that [unoplatform/uno#21380](https://github.com/unoplatform/uno/pull/21380) has been merged.  

