### PR TITLE
ci: update to include 6.4 release branch

### DIFF
--- a/.github/workflows/uno-updater.yml
+++ b/.github/workflows/uno-updater.yml
@@ -21,10 +21,6 @@ jobs:
       matrix:
         branch:
           - main
-          - release/stable/5.6
-          - release/stable/6.0
-          - release/stable/6.1
-          - release/stable/6.2
           - release/stable/6.3
           - release/stable/6.4
 


### PR DESCRIPTION
This pull request updates the workflow configuration by modifying the list of branches included in the matrix for the `uno-updater` GitHub Actions workflow. The update removes several older release branches and adds a new one, ensuring that the workflow only runs on relevant branches.

Workflow configuration updates:

* Updated the branch matrix in `.github/workflows/uno-updater.yml` by removing `release/stable/5.6`, `release/stable/6.0`, `release/stable/6.1`, and `release/stable/6.2`, and adding `release/stable/6.4` to keep the workflow aligned with currently supported releases.This pull request makes a small update to the `.github/workflows/uno-updater.yml` workflow file, adding a new release branch to the workflow configuration.

* Added the `release/stable/6.4` branch to the list of branches monitored by the `uno-updater` workflow.