### PR TITLE
Uno.Sdk Update - release/stable/6.4

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -19,8 +19,8 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | SvgSkiaVersion | 3.0.6 |
 | WinAppSdkVersion | 1.7.250909003 |
 | WinAppSdkBuildToolsVersion | 10.0.26100.6901 |
-| MicrosoftLoggingVersion** | 9.0.10 |
-| WindowsCompatibilityVersion** | 9.0.10 |
+| MicrosoftLoggingVersion** | 9.0.11 |
+| WindowsCompatibilityVersion** | 9.0.11 |
 | MicrosoftIdentityClientVersion | 4.78.0 |
 | CommunityToolkitMvvmVersion | 8.4.0 |
 | PrismVersion | 9.0.537 |
@@ -123,7 +123,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "sdkextras",
-    "version": "6.2.0-dev.4",
+    "version": "6.1.1",
     "packages": [
       "Uno.Sdk.Extras"
     ]
@@ -137,7 +137,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "hotdesign",
-    "version": "1.17.112",
+    "version": "1.17.129",
     "packages": [
       "Uno.UI.HotDesign"
     ]
@@ -178,7 +178,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "MicrosoftLoggingConsole",
-    "version": "9.0.10",
+    "version": "9.0.11",
     "packages": [
       "Microsoft.Extensions.Logging.Console"
     ],
@@ -188,7 +188,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "WindowsCompatibility",
-    "version": "9.0.10",
+    "version": "9.0.11",
     "packages": [
       "Microsoft.Windows.Compatibility"
     ],

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -95,7 +95,7 @@
   },
   {
     "group": "hotdesign",
-    "version": "1.17.112",
+    "version": "1.17.129",
     "packages": [
       "Uno.UI.HotDesign"
     ]
@@ -136,7 +136,7 @@
   },
   {
     "group": "MicrosoftLoggingConsole",
-    "version": "9.0.10",
+    "version": "9.0.11",
     "packages": [
       "Microsoft.Extensions.Logging.Console"
     ],
@@ -146,7 +146,7 @@
   },
   {
     "group": "WindowsCompatibility",
-    "version": "9.0.10",
+    "version": "9.0.11",
     "packages": [
       "Microsoft.Windows.Compatibility"
     ],


### PR DESCRIPTION
This updates the Uno.Sdk to the latest available version.