### PR TITLE
chore: rollback unneeded bumps for sr8

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -183,7 +183,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Microsoft.Extensions.Logging.Console"
     ],
     "versionOverride": {
-      "net10.0": "10.0.1"
+      "net10.0": "10.0.0"
     }
   },
   {
@@ -193,7 +193,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Microsoft.Windows.Compatibility"
     ],
     "versionOverride": {
-      "net10.0": "10.0.1"
+      "net10.0": "10.0.0"
     }
   },
   {
@@ -414,7 +414,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "MicrosoftWebView2",
-    "version": "1.0.3650.58",
+    "version": "1.0.3595.46",
     "packages": [
       "Microsoft.Web.WebView2"
     ]

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -141,7 +141,7 @@
       "Microsoft.Extensions.Logging.Console"
     ],
     "versionOverride": {
-      "net10.0": "10.0.1"
+      "net10.0": "10.0.0"
     }
   },
   {
@@ -151,7 +151,7 @@
       "Microsoft.Windows.Compatibility"
     ],
     "versionOverride": {
-      "net10.0": "10.0.1"
+      "net10.0": "10.0.0"
     }
   },
   {
@@ -372,7 +372,7 @@
   },
   {
     "group": "MicrosoftWebView2",
-    "version": "1.0.3650.58",
+    "version": "1.0.3595.46",
     "packages": [
       "Microsoft.Web.WebView2"
     ]


### PR DESCRIPTION
This pull request updates some package version references in both the `src/Uno.Sdk/packages.json` and `src/Uno.Sdk/ReadMe.md` files to ensure consistency. The changes primarily involve downgrading specific package versions for .NET 10.0 and the Microsoft WebView2 component.

**Package version downgrades:**

* Downgraded the `net10.0` version override for `Microsoft.Extensions.Logging.Console` from `10.0.1` to `10.0.0` in both `packages.json` and `ReadMe.md`. [[1]](diffhunk://#diff-70a9ecf65f115447c211bfd228af72a3a8428a9bde686defb5d91f4471b5f09bL144-R144) [[2]](diffhunk://#diff-54a22f66fa95c0f0d82774ee8c896137cca655f90f680bc999353bbc9293cf8eL186-R186)
* Downgraded the `net10.0` version override for `Microsoft.Windows.Compatibility` from `10.0.1` to `10.0.0` in both `packages.json` and `ReadMe.md`. [[1]](diffhunk://#diff-70a9ecf65f115447c211bfd228af72a3a8428a9bde686defb5d91f4471b5f09bL154-R154) [[2]](diffhunk://#diff-54a22f66fa95c0f0d82774ee8c896137cca655f90f680bc999353bbc9293cf8eL196-R196)
* Downgraded the `MicrosoftWebView2` package version from `1.0.3650.58` to `1.0.3595.46` in both `packages.json` and `ReadMe.md`. [[1]](diffhunk://#diff-70a9ecf65f115447c211bfd228af72a3a8428a9bde686defb5d91f4471b5f09bL375-R375) [[2]](diffhunk://#diff-54a22f66fa95c0f0d82774ee8c896137cca655f90f680bc999353bbc9293cf8eL417-R417)