### PR TITLE
Version bump after 6.5 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.5-dev.{height}",
+  "version": "6.6-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
This updates the Uno.Sdk to the latest available version.
This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/6.5, based on #1934