### PR TITLE
ci: add 6.5 branch

### DIFF
--- a/.github/workflows/uno-updater.yml
+++ b/.github/workflows/uno-updater.yml
@@ -23,6 +23,7 @@ jobs:
           - main
           - release/stable/6.3
           - release/stable/6.4
+          - release/stable/6.5
 
     steps:
     - name: Checkout


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration by adding support for the `release/stable/6.5` branch to the list of branches that trigger the workflow.