### PR TITLE
chore: adjust 6.5 packages

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -5,9 +5,9 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | MSBuild Property | Default Version |
 |----------------|:---------------:|
 | UnoVersion* | 6.6.0-dev.97 |
-| UnoExtensionsVersion | 7.2.0-dev.3 |
-| UnoToolkitVersion | 8.5.0-dev.2 |
-| UnoThemesVersion | 6.2.0-dev.3 |
+| UnoExtensionsVersion | 7.1.1 |
+| UnoToolkitVersion | 8.4.2 |
+| UnoThemesVersion | 6.1.1 |
 | UnoCSharpMarkupVersion | 6.6.0-dev.3 |
 | UnoWasmBootstrapVersion** | 9.0.23 |
 | UnoLoggingVersion | 1.7.0 |
@@ -123,7 +123,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "sdkextras",
-    "version": "6.3.0-dev.36",
+    "version": "6.3.1",
     "packages": [
       "Uno.Sdk.Extras"
     ]
@@ -355,7 +355,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "Extensions",
-    "version": "7.2.0-dev.3",
+    "version": "7.1.1",
     "packages": [
       "Uno.Extensions.Authentication.WinUI",
       "Uno.Extensions.Authentication.MSAL.WinUI",
@@ -385,7 +385,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "Toolkit",
-    "version": "8.5.0-dev.2",
+    "version": "8.4.2",
     "packages": [
       "Uno.Toolkit.WinUI",
       "Uno.Toolkit.WinUI.Cupertino",
@@ -397,7 +397,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "Themes",
-    "version": "6.2.0-dev.3",
+    "version": "6.1.1",
     "packages": [
       "Uno.Material.WinUI",
       "Uno.Material.WinUI.Markup",

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -81,7 +81,7 @@
   },
   {
     "group": "sdkextras",
-    "version": "6.3.0-dev.36",
+    "version": "6.3.1",
     "packages": [
       "Uno.Sdk.Extras"
     ]
@@ -313,7 +313,7 @@
   },
   {
     "group": "Extensions",
-    "version": "7.2.0-dev.3",
+    "version": "7.1.1",
     "packages": [
       "Uno.Extensions.Authentication.WinUI",
       "Uno.Extensions.Authentication.MSAL.WinUI",
@@ -343,7 +343,7 @@
   },
   {
     "group": "Toolkit",
-    "version": "8.5.0-dev.2",
+    "version": "8.4.2",
     "packages": [
       "Uno.Toolkit.WinUI",
       "Uno.Toolkit.WinUI.Cupertino",
@@ -355,7 +355,7 @@
   },
   {
     "group": "Themes",
-    "version": "6.2.0-dev.3",
+    "version": "6.1.1",
     "packages": [
       "Uno.Material.WinUI",
       "Uno.Material.WinUI.Markup",


### PR DESCRIPTION
This pull request updates several package versions for the Uno Platform SDK and related components, primarily moving from development (`-dev`) versions to stable releases. These changes are reflected consistently in both the documentation (`ReadMe.md`) and the package manifest (`packages.json`).

**Package version updates:**

* **Extensions:** Updated from `7.2.0-dev.3` to `7.1.1` in both `ReadMe.md` and `packages.json` to use a stable release. [[1]](diffhunk://#diff-54a22f66fa95c0f0d82774ee8c896137cca655f90f680bc999353bbc9293cf8eL358-R358) [[2]](diffhunk://#diff-70a9ecf65f115447c211bfd228af72a3a8428a9bde686defb5d91f4471b5f09bL316-R316)
* **Toolkit:** Updated from `8.5.0-dev.2` to `8.4.2` in both `ReadMe.md` and `packages.json` for improved stability. [[1]](diffhunk://#diff-54a22f66fa95c0f0d82774ee8c896137cca655f90f680bc999353bbc9293cf8eL388-R388) [[2]](diffhunk://#diff-70a9ecf65f115447c211bfd228af72a3a8428a9bde686defb5d91f4471b5f09bL346-R346)
* **Themes:** Updated from `6.2.0-dev.3` to `6.1.1` in both `ReadMe.md` and `packages.json` to align with a stable version. [[1]](diffhunk://#diff-54a22f66fa95c0f0d82774ee8c896137cca655f90f680bc999353bbc9293cf8eL400-R400) [[2]](diffhunk://#diff-70a9ecf65f115447c211bfd228af72a3a8428a9bde686defb5d91f4471b5f09bL358-R358)
* **SdkExtras:** Updated from `6.3.0-dev.36` to `6.3.1` in both `ReadMe.md` and `packages.json`, moving to a stable release. [[1]](diffhunk://#diff-54a22f66fa95c0f0d82774ee8c896137cca655f90f680bc999353bbc9293cf8eL126-R126) [[2]](diffhunk://#diff-70a9ecf65f115447c211bfd228af72a3a8428a9bde686defb5d91f4471b5f09bL84-R84)

**Documentation update:**

* **MSBuild Property Table:** Updated default versions for `UnoExtensionsVersion`, `UnoToolkitVersion`, and `UnoThemesVersion` in `ReadMe.md` to reflect the new stable versions.