### PR TITLE
fix(templates): Include isVsix in requiresNugetPackages

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -1235,7 +1235,7 @@
     "requiresNugetPackages": {
       "type": "computed",
       "datatype": "bool",
-      "value": "(useTestSolutionFolder || useUITests || useAspNetCoreSerilogPackage || useServer || mauiEmbedding || enableDeveloperMode || useWasmPackageVersions)"
+      "value": "(useTestSolutionFolder || useUITests || useAspNetCoreSerilogPackage || useServer || mauiEmbedding || enableDeveloperMode || useWasmPackageVersions || isVsix)"
     },
     "useAndroidMaterial": {
       "type": "computed",


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.studio/issues/1010

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Include `isVsix` in requiresNugetPackages so solution-level files are generated when creating a project from the VSIX wizard.

**Why:** Without this, VSIX-created projects skip Directory.Build.* files, so “Solution Items” is incomplete (issue [#1010](https://github.com/unoplatform/uno.studio/issues/1010)).

**Change:** Update `requiresNugetPackages` condition in `template.json`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Associated with an issue (GitHub or internal)

## Other information

Related previous PR that introduced this regression: https://github.com/unoplatform/uno.templates/pull/1872 (related to https://github.com/unoplatform/uno.templates/issues/1871)
