### PR TITLE
ci: reduce cancellation delays

### DIFF
--- a/src/Uno.Templates/content/unoapp/AzurePipelines/jobs/smoke-test.yml
+++ b/src/Uno.Templates/content/unoapp/AzurePipelines/jobs/smoke-test.yml
@@ -1,5 +1,6 @@
 jobs:
 - job: smoke_test
+  cancelTimeoutInMinutes: 0
   displayName: Smoke Test (Debug Build of MyExtensionsApp.1)
   pool:
     vmImage: $(windowsAgent)

--- a/src/Uno.Templates/content/unoapp/AzurePipelines/jobs/unit-test.yml
+++ b/src/Uno.Templates/content/unoapp/AzurePipelines/jobs/unit-test.yml
@@ -1,5 +1,6 @@
 jobs:
 - job: unit_test
+  cancelTimeoutInMinutes: 0
   displayName: Unit Tests
   pool:
     vmImage: $(windowsAgent)


### PR DESCRIPTION
## Summary
- add cancelTimeoutInMinutes: 0 to jobs/deployments
- ensure stage conditions include succeeded() to avoid running after cancellation if any

## Why
- reduce agent queue usage and stop work promptly on canceled runs

## Testing
- not run (not requested)