### PR TITLE
ci: fix macOS iOS runtimes on Xcode 26.2

### DIFF
--- a/.github/actions/ci/run-tests/action.yml
+++ b/.github/actions/ci/run-tests/action.yml
@@ -66,28 +66,33 @@ runs:
         echo "TemplateArgs = '$templateArgs'"
         $dotnetVersion = $env:TargetDotNetVersion
         $ValidationUnoCheckVersion = "invalid"
+        $IosRuntimeVersion = ""
 
         if ($templateArgs -match 'net9.0')
         {
-            $dotnetVersion = '9.0.308'
-            $ValidationUnoCheckVersion = $env:ValidationUnoCheckVersionNet9
-            $XcodeVersion = $env:XcodeVersionNet9
+          $dotnetVersion = '9.0.308'
+          $ValidationUnoCheckVersion = $env:ValidationUnoCheckVersionNet9
+          $XcodeVersion = $env:XcodeVersionNet9
+          $IosRuntimeVersion = '26.2'
         }
 
         if ($templateArgs -match 'net10.0')
         {
-            $dotnetVersion = '10.0.100'
-            $ValidationUnoCheckVersion = $env:ValidationUnoCheckVersionNet10
-            $XcodeVersion = $env:XcodeVersionNet10
+          $dotnetVersion = '10.0.100'
+          $ValidationUnoCheckVersion = $env:ValidationUnoCheckVersionNet10
+          $XcodeVersion = $env:XcodeVersionNet10
+          $IosRuntimeVersion = '26.2'
         }
 
         echo "Dotnet Version = '$dotnetVersion'"
         echo "UnoCheck Version = '$ValidationUnoCheckVersion'"
         echo "Xcode Version = '$XcodeVersion'"
+        echo "iOS Runtime Version = '$IosRuntimeVersion'"
     
         echo "DotNetVersion=$dotnetVersion" >> $env:GITHUB_ENV
         echo "ValidationUnoCheckVersion=$ValidationUnoCheckVersion" >> $env:GITHUB_ENV
         echo "XcodeRoot=$XcodeVersion" >> $env:GITHUB_ENV
+        echo "IosRuntimeVersion=$IosRuntimeVersion" >> $env:GITHUB_ENV
     env:
       TargetDotNetVersion: ${{ env.ValidationDotNetVersion }}
       ValidationUnoCheckVersionNet10: ${{ env.ValidationUnoCheckVersionNet10 }}
@@ -175,6 +180,18 @@ runs:
       echo 'xCode Root to ${{ env.XcodeRoot }}'
       echo 'MD_APPLE_SDK_ROOT=${{ env.XcodeRoot }}' >> $GITHUB_ENV
       sudo xcode-select --switch ${{ env.XcodeRoot }}/Contents/Developer
+
+  - name: 'Ensure iOS simulator runtime'
+    if: runner.os == 'macOS' && env.IosRuntimeVersion != ''
+    shell: bash
+    run: |
+      echo "Checking iOS simulator runtime ${{ env.IosRuntimeVersion }}"
+      if xcrun simctl list runtimes | grep -q "iOS ${{ env.IosRuntimeVersion }}"; then
+        echo "iOS runtime ${{ env.IosRuntimeVersion }} already installed"
+        exit 0
+      fi
+      echo "Downloading iOS simulator runtime ${{ env.IosRuntimeVersion }}"
+      sudo xcodebuild -downloadPlatform iOS -buildVersion ${{ env.IosRuntimeVersion }}
 
   - name: 'Install ninja'
     if: runner.os == 'macOS'
@@ -353,6 +370,11 @@ runs:
             "-p:MtouchInterpreter=all",
             "-p:TreatWarningsAsErrors=true"
           );
+
+          if ($IsMacos)
+          {
+            $extraArgs += "-p:ValidateXcodeVersion=false"
+          }
 
           & dotnet build $testName.sln "/bl:${{ github.workspace }}/artifacts/logs/$testName.${{ runner.os }}.$dotnetVersion.binlog" $extraArgs
           if ($LASTEXITCODE -ne 0)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ env:
   ValidationUnoCheckVersionNet9: '1.32.23'
   ValidationUnoCheckVersionNet10: '1.33.0-dev.30'
   ValidationDotNetVersion: '9.0.308'
-  XcodeVersionNet9: '/Applications/Xcode_26.0.1.app'
-  XcodeVersionNet10: '/Applications/Xcode_26.0.1.app'
+  XcodeVersionNet9: '/Applications/Xcode_26.2.app'
+  XcodeVersionNet10: '/Applications/Xcode_26.2.app'
 
   # https://github.com/unoplatform/Uno.Wasm.Bootstrap/pull/887 remove when upgarding to .NET 9
   # compatible version of the bootstrapper


### PR DESCRIPTION
## Changes

- Use Xcode 26.2 for macOS template tests
- Skip Xcode version validation on macOS
- Ensure iOS 26.2 simulator runtime is available (download if missing)

## Why

- macOS-15 runners removed the iOS 26.0 simulator runtime (issue #[13570](https://github.com/actions/runner-images/issues/13570)), which broke net9/net10 macOS tests.
- The .NET iOS workload still performs strict Xcode checks, so we skip validation and ensure the required simulator runtime is present to keep CI green.

### Refs:

- - https://github.com/actions/runner-images/issues/13570

