### PR TITLE
fix: ensure initial navigation is at root

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.recommended.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.recommended.cs
@@ -273,11 +273,11 @@ $$EnableDeveloperMode_Region_Navigate$$
                 var authenticated = await auth.RefreshAsync();
                 if (authenticated)
                 {
-                    await navigator.NavigateViewModelAsync<$mainRouteViewModel$>(this, qualifier: Qualifiers.Nested);
+                    await navigator.NavigateViewModelAsync<$mainRouteViewModel$>(this, qualifier: Qualifiers.ClearBackStack);
                 }
                 else
                 {
-                    await navigator.NavigateViewModelAsync<$loginRouteViewModel$>(this, qualifier: Qualifiers.Nested);
+                    await navigator.NavigateViewModelAsync<$loginRouteViewModel$>(this, qualifier: Qualifiers.ClearBackStack);
                 }
             });
 #endif


### PR DESCRIPTION
This pull request makes a small change to the navigation logic in the `OnLaunched` method to improve user experience. Now, after authentication, the navigation stack is cleared rather than nested, ensuring users cannot navigate back to previous screens such as the login page.

- Navigation logic update:
  * Changed the navigation qualifier from `Qualifiers.Nested` to `Qualifiers.ClearBackStack` when navigating to either the main or login view models after authentication, which clears the back stack and prevents navigating back to previous pages.