### PR TITLE
chore: Add Uno.WinUI.SpellChecking package to uno.templates

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -70,7 +70,8 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Uno.WinUI.MediaPlayer.Skia.Win32",
       "Uno.WinUI.WebView.Skia.X11",
       "Uno.WinUI.Graphics3DGL",
-      "Uno.WinUI.Graphics2DSK"
+      "Uno.WinUI.Graphics2DSK",
+      "Uno.WinUI.SpellChecking"
     ]
   },
   {

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -28,7 +28,8 @@
       "Uno.WinUI.MediaPlayer.Skia.Win32",
       "Uno.WinUI.WebView.Skia.X11",
       "Uno.WinUI.Graphics3DGL",
-      "Uno.WinUI.Graphics2DSK"
+      "Uno.WinUI.Graphics2DSK",
+      "Uno.WinUI.SpellChecking"
     ]
   },
   {


### PR DESCRIPTION
## What

Add the new [Uno.WinUI.SpellChecking](https://www.nuget.org/packages/Uno.WinUI.SpellChecking) to the Uno.Sdk package manifest and embedded manifest in ReadMe.md.

## Why

Keep the templates package list aligned with Uno core and avoid missing-package warnings.

## Which issue

Note: No related issue (Internal maintenance / Approved by Team member: @agneszitte).