### PR TITLE
ci: add manual branch trigger for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('CI (manual: {0})', github.event.inputs.branch) || format('CI ({0})', github.ref_name) }}
 
 on:
   push:
@@ -14,6 +15,13 @@ on:
 
   schedule:
     - cron: '0 0 * * *' # Canary
+
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch or ref to run CI on'
+        required: true
+        default: 'main'
   
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -21,6 +29,7 @@ concurrency:
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  CheckoutRef: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.ref }}
   IsCanaryBranch: ${{ startsWith(github.ref, 'refs/heads/canaries/') }}
   ValidationUnoCheckVersionNet9: '1.32.23'
   ValidationUnoCheckVersionNet10: '1.33.0-dev.30'
@@ -53,6 +62,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.CheckoutRef }}
 
     - name: "Build Package"
       uses: ./.github/actions/ci/build-packages
@@ -72,6 +82,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        ref: ${{ env.CheckoutRef }}
     - name: "Sign Packages"
       uses: ./.github/actions/ci/sign-package
       with:
@@ -91,6 +103,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        ref: ${{ env.CheckoutRef }}
     - name: "Uno Feed Publish"
       uses: ./.github/actions/ci/nuget-uno-publish
       with:
@@ -111,6 +125,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        ref: ${{ env.CheckoutRef }}
     - name: "Uno Feed Publish"
       uses: ./.github/actions/ci/nuget-uno-publish
       with:
@@ -127,6 +143,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        ref: ${{ env.CheckoutRef }}
     - name: "Uno Feed Publish"
       uses: ./.github/actions/ci/nuget-org-publish
       with:
@@ -147,6 +165,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: ${{ env.CheckoutRef }}
 
     - name: "Test Matrix"
       id: generate-test-matrix-step
@@ -173,6 +192,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        ref: ${{ env.CheckoutRef }}
     
     - name: "Run Tests"
       uses: ./.github/actions/ci/run-tests
@@ -202,6 +223,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        ref: ${{ env.CheckoutRef }}
     
     - name: "Run Tests"
       uses: ./.github/actions/ci/run-tests
@@ -231,6 +254,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        ref: ${{ env.CheckoutRef }}
     
     - name: "Run Tests"
       uses: ./.github/actions/ci/run-tests


### PR DESCRIPTION
This change adds manual `workflow_dispatch` support to the CI workflow with a `branch` input so maintainers can run CI on a specific ref without pushing new commits. It also wires checkout to the selected ref across jobs and adds a clearer run name to make manual executions easier to identify. This improves operational flexibility for validation and troubleshooting while preserving existing push/PR behavior.

Note: No related issue (Internal maintenance / Approved by Team member: @agneszitte).