### PR TITLE
fix(ci): quote workflow run-name expression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('CI (manual: {0})', github.event.inputs.branch) || format('CI ({0})', github.ref_name) }}
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('CI (manual: {0})', github.event.inputs.branch) || format('CI ({0})', github.ref_name) }}"
 
 on:
   push:


### PR DESCRIPTION
This hotfix quotes the `run-name` expression in the CI workflow so GitHub parses the workflow YAML correctly. The previous unquoted expression introduced a YAML syntax error at line 2, which prevented the workflow graph from loading and jobs from running.

Note: No related issue (Internal maintenance / Approved by Team member: @agneszitte).