### PR TITLE
fix(ci): remove run-name override from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: CI
-run-name: "${{ github.event_name == 'workflow_dispatch' && format('CI (manual: {0})', github.event.inputs.branch) || format('CI ({0})', github.ref_name) }}"
 
 on:
   push:


### PR DESCRIPTION
This change removes the custom `run-name` override from the CI workflow and returns to GitHub’s default run naming behavior. The manual `workflow_dispatch` branch selection remains in place, so maintainers can still run CI against a specific branch/ref while reducing workflow syntax/maintenance risk.

Note: No related issue (Internal maintenance / Approved by Team member: @agneszitte).