### PR TITLE
feat: make Shell opt-in

### DIFF
--- a/.github/actions/ci/generate-test-matrix/action.yml
+++ b/.github/actions/ci/generate-test-matrix/action.yml
@@ -24,6 +24,8 @@ runs:
             "Recommended;;unoapp;-skip -preset recommended",
             "SkiaOnlyHeads;!macOS;unoapp;-skip -platforms desktop",
             "MobileOnlyHeads;!macOS;unoapp;-skip -platforms android ios",
+            "RecommendedShell;!macOS;unoapp;-skip -preset recommended --shell",
+            "RecommendedShellMarkup;!macOS;unoapp;-skip -preset recommended --shell -markup csharp",
             "RecommendedMarkup;;unoapp;-skip -preset recommended -markup csharp",
             "RecommendedMarkupDsp;;unoapp;-skip -preset recommended -markup csharp -dsp",
             "RecommendedMarkupFluent;!macOS;unoapp;-skip -preset recommended -markup csharp -theme fluent",

--- a/src/Uno.Templates/content/unoapp/.template.config/TemplateWizard.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/TemplateWizard.json
@@ -100,6 +100,7 @@
 					"tests": "none",
 					"tfm": "net10.0",
 					"toolkit": "false",
+					"splash": "false",
 					"vscode": "true",
 					"wasmPwaManifest": "true",
 					"mauiEmbedding": "false",
@@ -143,6 +144,7 @@
 					"tests": "none",
 					"tfm": "net10.0",
 					"toolkit": "true",
+					"splash": "false",
 					"vscode": "true",
 					"wasmPwaManifest": "true",
 					"mauiEmbedding": "false",
@@ -233,7 +235,7 @@
 				// and we recently removed .NET 8 option from the template (see PR #1373).
 				// This feature will be re-enabled once multi-threading becomes available again.
 				//"SymbolIds": [ "toolkit", "mauiEmbedding", "server", "wasmMultiThreading", "wasmPwaManifest", "vscode", "enableDeveloperMode", "mediaElement" ]
-				"SymbolIds": [ "sample", "toolkit", "mauiEmbedding", "server", "wasmPwaManifest", "vscode", "enableDeveloperMode", "mediaPlayerElement" ]
+				"SymbolIds": [ "sample", "toolkit", "splash", "mauiEmbedding", "server", "wasmPwaManifest", "vscode", "enableDeveloperMode", "mediaPlayerElement" ]
 			}
 			,
 			{
@@ -685,6 +687,15 @@
 		"toolkit": {
 			"Icon": "/Assets/Features.Toolkit.svg"
 		},
+		"splash": {
+			"Icon": "/Assets/Features.Toolkit.svg",
+			"Requires": {
+				"toolkit": {
+					"RequiredValues": [ "true" ],
+					"MoreInformation": "Toolkit is required for Extended Splash Screen"
+				}
+			}
+		},
 		"renderer.skia": {
 			"Icon": "/Assets/Features.SkiaRendering.svg"
 		},
@@ -779,6 +790,7 @@
 		"navigation",
 		"sample",
 		"toolkit",
+		"splash",
 		"authentication",
 		"vscode",
 		"wasmPwaManifest",

--- a/src/Uno.Templates/content/unoapp/.template.config/TemplateWizard.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/TemplateWizard.json
@@ -100,7 +100,7 @@
 					"tests": "none",
 					"tfm": "net10.0",
 					"toolkit": "false",
-					"splash": "false",
+					"shell": "false",
 					"vscode": "true",
 					"wasmPwaManifest": "true",
 					"mauiEmbedding": "false",
@@ -144,7 +144,7 @@
 					"tests": "none",
 					"tfm": "net10.0",
 					"toolkit": "true",
-					"splash": "false",
+					"shell": "false",
 					"vscode": "true",
 					"wasmPwaManifest": "true",
 					"mauiEmbedding": "false",
@@ -235,7 +235,7 @@
 				// and we recently removed .NET 8 option from the template (see PR #1373).
 				// This feature will be re-enabled once multi-threading becomes available again.
 				//"SymbolIds": [ "toolkit", "mauiEmbedding", "server", "wasmMultiThreading", "wasmPwaManifest", "vscode", "enableDeveloperMode", "mediaElement" ]
-				"SymbolIds": [ "sample", "toolkit", "splash", "mauiEmbedding", "server", "wasmPwaManifest", "vscode", "enableDeveloperMode", "mediaPlayerElement" ]
+				"SymbolIds": [ "sample", "toolkit", "shell", "mauiEmbedding", "server", "wasmPwaManifest", "vscode", "enableDeveloperMode", "mediaPlayerElement" ]
 			}
 			,
 			{
@@ -687,14 +687,8 @@
 		"toolkit": {
 			"Icon": "/Assets/Features.Toolkit.svg"
 		},
-		"splash": {
-			"Icon": "/Assets/Features.Toolkit.svg",
-			"Requires": {
-				"toolkit": {
-					"RequiredValues": [ "true" ],
-					"MoreInformation": "Toolkit is required for Extended Splash Screen"
-				}
-			}
+		"shell": {
+			"Icon": "/Assets/Features.Toolkit.svg"
 		},
 		"renderer.skia": {
 			"Icon": "/Assets/Features.SkiaRendering.svg"
@@ -790,7 +784,7 @@
 		"navigation",
 		"sample",
 		"toolkit",
-		"splash",
+		"shell",
 		"authentication",
 		"vscode",
 		"wasmPwaManifest",

--- a/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
@@ -53,9 +53,9 @@
       "longName": "toolkit",
       "shortName": "toolkit"
     },
-    "splash": {
-      "longName": "splash",
-      "shortName": "splash"
+    "shell": {
+      "longName": "shell",
+      "shortName": "shell"
     },
     "dependencyInjection": {
       "longName": "dependency-injection",

--- a/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/dotnetcli.host.json
@@ -53,6 +53,10 @@
       "longName": "toolkit",
       "shortName": "toolkit"
     },
+    "splash": {
+      "longName": "splash",
+      "shortName": "splash"
+    },
     "dependencyInjection": {
       "longName": "dependency-injection",
       "shortName": "di"

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -425,9 +425,9 @@
       "type": "parameter",
       "datatype": "bool"
     },
-    "splash": {
-      "displayName": "Extended Splash Screen",
-      "description": "Includes an Extended Splash Screen (requires Toolkit)",
+    "shell": {
+      "displayName": "Shell",
+      "description": "Includes Shell.xaml as a root navigation container (with ExtendedSplashScreen when Toolkit is enabled)",
       "type": "parameter",
       "datatype": "bool"
     },
@@ -1098,7 +1098,7 @@
         "fallbackVariableName": "presetToolkitDefault"
       }
     },
-    "presetSplashDefault": {
+    "presetShellDefault": {
       "type": "generated",
       "generator": "switch",
       "parameters": {
@@ -1116,18 +1116,18 @@
         ]
       }
     },
-    "useSplash": {
+    "useShell": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "splash",
-        "fallbackVariableName": "presetSplashDefault"
+        "sourceVariableName": "shell",
+        "fallbackVariableName": "presetShellDefault"
       }
     },
     "useExtendedSplashScreen": {
       "type": "computed",
       "datatype": "bool",
-      "value": "useSplash && useToolkit"
+      "value": "useShell && useToolkit"
     },
     "presetLoggingDefault": {
       "type": "generated",
@@ -2181,6 +2181,24 @@
         ]
       }
     },
+    "navigationRootType": {
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "$navigationRootType$",
+      "parameters": {
+        "evaluator": "C++",
+        "cases": [
+          {
+            "condition": "(useShell)",
+            "value": "Shell"
+          },
+          {
+            "condition": "true",
+            "value": "MainPage"
+          }
+        ]
+      }
+    },
     "mainRouteViewModel": {
       "type": "generated",
       "generator": "switch",
@@ -2582,6 +2600,15 @@
             "MyExtensionsApp.1/Presentation/LoginViewModel.cs",
             "MyExtensionsApp.1/Presentation/MainViewModel.cs",
             "MyExtensionsApp.1/Presentation/SecondViewModel.cs",
+            "MyExtensionsApp.1/Presentation/ShellViewModel.cs"
+          ]
+        },
+        {
+          "condition": "(!useShell)",
+          "exclude": [
+            "MyExtensionsApp.1/Presentation/Shell.xaml",
+            "MyExtensionsApp.1/Presentation/Shell.xaml.cs",
+            "MyExtensionsApp.1/Presentation/ShellModel.cs",
             "MyExtensionsApp.1/Presentation/ShellViewModel.cs"
           ]
         },

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -429,7 +429,8 @@
       "displayName": "Shell",
       "description": "Includes Shell.xaml as a root navigation container (with ExtendedSplashScreen when Toolkit is enabled)",
       "type": "parameter",
-      "datatype": "bool"
+      "datatype": "bool",
+      "defaultValue": "false"
     },
     "sample": {
       "displayName": "Include sample content",
@@ -1098,36 +1099,10 @@
         "fallbackVariableName": "presetToolkitDefault"
       }
     },
-    "presetShellDefault": {
-      "type": "generated",
-      "generator": "switch",
-      "parameters": {
-        "evaluator": "C++",
-        "datatype": "bool",
-        "cases": [
-          {
-            "condition": "(preset == 'recommended')",
-            "value": "false"
-          },
-          {
-            "condition": "(preset == 'blank')",
-            "value": "false"
-          }
-        ]
-      }
-    },
-    "useShell": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "shell",
-        "fallbackVariableName": "presetShellDefault"
-      }
-    },
     "useExtendedSplashScreen": {
       "type": "computed",
       "datatype": "bool",
-      "value": "useShell && useToolkit"
+      "value": "shell && useToolkit"
     },
     "presetLoggingDefault": {
       "type": "generated",
@@ -2189,11 +2164,11 @@
         "evaluator": "C++",
         "cases": [
           {
-            "condition": "(useShell)",
+            "condition": "(shell)",
             "value": "Shell"
           },
           {
-            "condition": "true",
+            "condition": "(!shell)",
             "value": "MainPage"
           }
         ]
@@ -2604,7 +2579,7 @@
           ]
         },
         {
-          "condition": "(!useShell)",
+          "condition": "(!shell)",
           "exclude": [
             "MyExtensionsApp.1/Presentation/Shell.xaml",
             "MyExtensionsApp.1/Presentation/Shell.xaml.cs",

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -425,6 +425,12 @@
       "type": "parameter",
       "datatype": "bool"
     },
+    "splash": {
+      "displayName": "Extended Splash Screen",
+      "description": "Includes an Extended Splash Screen (requires Toolkit)",
+      "type": "parameter",
+      "datatype": "bool"
+    },
     "sample": {
       "displayName": "Include sample content",
       "description": "Configures whether to add sample pages and functionality to demonstrate basic usage patterns.",
@@ -1091,6 +1097,37 @@
         "sourceVariableName": "toolkit",
         "fallbackVariableName": "presetToolkitDefault"
       }
+    },
+    "presetSplashDefault": {
+      "type": "generated",
+      "generator": "switch",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "bool",
+        "cases": [
+          {
+            "condition": "(preset == 'recommended')",
+            "value": "false"
+          },
+          {
+            "condition": "(preset == 'blank')",
+            "value": "false"
+          }
+        ]
+      }
+    },
+    "useSplash": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "splash",
+        "fallbackVariableName": "presetSplashDefault"
+      }
+    },
+    "useExtendedSplashScreen": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "useSplash && useToolkit"
     },
     "presetLoggingDefault": {
       "type": "generated",

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.recommended.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.recommended.cs
@@ -267,14 +267,14 @@ $$EnableDeveloperMode_Frame_MainWindowContent$$
 //+:cnd:noEmit
 #elif (!useAuthentication)
 #if (!enableDeveloperMode)
-        Host = await builder.NavigateAsync<Shell>();
+        Host = await builder.NavigateAsync<$navigationRootType$>();
 #else
 $$EnableDeveloperMode_Region_Navigate$$
             ();
 #endif
 #else
 #if (!enableDeveloperMode)
-        Host = await builder.NavigateAsync<Shell>
+        Host = await builder.NavigateAsync<$navigationRootType$>
 #else
 $$EnableDeveloperMode_Region_Navigate$$
 #endif
@@ -299,7 +299,9 @@ $$EnableDeveloperMode_Region_Navigate$$
     {
 #if (useRegionsNav)
         views.Register(
+#if (useShell)
             new ViewMap(ViewModel: typeof($shellRouteViewModel$)),
+#endif
 #if (useAuthentication)
             new ViewMap<LoginPage, $loginRouteViewModel$>(),
 #endif
@@ -311,6 +313,7 @@ $$EnableDeveloperMode_Region_Navigate$$
 #endif
         );
 
+#if (useShell)
         routes.Register(
             new RouteMap("", View: views.FindByViewModel<$shellRouteViewModel$>(),
                 Nested:
@@ -325,6 +328,17 @@ $$EnableDeveloperMode_Region_Navigate$$
                 ]
             )
         );
+#else
+        routes.Register(
+#if (useAuthentication)
+            new RouteMap("Login", View: views.FindByViewModel<$loginRouteViewModel$>()),
+#endif
+            new RouteMap("Main", View: views.FindByViewModel<$mainRouteViewModel$>(), IsDefault:true)
+#if (useSampleContent)
+            , new RouteMap("Second", View: views.FindByViewModel<$secondRouteViewModel$>())
+#endif
+        );
+#endif
 #endif
     }
 #endif

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.recommended.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.recommended.cs
@@ -299,7 +299,7 @@ $$EnableDeveloperMode_Region_Navigate$$
     {
 #if (useRegionsNav)
         views.Register(
-#if (useShell)
+#if (shell)
             new ViewMap(ViewModel: typeof($shellRouteViewModel$)),
 #endif
 #if (useAuthentication)
@@ -313,7 +313,7 @@ $$EnableDeveloperMode_Region_Navigate$$
 #endif
         );
 
-#if (useShell)
+#if (shell)
         routes.Register(
             new RouteMap("", View: views.FindByViewModel<$shellRouteViewModel$>(),
                 Nested:

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/Shell.xaml
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/Shell.xaml
@@ -8,7 +8,7 @@
       d:DesignHeight="300"
       d:DesignWidth="400">
   <Border Background="{ThemeResource $themeBackgroundBrush$}">
-<!--#if (useToolkit)-->
+<!--#if (useExtendedSplashScreen)-->
     <utu:ExtendedSplashScreen x:Name="Splash"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch"

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/Shell.xaml.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Presentation/Shell.xaml.cs
@@ -10,7 +10,7 @@ public sealed partial class Shell : UserControl, IContentControlProvider
         this.Content(
             new Border()
                 .Child(
-    #if useToolkit
+    #if useExtendedSplashScreen
                     new ExtendedSplashScreen()
                         .Name(out var splash)
                         .HorizontalAlignment(HorizontalAlignment.Stretch)


### PR DESCRIPTION
GitHub Issue (If applicable): related to #2073

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Shell.xaml is always included when using Uno.Extensions navigation (regions). The recommended preset enables Toolkit by default, which means every recommended-preset project gets Shell with an ExtendedSplashScreen, and non-Toolkit projects get Shell with a nearly empty ContentControl wrapper. There is no way to exclude Shell without switching to frame-based navigation.

## What is the new behavior?

A new `shell` template parameter makes Shell entirely opt-in. When `--shell` is not passed, Shell.xaml and its associated files (ShellModel/ShellViewModel) are completely excluded from the generated project:

- Both `blank` and `recommended` presets default `shell` to `false`.
- When `shell` is false: Shell files are excluded, navigation goes directly to MainPage, and route maps use flat routes instead of nested routes under Shell.
- When `shell` is true: Shell.xaml is included as the root navigation container with nested route maps. If Toolkit is also enabled, the ExtendedSplashScreen is used inside Shell; otherwise a plain ContentControl is used.
- A `$navigationRootType$` replacement token resolves to `Shell` or `MainPage` based on the `useShell` flag, keeping the NavigateAsync call clean.
- CLI usage: `dotnet new unoapp -preset recommended --shell`

## Other information

### Files changed

- **template.json** -- Added `shell` parameter, `presetShellDefault`, `useShell`, and `navigationRootType` symbols; updated `useExtendedSplashScreen` to `useShell && useToolkit`; added `(!useShell)` file exclusion rule for Shell files
- **App.recommended.cs** -- Replaced `NavigateAsync<Shell>` with `NavigateAsync<$navigationRootType$>`; added `#if (useShell)` branching in RegisterRoutes for nested vs flat route maps
- **Shell.xaml / Shell.xaml.cs** -- Unchanged (already use `useExtendedSplashScreen` conditional from prior commit)
- **dotnetcli.host.json** -- Replaced `--splash` with `--shell` CLI flag
- **TemplateWizard.json** -- Replaced `splash` with `shell` in preset defaults, Features MultiSelect, SymbolOverrides, and ExportableSymbols; removed Toolkit dependency (Shell works without it)
- **CI test matrix** -- Added `RecommendedShell` and `RecommendedShellMarkup` test entries
