### PR TITLE
Version bump after 6.6 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.6-dev.{height}",
+  "version": "6.7-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
This is a manual version bump of the **main** branch after the creation of the release branch release/stable/6.6, based on [#2077](https://github.com/unoplatform/uno.templates/pull/2077)