### PR TITLE
docs: add AndroidX Leanback, CarApp, Wear, WearTiles version entries to ReadMe files

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -34,6 +34,10 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | AndroidXSwipeRefreshLayoutVersion | 1.1.0.28 |
 | AndroidXNavigationVersion | 2.8.9.2 |
 | AndroidXCollectionVersion | 1.5.0.2 |
+| AndroidXLeanbackVersion | 1.0.0.30 |
+| AndroidXCarAppVersion | 1.4.0.2 |
+| AndroidXWearVersion | 1.3.0.16 |
+| AndroidXWearTilesVersion | 1.4.0.1 |
 | MauiVersion** | 9.0.120 |
 
 \* UnoVersion cannot be changed via MSBuild. You must change the SDK Version to change the UnoVersion.

--- a/tools/Uno.Sdk.Updater/ReadMe.md
+++ b/tools/Uno.Sdk.Updater/ReadMe.md
@@ -34,6 +34,10 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | AndroidXSwipeRefreshLayoutVersion | $AndroidXSwipeRefreshLayout$ |
 | AndroidXNavigationVersion | $AndroidXNavigation$ |
 | AndroidXCollectionVersion | $AndroidXCollection$ |
+| AndroidXLeanbackVersion | $AndroidXLeanback$ |
+| AndroidXCarAppVersion | $AndroidXCarApp$ |
+| AndroidXWearVersion | $AndroidXWear$ |
+| AndroidXWearTilesVersion | $AndroidXWearTiles$ |
 | MauiVersion** | $Maui$ |
 
 \* UnoVersion cannot be changed via MSBuild. You must change the SDK Version to change the UnoVersion.


### PR DESCRIPTION
Related to https://github.com/unoplatform/uno-private/issues/1126.
Related to https://github.com/unoplatform/uno-private/issues/1327.
Related to https://github.com/unoplatform/uno-private/issues/1328.

Related to Initial PR: https://github.com/unoplatform/uno.templates/pull/2087
And as a follow-up of PR:
- https://github.com/unoplatform/uno/pull/23157
- https://github.com/unoplatform/uno/pull/23175
- https://github.com/unoplatform/uno/pull/23181

## What

Adds the missing version override documentation rows for the 4 new AndroidX packages (Leanback, CarApp, Wear, WearTiles) to both ReadMe files.

## Why

These packages were added to `packages.json` in PR #2072 but the corresponding ReadMe table entries are not included yet. This brings the documentation into parity with all other AndroidX packages (e.g. AndroidXCollection, AndroidXNavigation).

## Changes
- `src/Uno.Sdk/ReadMe.md` — 4 new rows with actual version numbers
- `tools/Uno.Sdk.Updater/ReadMe.md` — 4 new rows with placeholder syntax (`$AndroidXLeanback$`, etc.)