### PR TITLE
fix: revert Themes version to dev.28 to unblock uno CI

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -7,7 +7,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | UnoVersion* | 6.7.0-dev.32 |
 | UnoExtensionsVersion | 7.3.0-dev.7 |
 | UnoToolkitVersion | 8.5.0-dev.54 |
-| UnoThemesVersion | 7.0.0-dev.29 |
+| UnoThemesVersion | 7.0.0-dev.28 |
 | UnoCSharpMarkupVersion | 6.7.0-dev.5 |
 | UnoWasmBootstrapVersion** | 9.0.23 |
 | UnoLoggingVersion | 1.7.0 |
@@ -403,7 +403,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "Themes",
-    "version": "7.0.0-dev.29",
+    "version": "7.0.0-dev.28",
     "packages": [
       "Uno.Material.WinUI",
       "Uno.Material.WinUI.Markup",

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -357,7 +357,7 @@
   },
   {
     "group": "Themes",
-    "version": "7.0.0-dev.29",
+    "version": "7.0.0-dev.28",
     "packages": [
       "Uno.Material.WinUI",
       "Uno.Material.WinUI.Markup",


### PR DESCRIPTION
## Summary

Reverts Uno.Themes group version from `7.0.0-dev.29` back to `7.0.0-dev.28` in `packages.json`.

## Why

Uno.Themes `7.0.0-dev.29` (PR https://github.com/unoplatform/Uno.Themes/pull/1666) removed the `SimpleControlSize` enum and replaced it with `Density`. However, `Uno.Toolkit.UI 8.5.0-dev.54` still references the deleted type in `SimpleToolkitTheme.cs`, causing a `TypeLoadException` at runtime.

This breaks the `uno` repo [DevServer CI test](https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=211228&view=logs&j=f63c6d40-e6cc-5158-041c-5ecaeb969bfb&t=dd05ac6d-5f8e-575b-7053-261df9674ec3&l=1941) which creates a real app from templates and exercises it.

## Temporary Fix

Pin Themes to `dev.28` until the toolkit is updated to remove its `SimpleControlSize` dependency. Once Toolkit publishes a compatible version (Related new PR https://github.com/unoplatform/uno.toolkit.ui/pull/1589), Themes can be bumped back to `dev.29+`.

Related to https://github.com/unoplatform/Uno.Themes/pull/1666 and [related discussion](https://teams.microsoft.com/l/message/19:c857d68e0be84cfba6ff9a8611200680@thread.tacv2/1778108740831?tenantId=a297d6c0-b635-41a3-b1e3-558efe71e413&groupId=f55cdec8-036b-4efa-8e1a-c4129ba9bf12&parentMessageId=1778104180283&teamName=Uno%20Platform&channelName=Collab%20Lounge&createdTime=1778108740831)