### PR TITLE
chore: ignore C# Dev Kit *.lscache files in unoapp template gitignore

### DIFF
--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -66,7 +66,7 @@
 			Condition="!Exists('$(TemplateContentFolder)/unoapp/.gitignore')" />
 
 		<!-- Add our custom ignore for Single TFM targeting -->
-		<AppendSingleTargetIgnore Filename="$(TemplateContentFolder)/unoapp/.gitignore" />
+		<AppendCustomIgnores Filename="$(TemplateContentFolder)/unoapp/.gitignore" />
 
 		<Copy SourceFiles="@(TemplateFile)" DestinationFiles="$(TemplateContentFolder)/%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="false" />
 		<Copy SourceFiles="content/unoapp/GitHub/Install-WindowsSdkISO.cips" DestinationFiles="$(TemplateContentFolder)/unoapp/AzurePipelines/Install-WindowsSdkISO.cips" SkipUnchangedFiles="false" />
@@ -90,7 +90,7 @@
 		<ReplaceFileText Filename="%(_MauiLibTemplateFile.Identity)" MatchExpression="MyExtensionsApp.1.MauiControls" ReplacementText="MyExtensionsApp.1" />
 	</Target>
 
-	<UsingTask TaskName="AppendSingleTargetIgnore" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+	<UsingTask TaskName="AppendCustomIgnores" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
 		<ParameterGroup>
 			<Filename ParameterType="System.String" Required="true" />
 		</ParameterGroup>
@@ -103,7 +103,7 @@
 						Filename,
 						Environment.NewLine + "# Single Target Config" + Environment.NewLine + "solution-config.props" +
 						Environment.NewLine + "# Publish Profiles" + Environment.NewLine + "!**/Properties/PublishProfiles/*.pubxml" +
-						Environment.NewLine + "# C# Dev Kit language-service cache" + Environment.NewLine + "*.lscache"
+						Environment.NewLine + "# C# Dev Kit language-service cache (safe to delete, regenerated automatically)" + Environment.NewLine + "*.lscache"
 						);
 				]]>
 			</Code>

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -99,12 +99,16 @@
 			<Using Namespace="System.IO" />
 			<Code Type="Fragment" Language="cs">
 				<![CDATA[
-					File.AppendAllText(
-						Filename,
-						Environment.NewLine + "# Single Target Config" + Environment.NewLine + "solution-config.props" +
-						Environment.NewLine + "# Publish Profiles" + Environment.NewLine + "!**/Properties/PublishProfiles/*.pubxml" +
-						Environment.NewLine + "# C# Dev Kit language-service cache (safe to delete, regenerated automatically)" + Environment.NewLine + "*.lscache"
-						);
+					var lines = new[] {
+						"",
+						"# Single Target Config",
+						"solution-config.props",
+						"# Publish Profiles",
+						"!**/Properties/PublishProfiles/*.pubxml",
+						"# C# Dev Kit language-service cache (safe to delete, regenerated automatically)",
+						"*.lscache",
+					};
+					File.AppendAllText(Filename, string.Join(Environment.NewLine, lines));
 				]]>
 			</Code>
 		</Task>

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -102,7 +102,8 @@
 					File.AppendAllText(
 						Filename,
 						Environment.NewLine + "# Single Target Config" + Environment.NewLine + "solution-config.props" +
-						Environment.NewLine + "# Publish Profiles" + Environment.NewLine + "!**/Properties/PublishProfiles/*.pubxml"
+						Environment.NewLine + "# Publish Profiles" + Environment.NewLine + "!**/Properties/PublishProfiles/*.pubxml" +
+						Environment.NewLine + "# C# Dev Kit language-service cache" + Environment.NewLine + "*.lscache"
 						);
 				]]>
 			</Code>

--- a/src/Uno.Templates/Uno.Templates.csproj
+++ b/src/Uno.Templates/Uno.Templates.csproj
@@ -65,7 +65,7 @@
 			SourceUrl="https://raw.githubusercontent.com/dotnet/sdk/refs/heads/main/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore"
 			Condition="!Exists('$(TemplateContentFolder)/unoapp/.gitignore')" />
 
-		<!-- Add our custom ignore for Single TFM targeting -->
+		<!-- Add our custom .gitignore entries -->
 		<AppendCustomIgnores Filename="$(TemplateContentFolder)/unoapp/.gitignore" />
 
 		<Copy SourceFiles="@(TemplateFile)" DestinationFiles="$(TemplateContentFolder)/%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="false" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.templates/issues/2115

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

**Note** on a finding from re-validating this PR: the upstream dotnet/sdk gitignore template (the source we download from in Uno.Templates.csproj) already contains *.lscache — [dotnet/sdk#53751](https://github.com/dotnet/sdk/issues/53751) has since been merged. The duplicate is functionally harmless — gitignore tolerates duplicate patterns

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
