### PR TITLE
fix: restore Shell in recommended preset via preset-aware default

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/TemplateWizard.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/TemplateWizard.json
@@ -144,7 +144,7 @@
 					"tests": "none",
 					"tfm": "net10.0",
 					"toolkit": "true",
-					"shell": "false",
+					"shell": "true",
 					"vscode": "true",
 					"wasmPwaManifest": "true",
 					"mauiEmbedding": "false",

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -429,8 +429,7 @@
       "displayName": "Shell",
       "description": "Includes Shell.xaml as a root navigation container (with ExtendedSplashScreen when Toolkit is enabled)",
       "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "false"
+      "datatype": "bool"
     },
     "sample": {
       "displayName": "Include sample content",
@@ -1099,10 +1098,36 @@
         "fallbackVariableName": "presetToolkitDefault"
       }
     },
+    "presetShellDefault": {
+      "type": "generated",
+      "generator": "switch",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "bool",
+        "cases": [
+          {
+            "condition": "(preset == 'recommended')",
+            "value": "true"
+          },
+          {
+            "condition": "(preset == 'blank')",
+            "value": "false"
+          }
+        ]
+      }
+    },
+    "useShell": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "shell",
+        "fallbackVariableName": "presetShellDefault"
+      }
+    },
     "useExtendedSplashScreen": {
       "type": "computed",
       "datatype": "bool",
-      "value": "shell && useToolkit"
+      "value": "useShell && useToolkit"
     },
     "presetLoggingDefault": {
       "type": "generated",
@@ -2164,11 +2189,11 @@
         "evaluator": "C++",
         "cases": [
           {
-            "condition": "(shell)",
+            "condition": "(useShell)",
             "value": "Shell"
           },
           {
-            "condition": "(!shell)",
+            "condition": "(!useShell)",
             "value": "MainPage"
           }
         ]
@@ -2579,7 +2604,7 @@
           ]
         },
         {
-          "condition": "(!shell)",
+          "condition": "(!useShell)",
           "exclude": [
             "MyExtensionsApp.1/Presentation/Shell.xaml",
             "MyExtensionsApp.1/Presentation/Shell.xaml.cs",

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.recommended.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/App.recommended.cs
@@ -266,7 +266,7 @@ $$EnableDeveloperMode_Frame_MainWindowContent$$
         MainWindow.Activate();
 //+:cnd:noEmit
 #elif (!useAuthentication)
-#if (shell)
+#if (useShell)
 #if (!enableDeveloperMode)
         Host = await builder.NavigateAsync<$navigationRootType$>();
 #else
@@ -293,7 +293,7 @@ $$EnableDeveloperMode_Region_Navigate$$
                 await navigator.NavigateViewModelAsync<$loginRouteViewModel$>(this, qualifier: Qualifiers.ClearBackStack);
             }
         }
-#if (shell)
+#if (useShell)
 #if (!enableDeveloperMode)
         Host = await builder.NavigateAsync<$navigationRootType$>
 #else
@@ -313,7 +313,7 @@ $$EnableDeveloperMode_Region_Navigate$$
     {
 #if (useRegionsNav)
         views.Register(
-#if (shell)
+#if (useShell)
             new ViewMap(ViewModel: typeof($shellRouteViewModel$)),
 #endif
 #if (useAuthentication)
@@ -327,7 +327,7 @@ $$EnableDeveloperMode_Region_Navigate$$
 #endif
         );
 
-#if (shell)
+#if (useShell)
         routes.Register(
             new RouteMap("", View: views.FindByViewModel<$shellRouteViewModel$>(),
                 Nested:


### PR DESCRIPTION
## Summary

- `-preset recommended` was producing a project that looked like the blank preset because the `shell` parameter was hard-coded to `defaultValue: "false"` for both presets after commits `f0e99bb9` and `6fe31345`.
- Restore the standard preset-default pattern used by other params (`toolkit`, `dependencyInjection`, `configuration`, etc.): keep `shell` as a real opt-in parameter, but make its default preset-aware — `recommended → true`, `blank → false`.
- Users can still pass `-shell false` to opt out of Shell on the recommended preset.

Closes #2118

## Test plan

- [ ] `dotnet new unoapp -n T -preset recommended` generates Shell + multi-page Presentation/
- [ ] `dotnet new unoapp -n T -preset recommended -shell false` opts out of Shell while keeping the rest of the recommended infrastructure
- [ ] `dotnet new unoapp -n T -preset blank` is unchanged
- [ ] CI matrix entries `Recommended`, `RecommendedShell`, `RecommendedShellMarkup`, `RecommendedMarkup` still pass
