### PR TITLE
docs: Document WinAppSdkBuildToolsWinAppVersion in Uno.Sdk ReadMe

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -19,6 +19,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | SvgSkiaVersion | 3.0.6 |
 | WinAppSdkVersion | 1.7.250909003 |
 | WinAppSdkBuildToolsVersion | 10.0.28000.1839 |
+| WinAppSdkBuildToolsWinAppVersion | 0.3.2 |
 | MicrosoftLoggingVersion** | 9.0.17 |
 | WindowsCompatibilityVersion** | 9.0.17 |
 | MicrosoftIdentityClientVersion | 4.84.2 |

--- a/tools/Uno.Sdk.Updater/ReadMe.md
+++ b/tools/Uno.Sdk.Updater/ReadMe.md
@@ -19,6 +19,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | SvgSkiaVersion | $SvgSkia$ |
 | WinAppSdkVersion | $WinAppSdk$ |
 | WinAppSdkBuildToolsVersion | $WinAppSdkBuildTools$ |
+| WinAppSdkBuildToolsWinAppVersion | $WinAppSdkBuildToolsWinApp$ |
 | MicrosoftLoggingVersion** | $MicrosoftLoggingConsole$ |
 | WindowsCompatibilityVersion** | $WindowsCompatibility$ |
 | MicrosoftIdentityClientVersion | $MsalClient$ |


### PR DESCRIPTION
Closes #2136

## Summary

unoplatform/uno#23346 made [`Microsoft.Windows.SDK.BuildTools.WinApp`](https://www.nuget.org/packages/Microsoft.Windows.SDK.BuildTools.WinApp) an implicit Uno.Sdk package for WinAppSDK executables, enabling `dotnet run` to register a loose-layout package and launch with package identity.

The automated Uno.Sdk sync already brought the new `WinAppSdkBuildToolsWinApp` group into `src/Uno.Sdk/packages.json` (0.3.2), but the MSBuild property table in the ReadMe packed into the Uno.Sdk NuGet package was missing the corresponding `WinAppSdkBuildToolsWinAppVersion` override property.

## Changes

- `tools/Uno.Sdk.Updater/ReadMe.md` — added the `WinAppSdkBuildToolsWinAppVersion` row with the `$WinAppSdkBuildToolsWinApp$` placeholder, so future updater runs keep it in sync.
- `src/Uno.Sdk/ReadMe.md` — added the resolved row (`0.3.2`) so the currently packed README is correct without waiting for the next sync.

## Notes

No other changes are needed in this repository for unoplatform/uno#23346:

- `packages.json` is synced automatically and already includes the new group.
- The Uno.Sdk package is repacked from `Uno.Sdk.Private 6.7.0-dev.310`, which includes the new targets and buildschema entries.
- `Verify-NuGetDependenciesOnNuGetOrg.ps1` reads `packages.json` generically, so the new dependency is verified on publish.
- Templates need no changes: the reference is implicit via the Uno.Sdk, and the CPM `Directory.Packages.props` does not enumerate implicit packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)