### PR TITLE
chore: Remove deprecated Uno.WinUI.Runtime.Skia.Wpf package reference

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -61,7 +61,6 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Uno.WinUI.Runtime.Skia.Linux.FrameBuffer",
       "Uno.WinUI.Runtime.Skia.MacOS",
       "Uno.WinUI.Runtime.Skia.Win32",
-      "Uno.WinUI.Runtime.Skia.Wpf",
       "Uno.WinUI.Runtime.Skia.X11",
       "Uno.WinUI.Svg",
       "Uno.WinUI.WebAssembly",

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -15,7 +15,6 @@
       "Uno.WinUI.Runtime.Skia.Linux.FrameBuffer",
       "Uno.WinUI.Runtime.Skia.MacOS",
       "Uno.WinUI.Runtime.Skia.Win32",
-      "Uno.WinUI.Runtime.Skia.Wpf",
       "Uno.WinUI.Runtime.Skia.X11",
       "Uno.WinUI.Svg",
       "Uno.WinUI.WebAssembly",


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type
What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?
`Uno.WinUI.Runtime.Skia.Wpf` is listed in `packages.json` and `ReadMe.md` as a dependency. The `Verify-NuGetDependenciesOnNuGetOrg.ps1` script checks that all listed packages are available on NuGet.org before publishing, and fails because this package was deprecated and is no longer published.

## What is the new behavior?
`Uno.WinUI.Runtime.Skia.Wpf` is removed from `packages.json` and `ReadMe.md`. The NuGet dependency verification script no longer checks for this deprecated package.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Associated with an issue (GitHub or internal)

## Other information
Package was deprecated in unoplatform/uno#23261.