### PR TITLE
fix(sdk): revert SkiaSharp 3.119.4 -> 3.119.2 for 6.6 stable (iOS <26.2 breakage)

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -15,7 +15,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | UnoUniversalImageLoaderVersion | 1.9.37 |
 | UnoDspTasksVersion | 1.4.0 |
 | UnoResizetizerVersion | 1.12.1 |
-| SkiaSharpVersion | 3.119.4 |
+| SkiaSharpVersion | 3.119.2 |
 | SvgSkiaVersion | 3.0.6 |
 | WinAppSdkVersion | 1.7.250909003 |
 | WinAppSdkBuildToolsVersion | 10.0.28000.2270 |
@@ -145,7 +145,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "SkiaSharp",
-    "version": "3.119.4",
+    "version": "3.119.2",
     "packages": [
       "SkiaSharp.Skottie",
       "SkiaSharp.Views.Uno.WinUI",

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -103,7 +103,7 @@
   },
   {
     "group": "SkiaSharp",
-    "version": "3.119.4",
+    "version": "3.119.2",
     "packages": [
       "SkiaSharp.Skottie",
       "SkiaSharp.Views.Uno.WinUI",


### PR DESCRIPTION
## What & why

Reverts the **SkiaSharp `3.119.4` → `3.119.2`** pin in the Uno.Sdk for the 6.6 stable line. The `3.119.4` bump (introduced in Uno.Sdk 6.6.12 via #2106) ships its Apple platform assets targeting **iOS 26.2** (`net10.0-ios26.2`), which are **incompatible with iOS < 26.2 (Xcode < 26.2) builds** → NuGet falls back to the platform-neutral `net10.0` SkiaSharp assembly, which has **no native `libSkiaSharp` binding** → iOS apps break:

- **Skia-renderer iOS** → runtime `System.DllNotFoundException: libSkiaSharp` / black screen (unoplatform/uno.chefs#1750)
- **native-iOS Release** → `MT0099`; **canaries pinning lower** → `NU1605`

`3.119.2` is the **last iOS-safe** SkiaSharp and the version shipped by the current public **Uno.Sdk 6.5.36**, so this keeps 6.6 consistent with the last public release. Confirmed working on the failing iOS repro (Chefs, Xcode 26.1.1) via `<SkiaSharpVersion>3.119.2</SkiaSharpVersion>`.

## Changes
- `src/Uno.Sdk/packages.json`: SkiaSharp group `3.119.4` → `3.119.2`
- `src/Uno.Sdk/ReadMe.md`: regenerated version table + embedded manifest

## Notes
- Focused revert **as a start** — the broader 6.6-stable SDK version prep (extension bumps) can build on top of / supersede this.
- Interim until the **SkiaSharp 3.119.5** backport ([mono/SkiaSharp#3798](https://github.com/mono/SkiaSharp/pull/3798) / [mono/SkiaSharp/issues/4031#issuecomment-4907000395](https://github.com/mono/SkiaSharp/issues/4031#issuecomment-4907000395)) or the **v4** move in 7.0.
- Full iOS sanity check for uno.chefs#1750 to be run by QA on the produced SDK.

Related to https://github.com/unoplatform/uno/issues/23680
Related to https://github.com/unoplatform/uno.chefs/issues/1750
Related to https://github.com/unoplatform/uno-private/issues/1957#issuecomment-4938024224

(Related to https://github.com/unoplatform/private/issues/1076)