### PR TITLE
fix(sdk): pin SkiaSharp to 3.119.2 and exclude it from auto-update (iOS <26.2)

### DIFF
--- a/.github/sdk-update-exclude.json
+++ b/.github/sdk-update-exclude.json
@@ -1,7 +1,11 @@
 {
   "exclude": [
+    // SkiaSharp held at 3.119.2: 3.119.4 ships iOS-26.2 assets that break iOS <26.2 (Xcode <26.2)
+    // builds -> no native libSkiaSharp -> iOS apps fail. See unoplatform/uno#23680, unoplatform/uno.chefs#1750.
+    // Remove this exclude when SkiaSharp 3.119.5 ships (mono/SkiaSharp#3798) or on the v4 move at Uno.Sdk 7.0
+    // (backport status, not in our control: mono/SkiaSharp#4031).
+    "SkiaSharp",
     "SvgSkia",
     "WinAppSdk"
   ]
 }
-

--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -15,7 +15,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | UnoUniversalImageLoaderVersion | 1.9.37 |
 | UnoDspTasksVersion | 1.4.0 |
 | UnoResizetizerVersion | 1.13.0-dev.17 |
-| SkiaSharpVersion | 3.119.4 |
+| SkiaSharpVersion | 3.119.2 |
 | SvgSkiaVersion | 3.0.6 |
 | WinAppSdkVersion | 1.7.250909003 |
 | WinAppSdkBuildToolsVersion | 10.0.28000.2270 |
@@ -142,14 +142,14 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "hotdesign",
-    "version": "1.20.0-dev.473",
+    "version": "1.20.0-dev.477",
     "packages": [
       "Uno.UI.HotDesign"
     ]
   },
   {
     "group": "SkiaSharp",
-    "version": "3.119.4",
+    "version": "3.119.2",
     "packages": [
       "SkiaSharp.Skottie",
       "SkiaSharp.Views.Uno.WinUI",

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -95,14 +95,14 @@
   },
   {
     "group": "hotdesign",
-    "version": "1.20.0-dev.473",
+    "version": "1.20.0-dev.477",
     "packages": [
       "Uno.UI.HotDesign"
     ]
   },
   {
     "group": "SkiaSharp",
-    "version": "3.119.4",
+    "version": "3.119.2",
     "packages": [
       "SkiaSharp.Skottie",
       "SkiaSharp.Views.Uno.WinUI",

--- a/tools/Uno.Sdk.Updater/Config/ExcludeConfig.cs
+++ b/tools/Uno.Sdk.Updater/Config/ExcludeConfig.cs
@@ -29,7 +29,7 @@
             try
             {
                 using var fs = File.OpenRead(path);
-                using var doc = System.Text.Json.JsonDocument.Parse(fs);
+                using var doc = System.Text.Json.JsonDocument.Parse(fs, new System.Text.Json.JsonDocumentOptions { CommentHandling = System.Text.Json.JsonCommentHandling.Skip, AllowTrailingCommas = true });
                 if (doc.RootElement.TryGetProperty("exclude", out var arr) &&
                     arr.ValueKind == System.Text.Json.JsonValueKind.Array)
                 {


### PR DESCRIPTION
## What & why

Two changes on `main`:

1. **Pin SkiaSharp `3.119.4` → `3.119.2`** in the Uno.Sdk (`packages.json` SkiaSharp group + generated `ReadMe.md`).
   `3.119.4` ships its Apple assets targeting **iOS 26.2** (`net10.0-ios26.2`), incompatible with **iOS < 26.2 (Xcode < 26.2)** builds → NuGet falls back to the neutral `net10.0` SkiaSharp assembly with **no native `libSkiaSharp`** → iOS apps break (runtime `DllNotFoundException: libSkiaSharp` / `MT0099` / `NU1605`). `3.119.2` is the last iOS-safe version (as shipped by public Uno.Sdk 6.5.36).

2. **Add `SkiaSharp` to `.github/sdk-update-exclude.json`** so the **Uno.Sdk.Updater** stops re-bumping it in the automated "Uno.Sdk Update" PRs (same mechanism already used for `SvgSkia` / `WinAppSdk` — the updater action reads this file via `--exclude-file`). Without this, the next automated update would revert the pin back to `3.119.4`.

This holds SkiaSharp at 3.119.2 until either the **3.119.5** backport ([mono/SkiaSharp#3798](https://github.com/mono/SkiaSharp/pull/3798), corrects the asset TFM to `ios26.0`) lands, or the **v4** move in Uno.Sdk 7.0 — at which point the `SkiaSharp` exclude entry should be removed.

## Files
- `src/Uno.Sdk/packages.json` — SkiaSharp group `→ 3.119.2`
- `src/Uno.Sdk/ReadMe.md` — regenerated version table + embedded manifest
- `.github/sdk-update-exclude.json` — add `SkiaSharp`

Related to https://github.com/unoplatform/uno/issues/23680
Related to https://github.com/unoplatform/uno.chefs/issues/1750
Related to https://github.com/unoplatform/uno-private/issues/1957#issuecomment-4938024224

