### PR TITLE
chore(sdk): exclude SkiaSharp from auto-update on 6.6 (hold 3.119.2 pin)

### DIFF
--- a/.github/sdk-update-exclude.json
+++ b/.github/sdk-update-exclude.json
@@ -1,5 +1,9 @@
 {
   "exclude": [
+    // SkiaSharp held at 3.119.2: 3.119.4 ships iOS-26.2 assets that break iOS <26.2 (Xcode <26.2)
+    // builds -> no native libSkiaSharp -> iOS apps fail. See unoplatform/uno#23680, unoplatform/uno.chefs#1750.
+    // Remove this exclude when SkiaSharp 3.119.5 ships (mono/SkiaSharp#3798) or on the v4 move at Uno.Sdk 7.0
+    // (backport status, not in our control: mono/SkiaSharp#4031).
     "SkiaSharp",
     "SvgSkia",
     "WinAppSdk"

--- a/.github/sdk-update-exclude.json
+++ b/.github/sdk-update-exclude.json
@@ -1,7 +1,7 @@
 {
   "exclude": [
+    "SkiaSharp",
     "SvgSkia",
     "WinAppSdk"
   ]
 }
-

--- a/tools/Uno.Sdk.Updater/Config/ExcludeConfig.cs
+++ b/tools/Uno.Sdk.Updater/Config/ExcludeConfig.cs
@@ -29,7 +29,7 @@
             try
             {
                 using var fs = File.OpenRead(path);
-                using var doc = System.Text.Json.JsonDocument.Parse(fs);
+                using var doc = System.Text.Json.JsonDocument.Parse(fs, new System.Text.Json.JsonDocumentOptions { CommentHandling = System.Text.Json.JsonCommentHandling.Skip, AllowTrailingCommas = true });
                 if (doc.RootElement.TryGetProperty("exclude", out var arr) &&
                     arr.ValueKind == System.Text.Json.JsonValueKind.Array)
                 {


### PR DESCRIPTION
Follow-up to #2158. That PR reverted SkiaSharp `3.119.4 → 3.119.2` on 6.6, but the **Uno.Sdk.Updater** would re-bump it on the next automated "Uno.Sdk Update" PR. This adds `SkiaSharp` to `.github/sdk-update-exclude.json` (the updater's `--exclude-file`, already used for `SvgSkia` / `WinAppSdk`) so the pin holds.

Remove the `SkiaSharp` exclude once **3.119.5** ([mono/SkiaSharp#3798](https://github.com/mono/SkiaSharp/pull/3798)) ships or on the **v4** move in 7.0.

Related to https://github.com/unoplatform/uno/issues/23680
Related to https://github.com/unoplatform/uno.chefs/issues/1750
Related to https://github.com/unoplatform/uno-private/issues/1957#issuecomment-4938024224

(Related to https://github.com/unoplatform/private/issues/1076)