### PR TITLE
fix(ci): give tag-release a .NET 10 runtime for nbgv

### DIFF
--- a/.github/actions/ci/tag-release/action.yml
+++ b/.github/actions/ci/tag-release/action.yml
@@ -10,15 +10,21 @@ runs:
       fetch-depth: 0
 
   - name: Setup .NET SDK
-    uses: actions/setup-dotnet@v1
+    uses: actions/setup-dotnet@v4
     with:
-      dotnet-version: '9.0.300'
+      # nbgv is pre-installed on the runner image as a .NET 10 build, and
+      # `dotnet tool update` won't downgrade it to the pinned toolVersion,
+      # so a .NET 10 runtime must be present or `nbgv get-version` fails
+      # (exit 150). Keep 9.0.300 for parity with the rest of CI.
+      dotnet-version: |
+        9.0.300
+        10.0.x
 
   - uses: dotnet/nbgv@f088059084cb5d872e9d1a994433ca6440c2bf72 # v0.4.2
     name: NBGV
     id: nbgv
     with:
-      toolVersion: 3.6.139
+      toolVersion: 3.10.91
       setAllVars: true
 
   - name: "Tag and push to GitHub"


### PR DESCRIPTION
## Problem

The **Tag Release** step of the 6.6 production release failed with `nbgv` exit code 150, so the `6.6.29` git tag was never created (the packages **did** publish to nuget.org and the Uno feed — tag is the last step in the job).

Failed run: `release/stable/6.6` CI, job *Publish Nuget.org Production → Tag Release*.

## Root cause — runner-image drift

`.github/actions/ci/tag-release/action.yml`:
- installed **only .NET 9.0.300**, then
- ran the `dotnet/nbgv` action pinned to `toolVersion: 3.6.139` (`dotnet tool update -g nbgv --version 3.6.139`).

The GitHub runner image now **pre-ships nbgv 3.10.91**, a **.NET 10** build. `dotnet tool update` refuses to *downgrade* to 3.6.139:

```
The requested version 3.6.139 is lower than existing version 3.10.91.
```

so nbgv 3.10.91 ran — against a box with no .NET 10 runtime:

```
You must install or update .NET to run this application.
Framework: 'Microsoft.NETCore.App', version '10.0.0' ... found: 9.0.5
##[error]The process '/home/runner/.dotnet/tools/nbgv' failed with exit code 150
```

`nbgv get-version` aborts before `git tag` runs → no tag.

## Fix

- Install the **.NET 10 runtime** alongside 9.0.300 so nbgv can run.
- Pin `toolVersion` to **3.10.91** so resolution is deterministic instead of relying on whatever the runner pre-installs.
- Bump `actions/setup-dotnet@v1 → v4` (also clears the Node-20 deprecation warning).

## Notes

- The missing `6.6.29` tag is being created manually out-of-band on the released commit (`242715a`), so this line is tagged regardless of the merge of this PR.
- Same pinned-`3.6.139` + .NET-9-only nbgv pattern exists in other CI actions in this repo (build / sign / sdk-update) and in sibling repos (e.g. `uno.csharpmarkup`, `nuget.updater`). They don't tag, so they didn't fail here, but the same drift could bite them — worth a follow-up sweep.

Related to https://github.com/unoplatform/private/issues/1076