### PR TITLE
fix(ci): give tag-release a .NET 10 runtime for nbgv

### DIFF
--- a/.github/actions/ci/tag-release/action.yml
+++ b/.github/actions/ci/tag-release/action.yml
@@ -10,15 +10,21 @@ runs:
       fetch-depth: 0
 
   - name: Setup .NET SDK
-    uses: actions/setup-dotnet@v1
+    uses: actions/setup-dotnet@v4
     with:
-      dotnet-version: '9.0.300'
+      # nbgv is pre-installed on the runner image as a .NET 10 build, and
+      # `dotnet tool update` won't downgrade it to the pinned toolVersion,
+      # so a .NET 10 runtime must be present or `nbgv get-version` fails
+      # (exit 150). Keep 9.0.300 for parity with the rest of CI.
+      dotnet-version: |
+        9.0.300
+        10.0.x
 
   - uses: dotnet/nbgv@f088059084cb5d872e9d1a994433ca6440c2bf72 # v0.4.2
     name: NBGV
     id: nbgv
     with:
-      toolVersion: 3.6.139
+      toolVersion: 3.10.91
       setAllVars: true
 
   - name: "Tag and push to GitHub"


### PR DESCRIPTION
Same fix as #2168, forward-ported to `main` so the next release line doesn't hit the identical tag failure.

## Root cause — runner-image drift

`.github/actions/ci/tag-release/action.yml` installed only .NET 9.0.300 and pinned `nbgv` to `toolVersion: 3.6.139`. The runner image now pre-ships **nbgv 3.10.91** (a **.NET 10** build); `dotnet tool update` won't downgrade it, so nbgv 3.10.91 ran with no .NET 10 runtime present and aborted with **exit 150** before `git tag` — publishing succeeded but the release tag was never created.

## Fix

- Install the **.NET 10 runtime** alongside 9.0.300.
- Pin `toolVersion` to **3.10.91** for deterministic resolution.
- Bump `actions/setup-dotnet@v1 → v4`.

See #2168 for the full failing-run analysis and log excerpts.

Related to https://github.com/unoplatform/private/issues/1076