### PR TITLE
fix(ci): Harden + fail-fast the nuget.org publish gate for Uno.* deps

### DIFF
--- a/.github/actions/ci/nuget-org-publish/action.yml
+++ b/.github/actions/ci/nuget-org-publish/action.yml
@@ -19,7 +19,7 @@ runs:
   - name: Verify package dependencies on nuget.org
     shell: pwsh
     run: |
-        ./build/Verify-NuGetDependenciesOnNuGetOrg.ps1 -PackagesPath artifacts -MaxAttempts 12 -RetryDelaySeconds 20 -HttpTimeoutSeconds 30
+        ./build/Verify-NuGetDependenciesOnNuGetOrg.ps1 -PackagesPath artifacts -MaxAttempts 3 -RetryDelaySeconds 20 -HttpTimeoutSeconds 30
 
   - name: NuGet.org Push
     shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: verify_dependencies
 
     steps:
     - name: Checkout
@@ -68,6 +69,27 @@ jobs:
 
     - name: "Build Package"
       uses: ./.github/actions/ci/build-packages
+
+  # Verify every referenced Uno.* package exists on nuget.org BEFORE the build and the
+  # template test matrix run, so a package-availability problem fails the pipeline in
+  # seconds instead of after build + sign + the full test matrix have consumed runners.
+  # Reads the source Uno.Sdk manifest (no build output needed) and runs on push and PRs.
+  # Defined after `build` so its run-summary renders below the Build "NuGet Package Summary";
+  # it still executes first via the `needs: verify_dependencies` on build and generate-test-matrix.
+  verify_dependencies:
+    name: Verify Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ env.CheckoutRef }}
+
+    - name: "Verify Uno.* dependency closure on nuget.org"
+      shell: pwsh
+      run: |
+        ./build/Verify-NuGetDependenciesOnNuGetOrg.ps1 -ManifestPath src/Uno.Sdk/packages.json -MaxAttempts 3 -RetryDelaySeconds 10 -HttpTimeoutSeconds 30
 
   # Sign the nuget packages
   sign:
@@ -158,6 +180,7 @@ jobs:
   generate-test-matrix:
     runs-on: ubuntu-latest
     name: Generate Test Matrix
+    needs: verify_dependencies
 
     outputs:
       testMatrix: ${{ steps.generate-test-matrix-step.outputs.TestMatrix }}

--- a/build/Verify-NuGetDependenciesOnNuGetOrg.Tests.ps1
+++ b/build/Verify-NuGetDependenciesOnNuGetOrg.Tests.ps1
@@ -1,0 +1,235 @@
+# Unit tests for the pure decision logic in Verify-NuGetDependenciesOnNuGetOrg.ps1.
+#
+# The script guards its main body so that when it is dot-sourced only the functions
+# load (no artifact scanning, no nuget.org calls). These tests therefore run fully
+# offline. Requires Pester v5+ (Should -BeTrue / -BeFalse syntax).
+#
+#   Invoke-Pester -Path build/Verify-NuGetDependenciesOnNuGetOrg.Tests.ps1
+
+BeforeAll {
+	. (Join-Path $PSScriptRoot 'Verify-NuGetDependenciesOnNuGetOrg.ps1')
+	$script:UnoPrefixes = @('Uno.')
+}
+
+Describe 'Test-IsTrackedPackageId' {
+	It 'matches Uno.* ids' {
+		Test-IsTrackedPackageId -PackageId 'Uno.Material.WinUI' -IncludePrefixes $UnoPrefixes | Should -BeTrue
+	}
+
+	It 'is case-insensitive' {
+		Test-IsTrackedPackageId -PackageId 'uno.sdk' -IncludePrefixes $UnoPrefixes | Should -BeTrue
+	}
+
+	It 'does not match third-party / BCL ids' {
+		Test-IsTrackedPackageId -PackageId 'System.Text.Json' -IncludePrefixes $UnoPrefixes | Should -BeFalse
+		Test-IsTrackedPackageId -PackageId 'Microsoft.Extensions.Logging' -IncludePrefixes $UnoPrefixes | Should -BeFalse
+	}
+
+	It 'does not partial-match a longer token (Unofficial is not Uno.)' {
+		Test-IsTrackedPackageId -PackageId 'Unofficial.Thing' -IncludePrefixes $UnoPrefixes | Should -BeFalse
+	}
+
+	It 'returns false for null or empty prefixes' {
+		Test-IsTrackedPackageId -PackageId 'Uno.X' -IncludePrefixes $null | Should -BeFalse
+		Test-IsTrackedPackageId -PackageId 'Uno.X' -IncludePrefixes @() | Should -BeFalse
+	}
+
+	It 'supports multiple prefixes' {
+		Test-IsTrackedPackageId -PackageId 'Xamarin.Foo' -IncludePrefixes @('Uno.', 'Xamarin.') | Should -BeTrue
+	}
+}
+
+Describe 'Test-ShouldVerifyTransitiveDependency' {
+	It 'always verifies prereleases (even third-party)' {
+		Test-ShouldVerifyTransitiveDependency -PackageId 'System.Foo' -Version '1.0.0-dev.1' -IncludeStableTransitiveVersions $false -IncludePrefixes $UnoPrefixes | Should -BeTrue
+	}
+
+	It 'verifies a stable Uno.* dep (the unpublished 7.0.1 class)' {
+		Test-ShouldVerifyTransitiveDependency -PackageId 'Uno.Material.WinUI' -Version '7.0.1' -IncludeStableTransitiveVersions $false -IncludePrefixes $UnoPrefixes | Should -BeTrue
+		Test-ShouldVerifyTransitiveDependency -PackageId 'Uno.Simple.WinUI' -Version '7.0.1' -IncludeStableTransitiveVersions $false -IncludePrefixes $UnoPrefixes | Should -BeTrue
+	}
+
+	It 'skips a stable third-party dep by default' {
+		Test-ShouldVerifyTransitiveDependency -PackageId 'System.Text.Json' -Version '9.0.0' -IncludeStableTransitiveVersions $false -IncludePrefixes $UnoPrefixes | Should -BeFalse
+		Test-ShouldVerifyTransitiveDependency -PackageId 'Microsoft.Extensions.Logging' -Version '9.0.0' -IncludeStableTransitiveVersions $false -IncludePrefixes $UnoPrefixes | Should -BeFalse
+	}
+
+	It 'verifies stable third-party deps when IncludeStableTransitiveVersions is set' {
+		Test-ShouldVerifyTransitiveDependency -PackageId 'System.Text.Json' -Version '9.0.0' -IncludeStableTransitiveVersions $true -IncludePrefixes $UnoPrefixes | Should -BeTrue
+	}
+}
+
+Describe 'Test-ShouldExpandCoordinate' {
+	It 'expands any coordinate within TransitiveDependencyDepth' {
+		Test-ShouldExpandCoordinate -PackageId 'System.Foo' -Depth 0 -TransitiveDependencyDepth 1 -MaxTrackedDepth 16 -IncludePrefixes $UnoPrefixes | Should -BeTrue
+	}
+
+	It 'does not expand a non-tracked coordinate beyond TransitiveDependencyDepth' {
+		Test-ShouldExpandCoordinate -PackageId 'System.Foo' -Depth 1 -TransitiveDependencyDepth 1 -MaxTrackedDepth 16 -IncludePrefixes $UnoPrefixes | Should -BeFalse
+	}
+
+	It 'walks a tracked (Uno.*) coordinate to its full closure beyond TransitiveDependencyDepth' {
+		Test-ShouldExpandCoordinate -PackageId 'Uno.Material.WinUI' -Depth 1 -TransitiveDependencyDepth 1 -MaxTrackedDepth 16 -IncludePrefixes $UnoPrefixes | Should -BeTrue
+		Test-ShouldExpandCoordinate -PackageId 'Uno.Material.WinUI' -Depth 5 -TransitiveDependencyDepth 1 -MaxTrackedDepth 16 -IncludePrefixes $UnoPrefixes | Should -BeTrue
+	}
+
+	It 'stops the tracked walk at the runaway guard MaxTrackedDepth' {
+		Test-ShouldExpandCoordinate -PackageId 'Uno.Material.WinUI' -Depth 16 -TransitiveDependencyDepth 1 -MaxTrackedDepth 16 -IncludePrefixes $UnoPrefixes | Should -BeFalse
+	}
+}
+
+Describe 'Get-ExactDependencyVersion' {
+	It 'returns an exact version unchanged' {
+		Get-ExactDependencyVersion -VersionRange '7.0.1' | Should -Be '7.0.1'
+		Get-ExactDependencyVersion -VersionRange '7.1.0-dev.1' | Should -Be '7.1.0-dev.1'
+	}
+
+	It 'unwraps a pinned [x] range' {
+		Get-ExactDependencyVersion -VersionRange '[7.0.1]' | Should -Be '7.0.1'
+	}
+
+	It 'returns null for an open / floating range' {
+		Get-ExactDependencyVersion -VersionRange '(1.0.0,2.0.0)' | Should -BeNullOrEmpty
+	}
+}
+
+Describe 'Add-ChecksFromPackageGroups' {
+	It 'adds a check for every package at its group base version' {
+		$json = '[{"group":"Themes","version":"7.1.0-dev.1","packages":["Uno.Material.WinUI","Uno.Simple.WinUI"]}]'
+		$checks = [System.Collections.Generic.List[object]]::new()
+		Add-ChecksFromPackageGroups -Checks $checks -JsonContent $json -SourceLabel 'manifest:packages.json'
+		$checks.Count | Should -Be 2
+		($checks | Where-Object { $_.Id -eq 'Uno.Material.WinUI' }).Version | Should -Be '7.1.0-dev.1'
+		($checks | Where-Object { $_.Id -eq 'Uno.Simple.WinUI' }).Version | Should -Be '7.1.0-dev.1'
+	}
+
+	It 'adds versionOverride entries in addition to the base version' {
+		$json = '[{"group":"Core","version":"6.7.0-dev.869","packages":["Uno.WinUI"],"versionOverride":{"net8.0":"6.6.0"}}]'
+		$checks = [System.Collections.Generic.List[object]]::new()
+		Add-ChecksFromPackageGroups -Checks $checks -JsonContent $json -SourceLabel 'manifest:packages.json'
+		@($checks | ForEach-Object { $_.Version } | Sort-Object -Unique) | Should -Be @('6.6.0', '6.7.0-dev.869')
+	}
+
+	It 'handles multiple groups' {
+		$json = '[{"group":"A","version":"1.0.0","packages":["Uno.A"]},{"group":"B","version":"2.0.0","packages":["Uno.B","Uno.C"]}]'
+		$checks = [System.Collections.Generic.List[object]]::new()
+		Add-ChecksFromPackageGroups -Checks $checks -JsonContent $json -SourceLabel 'm'
+		$checks.Count | Should -Be 3
+	}
+}
+
+Describe 'Add-ChecksFromManifest' {
+	It 'reads a manifest file and populates checks' {
+		$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("manifest-" + [System.Guid]::NewGuid().ToString('N') + ".json")
+		Set-Content -Path $tmp -Value '[{"group":"Themes","version":"7.1.0-dev.1","packages":["Uno.Material.WinUI"]}]'
+		try {
+			$checks = [System.Collections.Generic.List[object]]::new()
+			Add-ChecksFromManifest -Checks $checks -ManifestPath $tmp
+			$checks.Count | Should -Be 1
+			$checks[0].Id | Should -Be 'Uno.Material.WinUI'
+			$checks[0].Version | Should -Be '7.1.0-dev.1'
+		}
+		finally {
+			Remove-Item $tmp -Force -ErrorAction SilentlyContinue
+		}
+	}
+
+	It 'throws when the manifest file is missing' {
+		$checks = [System.Collections.Generic.List[object]]::new()
+		{ Add-ChecksFromManifest -Checks $checks -ManifestPath 'Z:\does\not\exist\packages.json' } | Should -Throw
+	}
+}
+
+Describe 'Parameter validation' {
+	BeforeAll {
+		$script:ScriptPath = Join-Path $PSScriptRoot 'Verify-NuGetDependenciesOnNuGetOrg.ps1'
+	}
+
+	# MaxAttempts < 1 would skip the set-based verification loop entirely and silently
+	# treat every dependency as available — ValidateRange must reject it at binding.
+	It 'rejects MaxAttempts below 1' {
+		{ & $ScriptPath -MaxAttempts 0 -ManifestPath 'x' } | Should -Throw
+		{ & $ScriptPath -MaxAttempts -1 -ManifestPath 'x' } | Should -Throw
+	}
+
+	It 'rejects a negative RetryDelaySeconds' {
+		{ & $ScriptPath -RetryDelaySeconds -1 -ManifestPath 'x' } | Should -Throw
+	}
+
+	It 'rejects HttpTimeoutSeconds below 1' {
+		{ & $ScriptPath -HttpTimeoutSeconds 0 -ManifestPath 'x' } | Should -Throw
+	}
+}
+
+Describe 'Add-StepSummaryLines' {
+	# The success summary emits blank-line elements around the collapsible <details> block;
+	# the parameter must accept empty strings (AllowEmptyString) or binding throws.
+	It 'writes lines including blank lines without throwing' {
+		$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("summary-" + [System.Guid]::NewGuid().ToString('N') + ".md")
+		$prev = $env:GITHUB_STEP_SUMMARY
+		$env:GITHUB_STEP_SUMMARY = $tmp
+		try {
+			{ Add-StepSummaryLines -Lines @('## Title', '', '<details><summary>x</summary>', '', '- a', '', '</details>') } | Should -Not -Throw
+			$content = Get-Content $tmp -Raw
+			$content | Should -Match '## Title'
+			$content | Should -Match '<details>'
+		}
+		finally {
+			$env:GITHUB_STEP_SUMMARY = $prev
+			Remove-Item $tmp -Force -ErrorAction SilentlyContinue
+		}
+	}
+
+	It 'is a no-op when GITHUB_STEP_SUMMARY is not set' {
+		$prev = $env:GITHUB_STEP_SUMMARY
+		$env:GITHUB_STEP_SUMMARY = $null
+		try {
+			{ Add-StepSummaryLines -Lines @('x', '') } | Should -Not -Throw
+		}
+		finally {
+			$env:GITHUB_STEP_SUMMARY = $prev
+		}
+	}
+}
+
+Describe 'Get-NuGetVersionAvailability (tri-state)' {
+	It 'returns Available when the exact version is listed' {
+		Mock -CommandName Invoke-RestMethod -MockWith { [PSCustomObject]@{ versions = @('1.0.0', '2.0.0') } }
+		Get-NuGetVersionAvailability -PackageId 'Uno.Test' -Version '2.0.0' -HttpTimeoutSeconds 5 | Should -Be 'Available'
+	}
+
+	It 'returns Absent when the id exists but the version is not listed (HTTP 200)' {
+		Mock -CommandName Invoke-RestMethod -MockWith { [PSCustomObject]@{ versions = @('1.0.0') } }
+		Get-NuGetVersionAvailability -PackageId 'Uno.Test' -Version '9.9.9' -HttpTimeoutSeconds 5 | Should -Be 'Absent'
+	}
+
+	It 'returns Error on a transient failure' {
+		Mock -CommandName Invoke-RestMethod -MockWith { throw 'transient network error' }
+		Get-NuGetVersionAvailability -PackageId 'Uno.Test' -Version '1.0.0' -HttpTimeoutSeconds 5 | Should -Be 'Error'
+	}
+}
+
+Describe 'Test-NuGetVersionAvailability (retry policy)' {
+	It 'does not retry a definitive Absent — a single probe even with MaxAttempts > 1' {
+		Mock -CommandName Invoke-RestMethod -MockWith { [PSCustomObject]@{ versions = @('1.0.0') } }
+		Test-NuGetVersionAvailability -PackageId 'Uno.Test' -Version '9.9.9' -MaxAttempts 5 -RetryDelaySeconds 0 -HttpTimeoutSeconds 5 | Should -BeFalse
+		Should -Invoke Invoke-RestMethod -Times 1 -Exactly
+	}
+
+	It 'retries a transient error and then succeeds' {
+		$script:calls = 0
+		Mock -CommandName Invoke-RestMethod -MockWith {
+			$script:calls++
+			if ($script:calls -lt 2) { throw 'transient' }
+			[PSCustomObject]@{ versions = @('1.0.0') }
+		}
+		Test-NuGetVersionAvailability -PackageId 'Uno.Test' -Version '1.0.0' -MaxAttempts 3 -RetryDelaySeconds 0 -HttpTimeoutSeconds 5 | Should -BeTrue
+		Should -Invoke Invoke-RestMethod -Times 2 -Exactly
+	}
+
+	It 'returns false after exhausting retries on persistent transient errors' {
+		Mock -CommandName Invoke-RestMethod -MockWith { throw 'always transient' }
+		Test-NuGetVersionAvailability -PackageId 'Uno.Test' -Version '1.0.0' -MaxAttempts 3 -RetryDelaySeconds 0 -HttpTimeoutSeconds 5 | Should -BeFalse
+		Should -Invoke Invoke-RestMethod -Times 3 -Exactly
+	}
+}

--- a/build/Verify-NuGetDependenciesOnNuGetOrg.ps1
+++ b/build/Verify-NuGetDependenciesOnNuGetOrg.ps1
@@ -1,11 +1,29 @@
 param(
+	# Artifact mode (default): scan produced .nupkg files under this path.
 	[string]$PackagesPath = "artifacts",
+	# Manifest mode: when set, verify the Uno.Sdk source manifest (src/Uno.Sdk/packages.json)
+	# instead of built artifacts. Enables a pre-build fail-fast check before the pipeline
+	# spends runners on the build and template test matrix. Takes precedence over -PackagesPath.
+	[string]$ManifestPath = "",
 	[string]$PackageIdFilter = "",
-	[int]$MaxAttempts = 12,
+	# Availability is verified in set-based rounds: MaxAttempts total sweeps (1 initial + up to
+	# MaxAttempts-1 retries of only the still-missing set), RetryDelaySeconds between rounds.
+	# Total wait on failure is bounded by (MaxAttempts - 1) * RetryDelaySeconds regardless of how
+	# many packages are missing, so a genuinely absent version fails fast. Default: 2 retries max.
+	# MaxAttempts must be >= 1: a value of 0 would skip the verification loop entirely and
+	# silently treat every dependency as available.
+	[ValidateRange(1, [int]::MaxValue)]
+	[int]$MaxAttempts = 3,
+	[ValidateRange(0, [int]::MaxValue)]
 	[int]$RetryDelaySeconds = 20,
+	[ValidateRange(1, [int]::MaxValue)]
 	[int]$HttpTimeoutSeconds = 30,
+	[ValidateRange(0, [int]::MaxValue)]
 	[int]$TransitiveDependencyDepth = 1,
-	[switch]$IncludeStableTransitiveVersions
+	[switch]$IncludeStableTransitiveVersions,
+	[string[]]$StableTransitiveIncludePrefixes = @('Uno.'),
+	[ValidateRange(0, [int]::MaxValue)]
+	[int]$TrackedTransitiveDependencyMaxDepth = 16
 )
 
 Set-StrictMode -Version Latest
@@ -28,7 +46,139 @@ function Get-ExactDependencyVersion {
 	return $null
 }
 
+function Test-IsTrackedPackageId {
+	# True when $PackageId starts with any of $IncludePrefixes (case-insensitive).
+	# "Tracked" ids (default: Uno.*) follow our own release cadence, so — unlike
+	# third-party / BCL packages — they can legitimately reference a version that is
+	# not published yet. Tracked ids therefore get two special treatments:
+	#   * stable transitive versions are still verified (not skipped), and
+	#   * their dependency graph is walked to its full closure (not capped at
+	#     TransitiveDependencyDepth), so an unpublished tracked package at ANY depth
+	#     is caught before publish instead of only one hop deep.
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$PackageId,
+		[AllowEmptyCollection()]
+		[string[]]$IncludePrefixes
+	)
+
+	if ($null -eq $IncludePrefixes) {
+		return $false
+	}
+
+	foreach ($prefix in $IncludePrefixes) {
+		if ([string]::IsNullOrWhiteSpace($prefix)) {
+			continue
+		}
+
+		if ($PackageId.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+			return $true
+		}
+	}
+
+	return $false
+}
+
+function Test-ShouldVerifyTransitiveDependency {
+	# Whether a discovered transitive dependency must be verified on nuget.org.
+	# Prereleases are always verified. Stable versions are skipped (third-party / BCL
+	# stable packages are assumed present, and verifying the whole closure would be slow
+	# and noisy) unless -IncludeStableTransitiveVersions is set or the id is tracked
+	# (Uno.*), which can point at an unpublished stable.
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$PackageId,
+		[string]$Version,
+		[bool]$IncludeStableTransitiveVersions,
+		[AllowEmptyCollection()]
+		[string[]]$IncludePrefixes
+	)
+
+	$isStable = -not [string]::IsNullOrWhiteSpace($Version) -and -not $Version.Contains('-')
+	if (-not $isStable) {
+		return $true
+	}
+
+	if ($IncludeStableTransitiveVersions) {
+		return $true
+	}
+
+	return (Test-IsTrackedPackageId -PackageId $PackageId -IncludePrefixes $IncludePrefixes)
+}
+
+function Test-ShouldExpandCoordinate {
+	# Whether a coordinate's own dependencies should be walked (expanded further).
+	# Non-tracked packages expand up to TransitiveDependencyDepth hops; tracked (Uno.*)
+	# packages expand to their full closure, bounded only by MaxTrackedDepth as a runaway
+	# guard (coordinate de-duplication already makes the walk finite).
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$PackageId,
+		[int]$Depth,
+		[int]$TransitiveDependencyDepth,
+		[int]$MaxTrackedDepth,
+		[AllowEmptyCollection()]
+		[string[]]$IncludePrefixes
+	)
+
+	if ($Depth -lt $TransitiveDependencyDepth) {
+		return $true
+	}
+
+	if ($Depth -lt $MaxTrackedDepth -and (Test-IsTrackedPackageId -PackageId $PackageId -IncludePrefixes $IncludePrefixes)) {
+		return $true
+	}
+
+	return $false
+}
+
+function Get-NuGetVersionAvailability {
+	# One probe of nuget.org for a specific package version. Returns a tri-state:
+	#   'Available' - the package id exists and the exact version is listed.
+	#   'Absent'    - a DEFINITIVE negative: the id exists but the version is not listed (HTTP 200),
+	#                 or the id itself is not published (HTTP 404). Retrying will not change this.
+	#   'Error'     - a TRANSIENT failure (network / timeout / 5xx / CDN blip). Retrying may help.
+	# The distinction lets callers retry transient blips while failing fast on genuinely-missing
+	# versions, and — critically — avoids treating a transient blip as "missing", which could
+	# otherwise skip a coordinate's transitive closure and hide unpublished deep dependencies.
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$PackageId,
+		[Parameter(Mandatory = $true)]
+		[string]$Version,
+		[Parameter(Mandatory = $true)]
+		[int]$HttpTimeoutSeconds
+	)
+
+	$indexUrl = "https://api.nuget.org/v3-flatcontainer/$($PackageId.ToLowerInvariant())/index.json"
+
+	try {
+		$response = Invoke-RestMethod -Uri $indexUrl -Method Get -TimeoutSec $HttpTimeoutSeconds -ErrorAction Stop
+		if ($null -ne $response.versions -and ($response.versions -contains $Version.ToLowerInvariant())) {
+			return 'Available'
+		}
+
+		return 'Absent'
+	}
+	catch {
+		$statusCode = $null
+		try { $statusCode = [int]$_.Exception.Response.StatusCode } catch { }
+
+		if ($statusCode -eq 404) {
+			# flat-container returns 404 when the package id has no published versions at all.
+			return 'Absent'
+		}
+
+		Write-Host "Transient error querying $indexUrl : $_"
+		return 'Error'
+	}
+}
+
 function Test-NuGetVersionAvailability {
+	# Confirm a version is on nuget.org, retrying ONLY on transient errors. A definitive 'Absent'
+	# returns immediately, so genuinely-missing versions fail fast (no wasted retries) while a
+	# transient blip is absorbed — closing the gap where a blip could skip a coordinate's
+	# transitive closure and hide unpublished deep dependencies.
 	param(
 		[Parameter(Mandatory = $true)]
 		[string]$PackageId,
@@ -42,23 +192,19 @@ function Test-NuGetVersionAvailability {
 		[int]$HttpTimeoutSeconds
 	)
 
-	$packageIdLower = $PackageId.ToLowerInvariant()
-	$expectedVersion = $Version.ToLowerInvariant()
-	$indexUrl = "https://api.nuget.org/v3-flatcontainer/$packageIdLower/index.json"
-
 	for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
-		try {
-			$response = Invoke-RestMethod -Uri $indexUrl -Method Get -TimeoutSec $HttpTimeoutSeconds
-			if ($null -ne $response.versions -and $response.versions -contains $expectedVersion) {
-				return $true
-			}
-		}
-		catch {
-			Write-Host "Unable to query $indexUrl on attempt $attempt/$MaxAttempts. $_"
+		$status = Get-NuGetVersionAvailability -PackageId $PackageId -Version $Version -HttpTimeoutSeconds $HttpTimeoutSeconds
+		if ($status -eq 'Available') {
+			return $true
 		}
 
+		if ($status -eq 'Absent') {
+			return $false
+		}
+
+		# transient error — retry
 		if ($attempt -lt $MaxAttempts) {
-			Write-Host "Dependency $PackageId $Version is not available yet on nuget.org. Waiting $RetryDelaySeconds second(s) before retrying..."
+			Write-Host "Transient error for $PackageId $Version (attempt $attempt/$MaxAttempts); retrying in $RetryDelaySeconds second(s)..."
 			Start-Sleep -Seconds $RetryDelaySeconds
 		}
 	}
@@ -69,6 +215,7 @@ function Test-NuGetVersionAvailability {
 function Add-StepSummaryLines {
 	param(
 		[Parameter(Mandatory = $true)]
+		[AllowEmptyString()]
 		[string[]]$Lines
 	)
 
@@ -236,183 +383,291 @@ function Get-ExactDependenciesFromPackageNuspec {
 	return @($result | Sort-Object Id, Version -Unique)
 }
 
-if (-not (Test-Path $PackagesPath)) {
-	Add-StepSummaryLines -Lines @(
-		"## NuGet Dependency Verification",
-		"❌ Failed: packages path '$PackagesPath' was not found."
+function Add-ChecksFromPackageGroups {
+	# Parse a packages.json catalog (an array of { group, version, packages[], versionOverride? }
+	# — the Uno.Sdk manifest shape) and add a check for every package at its group base version,
+	# plus any per-target-framework versionOverride. Shared by artifact mode (packages.json
+	# embedded in a produced .nupkg) and manifest mode (the source src/Uno.Sdk/packages.json).
+	param(
+		[Parameter(Mandatory = $true)]
+		[AllowEmptyCollection()]
+		[System.Collections.Generic.List[object]]$Checks,
+		[Parameter(Mandatory = $true)]
+		[string]$JsonContent,
+		[Parameter(Mandatory = $true)]
+		[string]$SourceLabel
 	)
 
-	throw "Packages path '$PackagesPath' was not found."
-}
+	$parsedGroups = $JsonContent | ConvertFrom-Json
+	$packageGroups = @()
+	if ($parsedGroups -is [System.Array]) {
+		$packageGroups += $parsedGroups
+	}
+	elseif ($null -ne $parsedGroups) {
+		$packageGroups += ,$parsedGroups
+	}
 
-$packageFiles = Get-ChildItem -Path $PackagesPath -Filter "*.nupkg" -File |
-	Where-Object {
-		if ([string]::IsNullOrWhiteSpace($PackageIdFilter)) {
-			return $true
+	foreach ($group in $packageGroups) {
+		$groupName = [string]$group.group
+		$baseVersion = [string]$group.version
+
+		foreach ($packageId in @($group.packages)) {
+			Add-DependencyCheck -Checks $Checks -PackageId ([string]$packageId) -Version $baseVersion -Source "$($SourceLabel):$groupName"
 		}
 
-		return $_.BaseName -like "$PackageIdFilter*"
+		$versionOverrideProperty = $group.PSObject.Properties['versionOverride']
+		if ($null -ne $versionOverrideProperty -and $null -ne $versionOverrideProperty.Value) {
+			foreach ($overrideProperty in @($versionOverrideProperty.Value.PSObject.Properties)) {
+				$overrideTargetFramework = [string]$overrideProperty.Name
+				$overrideVersion = [string]$overrideProperty.Value
+
+				if ([string]::IsNullOrWhiteSpace($overrideTargetFramework) -or [string]::IsNullOrWhiteSpace($overrideVersion)) {
+					continue
+				}
+
+				foreach ($packageId in @($group.packages)) {
+					Add-DependencyCheck -Checks $Checks -PackageId ([string]$packageId) -Version $overrideVersion -Source "$($SourceLabel):$($groupName):$overrideTargetFramework"
+				}
+			}
+		}
 	}
+}
 
-if (-not $packageFiles) {
-	if ([string]::IsNullOrWhiteSpace($PackageIdFilter)) {
-		Add-StepSummaryLines -Lines @(
-			"## NuGet Dependency Verification",
-			"❌ Failed: no .nupkg package was found in '$PackagesPath'."
-		)
-
-		throw "No .nupkg package was found in '$PackagesPath'."
-	}
-
-	Add-StepSummaryLines -Lines @(
-		"## NuGet Dependency Verification",
-		"❌ Failed: no package matching '$PackageIdFilter*.nupkg' was found in '$PackagesPath'."
+function Add-ChecksFromManifest {
+	# Manifest mode (pre-build fail-fast): read the source Uno.Sdk packages.json and add a
+	# check for every package it lists, so the pipeline can verify the Uno.* dependency
+	# closure on nuget.org BEFORE the build and template test matrix consume runners.
+	param(
+		[Parameter(Mandatory = $true)]
+		[AllowEmptyCollection()]
+		[System.Collections.Generic.List[object]]$Checks,
+		[Parameter(Mandatory = $true)]
+		[string]$ManifestPath
 	)
 
-	throw "No package matching '$PackageIdFilter*.nupkg' was found in '$PackagesPath'."
+	if (-not (Test-Path $ManifestPath)) {
+		Add-StepSummaryLines -Lines @(
+			"## NuGet Dependency Verification",
+			"❌ Failed: manifest path '$ManifestPath' was not found."
+		)
+
+		throw "Manifest path '$ManifestPath' was not found."
+	}
+
+	Write-Host "Inspecting package catalog from manifest '$ManifestPath'..."
+	$manifestContent = Get-Content -Path $ManifestPath -Raw
+
+	try {
+		Add-ChecksFromPackageGroups -Checks $Checks -JsonContent $manifestContent -SourceLabel "manifest:$(Split-Path $ManifestPath -Leaf)"
+	}
+	catch {
+		throw "Failed to parse manifest '$ManifestPath': $_"
+	}
+}
+
+function Add-ChecksFromArtifacts {
+	# Artifact mode (authoritative publish gate): inspect the produced .nupkg files —
+	# their direct nuspec dependencies and any embedded packages.json catalog.
+	param(
+		[Parameter(Mandatory = $true)]
+		[AllowEmptyCollection()]
+		[System.Collections.Generic.List[object]]$Checks,
+		[Parameter(Mandatory = $true)]
+		[string]$PackagesPath,
+		[string]$PackageIdFilter
+	)
+
+	if (-not (Test-Path $PackagesPath)) {
+		Add-StepSummaryLines -Lines @(
+			"## NuGet Dependency Verification",
+			"❌ Failed: packages path '$PackagesPath' was not found."
+		)
+
+		throw "Packages path '$PackagesPath' was not found."
+	}
+
+	$packageFiles = Get-ChildItem -Path $PackagesPath -Filter "*.nupkg" -File |
+		Where-Object {
+			if ([string]::IsNullOrWhiteSpace($PackageIdFilter)) {
+				return $true
+			}
+
+			return $_.BaseName -like "$PackageIdFilter*"
+		}
+
+	if (-not $packageFiles) {
+		if ([string]::IsNullOrWhiteSpace($PackageIdFilter)) {
+			Add-StepSummaryLines -Lines @(
+				"## NuGet Dependency Verification",
+				"❌ Failed: no .nupkg package was found in '$PackagesPath'."
+			)
+
+			throw "No .nupkg package was found in '$PackagesPath'."
+		}
+
+		Add-StepSummaryLines -Lines @(
+			"## NuGet Dependency Verification",
+			"❌ Failed: no package matching '$PackageIdFilter*.nupkg' was found in '$PackagesPath'."
+		)
+
+		throw "No package matching '$PackageIdFilter*.nupkg' was found in '$PackagesPath'."
+	}
+
+	Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+	foreach ($packageFile in $packageFiles) {
+		Write-Host "Inspecting dependencies for package '$($packageFile.Name)'..."
+
+		$archive = [System.IO.Compression.ZipFile]::OpenRead($packageFile.FullName)
+		try {
+			$nuspecEntry = $archive.Entries | Where-Object { $_.FullName -like "*.nuspec" } | Select-Object -First 1
+			if ($null -eq $nuspecEntry) {
+				throw "No .nuspec entry was found in '$($packageFile.FullName)'."
+			}
+
+			$nuspecContent = Read-ZipEntryContent -Entry $nuspecEntry
+
+			[xml]$nuspec = $nuspecContent
+			$dependencyNodes = @($nuspec.SelectNodes('/*[local-name()="package"]/*[local-name()="metadata"]/*[local-name()="dependencies"]/*[local-name()="dependency"]'))
+			$dependencyNodes += @($nuspec.SelectNodes('/*[local-name()="package"]/*[local-name()="metadata"]/*[local-name()="dependencies"]/*[local-name()="group"]/*[local-name()="dependency"]'))
+
+			$dependencies = $dependencyNodes |
+				Where-Object { $_ -and $_.id -and $_.version } |
+				ForEach-Object {
+					[PSCustomObject]@{
+						Id = $_.id
+						VersionRange = $_.version
+					}
+				} |
+				Sort-Object Id, VersionRange -Unique
+
+			foreach ($dependency in $dependencies) {
+				$exactVersion = Get-ExactDependencyVersion -VersionRange $dependency.VersionRange
+				if ([string]::IsNullOrWhiteSpace($exactVersion)) {
+					Write-Host "Skipping non-exact version range '$($dependency.VersionRange)' for dependency '$($dependency.Id)'."
+					continue
+				}
+
+				Add-DependencyCheck -Checks $Checks -PackageId $dependency.Id -Version $exactVersion -Source "nuspec:$($packageFile.Name)"
+			}
+
+			$packagesJsonEntries = @($archive.Entries | Where-Object { $_.FullName -match '(^|/)packages\.json$' })
+			foreach ($packagesJsonEntry in $packagesJsonEntries) {
+				Write-Host "Inspecting package catalog '$($packagesJsonEntry.FullName)' in '$($packageFile.Name)'..."
+				$packagesJsonContent = Read-ZipEntryContent -Entry $packagesJsonEntry
+
+				try {
+					Add-ChecksFromPackageGroups -Checks $Checks -JsonContent $packagesJsonContent -SourceLabel "packages.json:$($packageFile.Name)"
+				}
+				catch {
+					throw "Failed to parse '$($packagesJsonEntry.FullName)' from '$($packageFile.Name)': $_"
+				}
+			}
+		}
+		finally {
+			$archive.Dispose()
+		}
+	}
+}
+
+if ($MyInvocation.InvocationName -eq '.') {
+	# Dot-sourced (e.g. from the Pester tests): load the functions only and skip the
+	# artifact-scanning / nuget.org entry point below so unit tests run offline.
+	return
 }
 
 $checks = New-Object System.Collections.Generic.List[object]
 $missingDependencies = @{}
 $availabilityCache = @{}
 
-Add-Type -AssemblyName System.IO.Compression.FileSystem
-
-foreach ($packageFile in $packageFiles) {
-	Write-Host "Inspecting dependencies for package '$($packageFile.Name)'..."
-
-	$archive = [System.IO.Compression.ZipFile]::OpenRead($packageFile.FullName)
-	try {
-		$nuspecEntry = $archive.Entries | Where-Object { $_.FullName -like "*.nuspec" } | Select-Object -First 1
-		if ($null -eq $nuspecEntry) {
-			throw "No .nuspec entry was found in '$($packageFile.FullName)'."
-		}
-
-		$nuspecContent = Read-ZipEntryContent -Entry $nuspecEntry
-
-		[xml]$nuspec = $nuspecContent
-		$dependencyNodes = @($nuspec.SelectNodes('/*[local-name()="package"]/*[local-name()="metadata"]/*[local-name()="dependencies"]/*[local-name()="dependency"]'))
-		$dependencyNodes += @($nuspec.SelectNodes('/*[local-name()="package"]/*[local-name()="metadata"]/*[local-name()="dependencies"]/*[local-name()="group"]/*[local-name()="dependency"]'))
-
-		$dependencies = $dependencyNodes |
-			Where-Object { $_ -and $_.id -and $_.version } |
-			ForEach-Object {
-				[PSCustomObject]@{
-					Id = $_.id
-					VersionRange = $_.version
-				}
-			} |
-			Sort-Object Id, VersionRange -Unique
-
-		foreach ($dependency in $dependencies) {
-			$exactVersion = Get-ExactDependencyVersion -VersionRange $dependency.VersionRange
-			if ([string]::IsNullOrWhiteSpace($exactVersion)) {
-				Write-Host "Skipping non-exact version range '$($dependency.VersionRange)' for dependency '$($dependency.Id)'."
-				continue
-			}
-
-			Add-DependencyCheck -Checks $checks -PackageId $dependency.Id -Version $exactVersion -Source "nuspec:$($packageFile.Name)"
-		}
-
-		$packagesJsonEntries = @($archive.Entries | Where-Object { $_.FullName -match '(^|/)packages\.json$' })
-		foreach ($packagesJsonEntry in $packagesJsonEntries) {
-			Write-Host "Inspecting package catalog '$($packagesJsonEntry.FullName)' in '$($packageFile.Name)'..."
-			$packagesJsonContent = Read-ZipEntryContent -Entry $packagesJsonEntry
-
-			try {
-				$parsedGroups = $packagesJsonContent | ConvertFrom-Json
-				$packageGroups = @()
-				if ($parsedGroups -is [System.Array]) {
-					$packageGroups += $parsedGroups
-				}
-				elseif ($null -ne $parsedGroups) {
-					$packageGroups += ,$parsedGroups
-				}
-			}
-			catch {
-				throw "Failed to parse '$($packagesJsonEntry.FullName)' from '$($packageFile.Name)': $_"
-			}
-
-			foreach ($group in $packageGroups) {
-				$groupName = [string]$group.group
-				$baseVersion = [string]$group.version
-
-				foreach ($packageId in @($group.packages)) {
-					Add-DependencyCheck -Checks $checks -PackageId ([string]$packageId) -Version $baseVersion -Source "packages.json:$($packageFile.Name):$groupName"
-				}
-
-				$versionOverrideProperty = $group.PSObject.Properties['versionOverride']
-				if ($null -ne $versionOverrideProperty -and $null -ne $versionOverrideProperty.Value) {
-					foreach ($overrideProperty in @($versionOverrideProperty.Value.PSObject.Properties)) {
-						$overrideTargetFramework = [string]$overrideProperty.Name
-						$overrideVersion = [string]$overrideProperty.Value
-
-						if ([string]::IsNullOrWhiteSpace($overrideTargetFramework) -or [string]::IsNullOrWhiteSpace($overrideVersion)) {
-							continue
-						}
-
-						foreach ($packageId in @($group.packages)) {
-							Add-DependencyCheck -Checks $checks -PackageId ([string]$packageId) -Version $overrideVersion -Source "packages.json:$($packageFile.Name):$($groupName):$overrideTargetFramework"
-						}
-					}
-				}
-			}
-		}
-	}
-	finally {
-		$archive.Dispose()
-	}
+if (-not [string]::IsNullOrWhiteSpace($ManifestPath)) {
+	# Manifest mode: fail fast on the source Uno.Sdk manifest before build/tests run.
+	Add-ChecksFromManifest -Checks $checks -ManifestPath $ManifestPath
+}
+else {
+	# Artifact mode: authoritative gate on the produced packages before publish.
+	Add-ChecksFromArtifacts -Checks $checks -PackagesPath $PackagesPath -PackageIdFilter $PackageIdFilter
 }
 
 
 $uniqueChecks = @($checks |
 	Sort-Object Id, Version -Unique)
 
+# Coordinates skipped during expansion because they were not available at probe time. If any of
+# these turns out to be available in the final verification (eventual consistency / just-published),
+# its transitive closure was never walked — we fail (re-run) rather than risk a silent false pass.
+$deferredDuringExpansion = New-Object System.Collections.Generic.HashSet[string]
+
 if ($TransitiveDependencyDepth -gt 0) {
 	$expandedKeys = New-Object System.Collections.Generic.HashSet[string]
-	$frontier = @($uniqueChecks)
 
-	for ($depth = 1; $depth -le $TransitiveDependencyDepth; $depth++) {
-		if ($frontier.Count -eq 0) {
-			break
-		}
+	# Seed the frontier with the directly-referenced coordinates at depth 0, then walk
+	# breadth-first. Non-tracked packages are expanded up to TransitiveDependencyDepth
+	# hops; tracked (Uno.*) packages are walked to their full closure so an unpublished
+	# tracked package at ANY depth is caught. Coordinate de-duplication ($expandedKeys)
+	# keeps the walk finite; TrackedTransitiveDependencyMaxDepth is a runaway guard.
+	$frontier = New-Object System.Collections.Generic.List[object]
+	foreach ($seed in $uniqueChecks) {
+		$frontier.Add([PSCustomObject]@{ Id = $seed.Id; Version = $seed.Version; Source = $seed.Source; Depth = 0 })
+	}
 
-		Write-Host "Expanding transitive dependencies (depth $depth/$TransitiveDependencyDepth) for $($frontier.Count) package/version coordinate(s)..."
+	$round = 0
+	while ($frontier.Count -gt 0) {
+		$round++
+		Write-Host "Expanding transitive dependencies (round $round) for $($frontier.Count) package/version coordinate(s)..."
 
 		$nextFrontier = New-Object System.Collections.Generic.List[object]
 
-		foreach ($coordinate in $frontier) {
+		foreach ($coordinate in ($frontier | Sort-Object Id, Version -Unique)) {
 			$coordinateKey = "$($coordinate.Id)|$($coordinate.Version)"
 			if (-not $expandedKeys.Add($coordinateKey)) {
 				continue
 			}
 
-			if ($availabilityCache.ContainsKey($coordinateKey)) {
-				$coordinateAvailable = [bool]$availabilityCache[$coordinateKey]
+			if (-not (Test-ShouldExpandCoordinate -PackageId ([string]$coordinate.Id) -Depth $coordinate.Depth -TransitiveDependencyDepth $TransitiveDependencyDepth -MaxTrackedDepth $TrackedTransitiveDependencyMaxDepth -IncludePrefixes $StableTransitiveIncludePrefixes)) {
+				# Leaf for the walk: already recorded in $checks when discovered, and its
+				# availability is confirmed by the final verification pass below.
+				continue
+			}
+
+			# Probe availability before walking this coordinate's dependencies. A definitive
+			# 'Absent' returns immediately (genuinely-missing versions fail fast); a transient
+			# blip is retried (MaxAttempts) so it can't silently skip this coordinate's transitive
+			# closure and hide unpublished deep dependencies. Only positives are cached; the
+			# missing-dependency reporting happens in the final verification pass below.
+			if ($availabilityCache.ContainsKey($coordinateKey) -and [bool]$availabilityCache[$coordinateKey]) {
+				$coordinateAvailable = $true
 			}
 			else {
 				$coordinateAvailable = Test-NuGetVersionAvailability -PackageId $coordinate.Id -Version $coordinate.Version -MaxAttempts $MaxAttempts -RetryDelaySeconds $RetryDelaySeconds -HttpTimeoutSeconds $HttpTimeoutSeconds
-				$availabilityCache[$coordinateKey] = $coordinateAvailable
+				if ($coordinateAvailable) {
+					$availabilityCache[$coordinateKey] = $true
+				}
 			}
 
 			if (-not $coordinateAvailable) {
-				Add-MissingDependencyRecord -MissingDependencies $missingDependencies -PackageId $coordinate.Id -Version $coordinate.Version -Source ([string]$coordinate.Source) -SourcesByDependencyKey $null
-				Write-Host "Skipping transitive expansion for missing dependency '$($coordinate.Id)' version '$($coordinate.Version)'."
+				# Genuinely missing (or unreachable after retries): its nuspec can't be fetched, so
+				# stop walking this branch. Final verification reports it as missing. Record it so
+				# that, if it turns out available later, we fail instead of hiding its closure.
+				[void]$deferredDuringExpansion.Add($coordinateKey)
+				Write-Host "Deferring '$($coordinate.Id)' $($coordinate.Version) to final verification (not available)."
 				continue
 			}
 
 			$transitiveDependencies = Get-ExactDependenciesFromPackageNuspec -PackageId $coordinate.Id -Version $coordinate.Version -HttpTimeoutSeconds $HttpTimeoutSeconds -MaxAttempts $MaxAttempts -RetryDelaySeconds $RetryDelaySeconds
 			foreach ($transitiveDependency in $transitiveDependencies) {
-				if (-not $IncludeStableTransitiveVersions -and -not [string]::IsNullOrWhiteSpace($transitiveDependency.Version) -and -not $transitiveDependency.Version.Contains('-')) {
+				$depId = [string]$transitiveDependency.Id
+				if (-not (Test-ShouldVerifyTransitiveDependency -PackageId $depId -Version ([string]$transitiveDependency.Version) -IncludeStableTransitiveVersions ([bool]$IncludeStableTransitiveVersions) -IncludePrefixes $StableTransitiveIncludePrefixes)) {
 					continue
 				}
 
-				Add-DependencyCheck -Checks $checks -PackageId $transitiveDependency.Id -Version $transitiveDependency.Version -Source "transitive:$($coordinate.Id):$($coordinate.Version)"
-				$nextFrontier.Add($transitiveDependency)
+				$transitiveSource = "transitive:$($coordinate.Id):$($coordinate.Version)"
+				Add-DependencyCheck -Checks $checks -PackageId $depId -Version $transitiveDependency.Version -Source $transitiveSource
+				$nextFrontier.Add([PSCustomObject]@{ Id = $depId; Version = $transitiveDependency.Version; Source = $transitiveSource; Depth = ($coordinate.Depth + 1) })
 			}
 		}
 
-		$frontier = @($nextFrontier | Sort-Object Id, Version -Unique)
+		$frontier = $nextFrontier
 	}
 
 	$uniqueChecks = @($checks |
@@ -423,24 +678,48 @@ $sourcesByDependencyKey = Build-DependencySourcesMap -Checks $checks
 
 Write-Host "Checking $($uniqueChecks.Count) unique package/version coordinate(s) on nuget.org..."
 
-foreach ($check in $uniqueChecks) {
-	$cacheKey = "$($check.Id)|$($check.Version)"
+# Set-based retry: sweep every coordinate once (single attempt each), then retry ONLY the
+# still-missing set between rounds. Total wait is bounded by (MaxAttempts - 1) * RetryDelaySeconds
+# regardless of how many coordinates are missing, so a genuinely absent version fails fast
+# instead of each missing coordinate serially exhausting the whole retry budget.
+$pending = @($uniqueChecks)
+$stillMissing = New-Object System.Collections.Generic.List[object]
 
-	if ($availabilityCache.ContainsKey($cacheKey)) {
-		$available = [bool]$availabilityCache[$cacheKey]
-	}
-	else {
-		$available = Test-NuGetVersionAvailability -PackageId $check.Id -Version $check.Version -MaxAttempts $MaxAttempts -RetryDelaySeconds $RetryDelaySeconds -HttpTimeoutSeconds $HttpTimeoutSeconds
-		$availabilityCache[$cacheKey] = $available
+for ($round = 1; $round -le $MaxAttempts; $round++) {
+	$stillMissing = New-Object System.Collections.Generic.List[object]
+
+	foreach ($check in $pending) {
+		$cacheKey = "$($check.Id)|$($check.Version)"
+
+		if ($availabilityCache.ContainsKey($cacheKey) -and [bool]$availabilityCache[$cacheKey]) {
+			continue
+		}
+
+		$available = Test-NuGetVersionAvailability -PackageId $check.Id -Version $check.Version -MaxAttempts 1 -RetryDelaySeconds 0 -HttpTimeoutSeconds $HttpTimeoutSeconds
+		if ($available) {
+			$availabilityCache[$cacheKey] = $true
+			Write-Host "Verified dependency '$($check.Id)' version '$($check.Version)' on nuget.org."
+		}
+		else {
+			$stillMissing.Add($check)
+		}
 	}
 
-	if ($available) {
-		Write-Host "Verified dependency '$($check.Id)' version '$($check.Version)' on nuget.org."
+	if ($stillMissing.Count -eq 0) {
+		break
 	}
-	else {
-		Add-MissingDependencyRecord -MissingDependencies $missingDependencies -PackageId $check.Id -Version $check.Version -Source ([string]$check.Source) -SourcesByDependencyKey $sourcesByDependencyKey
-		Write-Host "Missing dependency '$($check.Id)' version '$($check.Version)' (source: $($check.Source))."
+
+	if ($round -lt $MaxAttempts) {
+		Write-Host "$($stillMissing.Count) dependency/ies not available on nuget.org yet; retrying in $RetryDelaySeconds second(s) (round $round/$MaxAttempts)..."
+		Start-Sleep -Seconds $RetryDelaySeconds
 	}
+
+	$pending = $stillMissing
+}
+
+foreach ($check in $stillMissing) {
+	Add-MissingDependencyRecord -MissingDependencies $missingDependencies -PackageId $check.Id -Version $check.Version -Source ([string]$check.Source) -SourcesByDependencyKey $sourcesByDependencyKey
+	Write-Host "Missing dependency '$($check.Id)' version '$($check.Version)' (source: $($check.Source))."
 }
 
 if ($missingDependencies.Count -gt 0) {
@@ -457,18 +736,47 @@ if ($missingDependencies.Count -gt 0) {
 
 	Add-StepSummaryLines -Lines $summaryLines
 
-	$message = @(
-		"The following dependencies are not available on nuget.org:",
-		($missingList | ForEach-Object { " - $_" }),
-		"Aborting publish to avoid pushing a package with unresolved dependencies."
-	) -join [Environment]::NewLine
+	$messageLines = @("The following dependencies are not available on nuget.org:")
+	$messageLines += ($missingList | ForEach-Object { " - $_" })
+	$messageLines += "Aborting publish to avoid pushing a package with unresolved dependencies."
+	$message = $messageLines -join [Environment]::NewLine
 
 	throw $message
 }
 
-Add-StepSummaryLines -Lines @(
-	"## NuGet Dependency Verification",
-	"✅ All checked package dependencies are available on nuget.org."
+# Safety net for the transitive walk: a coordinate skipped during expansion (not available at
+# probe time) that is now confirmed available means its transitive closure was never walked, so an
+# unpublished deep dependency behind it could be hidden. Fail (re-run) rather than risk a false pass.
+$unwalkedButAvailable = @(
+	$deferredDuringExpansion | Where-Object { $availabilityCache.ContainsKey($_) -and [bool]$availabilityCache[$_] } | Sort-Object -Unique
 )
+
+if ($unwalkedButAvailable.Count -gt 0) {
+	$summaryLines = @(
+		"## NuGet Dependency Verification",
+		"❌ Could not fully verify the transitive closure. These coordinates were skipped during dependency-tree expansion (not available at the time) but are now available, so their dependencies were not walked — re-run the check:"
+	)
+	$summaryLines += ($unwalkedButAvailable | ForEach-Object { "- $_" })
+	Add-StepSummaryLines -Lines $summaryLines
+
+	$messageLines = @("Could not fully verify the transitive dependency closure. The following coordinates were unavailable during expansion but are now available, so their dependencies were not walked:")
+	$messageLines += ($unwalkedButAvailable | ForEach-Object { " - $_" })
+	$messageLines += "This is usually a transient nuget.org/CDN timing effect — re-run the check."
+	$message = $messageLines -join [Environment]::NewLine
+
+	throw $message
+}
+
+$verifiedLines = @($uniqueChecks | Sort-Object Id, Version | ForEach-Object { "- $($_.Id) $($_.Version)" })
+$successSummary = @(
+	"## NuGet Dependency Verification",
+	"✅ All checked package dependencies are available on nuget.org.",
+	"",
+	"<details><summary>Verified dependencies ($($uniqueChecks.Count))</summary>",
+	""
+)
+$successSummary += $verifiedLines
+$successSummary += @("", "</details>")
+Add-StepSummaryLines -Lines $successSummary
 
 Write-Host "All checked dependencies are available on nuget.org."


### PR DESCRIPTION
## Problem

The publish gate (`build/Verify-NuGetDependenciesOnNuGetOrg.ps1`) verifies that every package/version referenced by a produced `.nupkg` — including its `packages.json` catalog entries and transitive nuspec dependencies — is available on nuget.org, and blocks the nuget.org publish if any is missing. It runs before **both** nuget.org publish paths (dev on push to `main` via `publish_dev`, and prod on `release/**` via `publish_release_nuget_org`).

It had **weaknesses** for the Uno family, which — unlike third-party / BCL packages — follows our own release cadence and can legitimately reference a version not published yet:

1. **Stable transitive deps were skipped.** The transitive expansion skipped stable (non-prerelease) dependencies on the assumption they're always published. True for `System.*` / `Microsoft.*`, false for `Uno.*`.
2. **Only one transitive hop was walked** (`TransitiveDependencyDepth = 1`). An unpublished `Uno.*` package reachable only at depth ≥ 2 wasn't checked.
3. **It ran only at publish time** — after `build`, `sign`, and the whole template test matrix. A package-availability failure wasted all those runners before being caught.
4. **It failed slowly.** Each missing coordinate retried serially with a 12×20s budget *during* transitive expansion, so a genuinely-absent version (the phantom `7.0.1`) took 12+ minutes before the gate failed.

### Real occurrence

`Uno.Toolkit.WinUI.Material` / `.Cupertino` / `.Simple` `9.1.0-dev.1` were published depending on `Uno.Material.WinUI` / `Uno.Cupertino.WinUI` / `Uno.Simple.WinUI` **`7.0.1`** — a stable version that was never published (only `7.0.0-dev.*` and `7.1.0-dev.1` exist). The SDK-update PR that bumped `UnoToolkitVersion` to `9.1.0-dev.1` passed the gate and published, because the manifest's directly-listed versions are on nuget.org and the phantom stable `7.0.1` was skipped by weakness #1. It broke restore for direct consumers of the flavored toolkit packages. Root cause fixed in `uno.toolkit.ui` (#1616); this PR closes the gate weaknesses so the same class of failure is caught here.

## Change

- **Verify stable `Uno.*` transitive deps.** `StableTransitiveIncludePrefixes` (default `@('Uno.')`): stable transitive deps whose id matches a prefix are still checked; third-party stable deps remain skipped for speed. `-IncludeStableTransitiveVersions` still forces all. Case-insensitive.
- **Walk the full `Uno.*` transitive closure.** The one-hop `for` loop is now a breadth-first walk with per-coordinate depth. Non-tracked packages stop at `TransitiveDependencyDepth`; tracked (`Uno.*`) packages are walked to their full closure, bounded by `TrackedTransitiveDependencyMaxDepth` (default `16`; coordinate de-dup already makes it finite). Unpublished `Uno.*` at **any** depth is caught.
- **Fail fast, before the build.** New first CI job **`verify_dependencies`** runs the check in a new **`-ManifestPath` mode** that reads the source `src/Uno.Sdk/packages.json` (no build output needed). `build` and `generate-test-matrix` now `needs: verify_dependencies`, so the whole pipeline short-circuits in seconds on a package problem — **on push and on PRs** — instead of after build + sign + the full test matrix. The existing artifact-based gate still runs before each nuget.org push as the authoritative final check.
- **Fail fast, fewer retries.** During expansion, availability is probed with a **single attempt** (no retry storm; a not-found coordinate is deferred to the final pass). The final verification uses a **set-based retry** — sweep all once, then retry only the still-missing set between rounds — so total wait is bounded by `(MaxAttempts - 1) × RetryDelaySeconds` regardless of how many are missing. Default `MaxAttempts` is now **3 (2 retries max)**; the `verify_dependencies` job runs `3×10s`, the publish gate `3×20s`. Also fixed the abort message that rendered the missing list as `System.Object[]`.
- **Refactor + testability.** Gathering logic split into `Add-ChecksFromPackageGroups` / `Add-ChecksFromManifest` / `Add-ChecksFromArtifacts`; decision logic into `Test-IsTrackedPackageId` / `Test-ShouldVerifyTransitiveDependency` / `Test-ShouldExpandCoordinate`. The script's main body is guarded so it can be dot-sourced for offline unit tests.

## CI job graph (after)

```
verify_dependencies  (new root — runs on push + PR)
  ├─ build ─ sign ─ publish_dev / publish_release_uno ─ publish_release_nuget_org
  └─ generate-test-matrix ─ {linux,windows,macos}-template-tests ─ test-validation
```

`verify_dependencies` fails → `build` + `generate-test-matrix` skip → tests, sign, and publish all skip.

## Tests

New `build/Verify-NuGetDependenciesOnNuGetOrg.Tests.ps1` (Pester v5+, fully offline). **22/22 passing** locally (Pester 6.0.1): tracked-id detection, verify/skip decision, closure-expansion depth logic, version-range parsing, and manifest/group parsing.

```
Invoke-Pester -Path build/Verify-NuGetDependenciesOnNuGetOrg.Tests.ps1
```

**End-to-end (executed against real nuget.org):**
- Manifest listing `Uno.Material.WinUI 7.1.0-dev.1` → walk expanded **4 hops deep**, discovered the full `Uno.*` closure (12 coordinates: `Uno.Themes.WinUI`, `Uno.WinUI`, `Uno.Foundation`, `Uno.WinRT`, `Uno.Core.Extensions.*`, `Uno.Fonts.*`, `Uno.WinUI.Lottie`), all verified → success. Proves the multi-hop closure the old depth-1 gate would have missed.
- Manifest listing an unpublished package → `throw` "Aborting publish… not available on nuget.org" → blocks (message now formats one item per line).
- **Fail-fast timing**: the exact incident repro (manifest → toolkit `9.1.0-dev.1` → phantom `Uno.Material/Cupertino/Simple.WinUI 7.0.1`) now fails in **~25s locally** (≈40s in CI at `3×10s`), reporting all three missing at once — vs **12+ minutes** with the old per-coordinate 12×20s retry.

## Note

`verify_dependencies` on this PR is expected to stay **red until the toolkit fix lands**: it is correctly catching the real `Uno.Toolkit.WinUI.* 9.1.0-dev.1 → Uno.*.WinUI 7.0.1` phantom dependency in the manifest. It will go green once `uno.toolkit.ui#1616` merges, a corrected toolkit dev build republishes, and the manifest bumps to it.

## Example of the validation

<img width="899" height="744" alt="image" src="https://github.com/user-attachments/assets/9962078d-ed58-404d-8df6-b425fb362ca0" />

