### PR TITLE
ci(templates): Prioritize release path; gate nuget.org on publish, advise on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: verify_dependencies
 
     steps:
     - name: Checkout
@@ -70,14 +69,18 @@ jobs:
     - name: "Build Package"
       uses: ./.github/actions/ci/build-packages
 
-  # Verify every referenced Uno.* package exists on nuget.org BEFORE the build and the
-  # template test matrix run, so a package-availability problem fails the pipeline in
-  # seconds instead of after build + sign + the full test matrix have consumed runners.
-  # Reads the source Uno.Sdk manifest (no build output needed) and runs on push and PRs.
-  # Defined after `build` so its run-summary renders below the Build "NuGet Package Summary";
-  # it still executes first via the `needs: verify_dependencies` on build and generate-test-matrix.
-  verify_dependencies:
-    name: Verify Dependencies
+  # The nuget.org dependency verification is a HARD GATE only on the publication paths:
+  #   * dev publish  (push to main)        -> verify_dependencies_dev  (this job) gates publish_dev
+  #   * prod publish (push to release/**)  -> verify_dependencies_prod gates publish_release_nuget_org
+  # On PRs it is NOT a gate: the build restores from the internal feed, so a dev package that is not
+  # yet on nuget.org does not block the PR -- report_dependencies surfaces it as a resolvable comment.
+
+  # Dev-publish gate: before pushing the -dev packages to nuget.org (push to main), verify the FULL
+  # Uno.* dependency closure is already resolvable there. publish_dev depends on this, so a missing
+  # dependency blocks the dev publish (but not the build/tests).
+  verify_dependencies_dev:
+    name: Verify Dependencies (dev publish)
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -90,6 +93,36 @@ jobs:
       shell: pwsh
       run: |
         ./build/Verify-NuGetDependenciesOnNuGetOrg.ps1 -ManifestPath src/Uno.Sdk/packages.json -MaxAttempts 3 -RetryDelaySeconds 10 -HttpTimeoutSeconds 30
+
+  # Non-blocking PR advisory: surface any prerelease (dev) dependency the manifest references that is
+  # not yet on nuget.org as a resolvable inline PR comment. Never blocks the PR -- the build restores
+  # from the internal feed, and the hard gate lives only on the publish paths. Direct manifest
+  # entries only (depth 0) to keep the PR run cheap.
+  report_dependencies:
+    name: Report Missing Dependencies
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: "Collect dev dependencies missing from nuget.org"
+      shell: pwsh
+      run: |
+        ./build/Verify-NuGetDependenciesOnNuGetOrg.ps1 -ManifestPath src/Uno.Sdk/packages.json -PrereleaseDependenciesOnly -ReportOnly -ReportOutputPath missing-dependencies.json -TransitiveDependencyDepth 0 -MaxAttempts 3 -RetryDelaySeconds 5 -HttpTimeoutSeconds 30
+
+    - name: "Post resolvable inline comment(s) for missing dev dependencies"
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        ./build/Report-MissingDependenciesOnPr.ps1 -Repository "${{ github.repository }}" -PullNumber ${{ github.event.pull_request.number }} -HeadSha "${{ github.event.pull_request.head.sha }}" -ReportPath missing-dependencies.json
 
   # Sign the nuget packages
   sign:
@@ -122,7 +155,7 @@ jobs:
     name: Publish Dev
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
-    needs: sign
+    needs: [sign, verify_dependencies_dev]
 
     steps:
     - name: Checkout
@@ -156,13 +189,36 @@ jobs:
       with:
         token: ${{ secrets.UNO_NUGET_FEED_API_KEY }}
 
+  # Ordering gate for the nuget.org (production) publish on a stable release. Stable releases are
+  # built + signed + pushed to the Uno production feed and deeply tested FIRST; only then are the
+  # packages published to nuget.org. This job runs right after the production-feed publish and right
+  # before the nuget.org publish, verifying the FULL Uno.* dependency closure is already on nuget.org
+  # -- so we never push a stable package whose (previously-released) stable dependencies are not yet
+  # public. This enforces the correct order when releasing all the stables in sequence.
+  verify_dependencies_prod:
+    name: Verify Dependencies (pre-publish)
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/') }}
+    runs-on: ubuntu-latest
+    needs: publish_release_uno
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ env.CheckoutRef }}
+
+    - name: "Verify Uno.* dependency closure on nuget.org"
+      shell: pwsh
+      run: |
+        ./build/Verify-NuGetDependenciesOnNuGetOrg.ps1 -ManifestPath src/Uno.Sdk/packages.json -MaxAttempts 3 -RetryDelaySeconds 10 -HttpTimeoutSeconds 30
+
   # Publish release packages to nuget.org
   publish_release_nuget_org:
     name: Publish Nuget.org Production
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/') }}
     runs-on: ubuntu-latest
     environment: Production
-    needs: publish_release_uno
+    needs: verify_dependencies_prod
 
     steps:
     - name: Checkout
@@ -176,11 +232,28 @@ jobs:
     - name: "Tag Release"
       uses: ./.github/actions/ci/tag-release
 
-  # Generate the template tests build matrix
+  # Generate the template tests build matrix.
+  # Gated on the full release path so signing + publication are prioritized for the hosted
+  # runners on a merge build (push to main / release): the matrix waits for build -> sign ->
+  # publish*, then runs. On PRs / schedule / dispatch the publish jobs are skipped, so the
+  # skip-tolerant condition lets the matrix run once `build` finishes (tests prioritized).
+  # `build` is listed explicitly so this never starts before it in any event; the test jobs
+  # also require `build`. always() is required so the condition is evaluated when the publish
+  # jobs are skipped.
   generate-test-matrix:
     runs-on: ubuntu-latest
     name: Generate Test Matrix
-    needs: verify_dependencies
+    needs:
+      - build
+      - publish_dev
+      - publish_release_uno
+      - publish_release_nuget_org
+    if: >-
+      ${{ always()
+      && needs.build.result == 'success'
+      && (needs.publish_dev.result == 'success' || needs.publish_dev.result == 'skipped')
+      && (needs.publish_release_uno.result == 'success' || needs.publish_release_uno.result == 'skipped')
+      && (needs.publish_release_nuget_org.result == 'success' || needs.publish_release_nuget_org.result == 'skipped') }}
 
     outputs:
       testMatrix: ${{ steps.generate-test-matrix-step.outputs.TestMatrix }}
@@ -199,9 +272,16 @@ jobs:
   # Run the test matrix on linux
   linux-template-tests:
     runs-on: ubuntu-latest
-    needs: 
+    needs:
     - generate-test-matrix
     - build
+    # Explicit condition: generate-test-matrix runs via always() and transitively depends on the
+    # publish jobs (skipped on PRs), which would poison this job's implicit success() and skip it.
+    # Run whenever the matrix + build succeeded, regardless of those skipped publish ancestors.
+    if: >-
+      ${{ always()
+      && needs.generate-test-matrix.result == 'success'
+      && needs.build.result == 'success' }}
 
     name: Linux Tests (${{ matrix.groupName }})
 
@@ -230,9 +310,14 @@ jobs:
   # Run the test matrix on Windows
   windows-template-tests:
     runs-on: windows-latest
-    needs: 
+    needs:
     - generate-test-matrix
     - build
+    # See Linux Tests: run whenever the matrix + build succeeded, ignoring skipped publish ancestors.
+    if: >-
+      ${{ always()
+      && needs.generate-test-matrix.result == 'success'
+      && needs.build.result == 'success' }}
 
     name: Windows Tests (${{ matrix.groupName }})
 
@@ -261,9 +346,14 @@ jobs:
   # Run the test matrix on macOS
   macos-template-tests:
     runs-on: macos-15
-    needs: 
+    needs:
     - generate-test-matrix
     - build
+    # See Linux Tests: run whenever the matrix + build succeeded, ignoring skipped publish ancestors.
+    if: >-
+      ${{ always()
+      && needs.generate-test-matrix.result == 'success'
+      && needs.build.result == 'success' }}
 
     name: macOS Tests (${{ matrix.groupName }})
 

--- a/build/Report-MissingDependenciesOnPr.ps1
+++ b/build/Report-MissingDependenciesOnPr.ps1
@@ -1,0 +1,116 @@
+# Posts a resolvable inline PR review comment for each Uno.* dependency that a PR references but
+# that is not yet published to nuget.org. Non-blocking by design: the pre-build "report" pass
+# collects the missing (dev) dependencies, and this script surfaces them as review-thread comments
+# (which carry the "Resolve conversation" button) instead of failing the PR. The build/tests are
+# unaffected — they restore from the internal feed. The hard gate lives only on the publish paths.
+#
+# Idempotent: a hidden marker per (version, line) means re-runs on the same PR do not duplicate a
+# comment. Never throws — any API hiccup is logged and skipped so the job stays green.
+#
+# Requires GH_TOKEN / GITHUB_TOKEN in the environment (the workflow provides the job's GITHUB_TOKEN
+# with `pull-requests: write`).
+
+param(
+	[Parameter(Mandatory = $true)]
+	[string]$Repository,          # owner/repo, e.g. unoplatform/uno.templates
+	[Parameter(Mandatory = $true)]
+	[int]$PullNumber,
+	[Parameter(Mandatory = $true)]
+	[string]$HeadSha,             # PR head commit the review comment is anchored to
+	[Parameter(Mandatory = $true)]
+	[string]$ReportPath,          # JSON produced by Verify-NuGetDependenciesOnNuGetOrg.ps1 -ReportOnly
+	[string]$ManifestPath = "src/Uno.Sdk/packages.json",
+	# Path used in the review comment; must be the repo-relative path with forward slashes.
+	[string]$CommentPath = "src/Uno.Sdk/packages.json",
+	# Log the intended API calls instead of posting (local validation).
+	[switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $ReportPath)) {
+	Write-Host "No report file at '$ReportPath'; nothing to comment."
+	return
+}
+
+$missing = @(Get-Content -Path $ReportPath -Raw | ConvertFrom-Json)
+if ($missing.Count -eq 0) {
+	Write-Host "No missing dependencies reported; nothing to comment."
+	return
+}
+
+if (-not (Test-Path $ManifestPath)) {
+	Write-Warning "Manifest '$ManifestPath' not found; cannot anchor comments."
+	return
+}
+
+# Fetch existing review comments once for idempotency (match on the hidden marker in the body).
+$existingBodies = @()
+try {
+	$existingBodies = @(gh api --paginate "repos/$Repository/pulls/$PullNumber/comments" --jq '.[].body')
+}
+catch {
+	Write-Warning "Could not list existing review comments: $($_.Exception.Message)"
+}
+
+# Group the missing coordinates by version, so one comment per manifest line covers every package
+# that shares that (missing) version instead of one comment per package id.
+$byVersion = $missing | Group-Object -Property Version
+
+foreach ($group in $byVersion) {
+	$version = [string]$group.Name
+	$ids = @($group.Group | ForEach-Object { [string]$_.Id } | Sort-Object -Unique)
+
+	# Anchor on the manifest line(s) that carry this version, e.g. `"version": "7.1.0-dev.1",`.
+	$pattern = '"version"\s*:\s*"' + [regex]::Escape($version) + '"'
+	$versionLineMatches = @(Select-String -Path $ManifestPath -Pattern $pattern)
+	if ($versionLineMatches.Count -eq 0) {
+		# Fallback: any line mentioning the version string (e.g. a versionOverride).
+		$versionLineMatches = @(Select-String -Path $ManifestPath -Pattern ([regex]::Escape($version)))
+	}
+
+	if ($versionLineMatches.Count -eq 0) {
+		Write-Warning "Could not locate a manifest line for version '$version'; skipping inline comment for: $($ids -join ', ')."
+		continue
+	}
+
+	foreach ($versionMatch in $versionLineMatches) {
+		$line = [int]$versionMatch.LineNumber
+		$marker = "<!-- nuget-dep-report:v=${version}:L$line -->"
+
+		if (($existingBodies | Where-Object { $_ -and $_.Contains($marker) }).Count -gt 0) {
+			Write-Host "Comment already present for version '$version' at line $line; skipping."
+			continue
+		}
+
+		$idList = ($ids | ForEach-Object { "``$_``" }) -join ', '
+		$body = @"
+$marker
+⚠️ **Dependency not yet on nuget.org**
+
+$idList at version ``$version`` is referenced here but is **not published to nuget.org** yet.
+
+This does **not** block this PR — the build restores from the internal feed. The version must be public before the **dev/prod publish** gate will pass. **Resolve this conversation** once it is published (or if it is intentionally internal-only).
+"@
+
+		if ($DryRun) {
+			Write-Host "[DryRun] Would post inline comment -> path='$CommentPath' line=$line commit=$HeadSha version='$version' ids=($($ids -join ', '))"
+			Write-Host "[DryRun] marker: $marker"
+			continue
+		}
+
+		try {
+			gh api --method POST "repos/$Repository/pulls/$PullNumber/comments" `
+				-f body="$body" `
+				-f commit_id="$HeadSha" `
+				-f path="$CommentPath" `
+				-F line=$line `
+				-f side="RIGHT" | Out-Null
+			Write-Host "Posted inline comment for version '$version' at line $line ($($ids -join ', '))."
+		}
+		catch {
+			# A 422 usually means the line is not part of the PR diff; log and continue (non-blocking).
+			Write-Warning "Could not post inline comment for version '$version' at line ${line}: $($_.Exception.Message)"
+		}
+	}
+}

--- a/build/Verify-NuGetDependenciesOnNuGetOrg.Tests.ps1
+++ b/build/Verify-NuGetDependenciesOnNuGetOrg.Tests.ps1
@@ -57,6 +57,87 @@ Describe 'Test-ShouldVerifyTransitiveDependency' {
 	It 'verifies stable third-party deps when IncludeStableTransitiveVersions is set' {
 		Test-ShouldVerifyTransitiveDependency -PackageId 'System.Text.Json' -Version '9.0.0' -IncludeStableTransitiveVersions $true -IncludePrefixes $UnoPrefixes | Should -BeTrue
 	}
+
+	It 'in prerelease-only mode still verifies a prerelease dep' {
+		Test-ShouldVerifyTransitiveDependency -PackageId 'Uno.Simple.WinUI' -Version '7.1.0-dev.1' -IncludeStableTransitiveVersions $false -IncludePrefixes $UnoPrefixes -PrereleaseDependenciesOnly $true | Should -BeTrue
+	}
+
+	It 'in prerelease-only mode skips a stable dep even a tracked Uno.* one' {
+		Test-ShouldVerifyTransitiveDependency -PackageId 'Uno.Simple.WinUI' -Version '7.0.3' -IncludeStableTransitiveVersions $false -IncludePrefixes $UnoPrefixes -PrereleaseDependenciesOnly $true | Should -BeFalse
+	}
+
+	It 'prerelease-only overrides IncludeStableTransitiveVersions for a stable dep' {
+		Test-ShouldVerifyTransitiveDependency -PackageId 'System.Text.Json' -Version '9.0.0' -IncludeStableTransitiveVersions $true -IncludePrefixes $UnoPrefixes -PrereleaseDependenciesOnly $true | Should -BeFalse
+	}
+}
+
+Describe 'Test-IsPrereleaseVersion' {
+	It 'is true for a dev / prerelease version' {
+		Test-IsPrereleaseVersion -Version '7.1.0-dev.1' | Should -BeTrue
+		Test-IsPrereleaseVersion -Version '2.9.0-dev.12' | Should -BeTrue
+	}
+
+	It 'is false for a stable version (incl. 4-part build-tools versions)' {
+		Test-IsPrereleaseVersion -Version '7.0.3' | Should -BeFalse
+		Test-IsPrereleaseVersion -Version '10.0.28000.2270' | Should -BeFalse
+	}
+
+	It 'is false for null / blank' {
+		Test-IsPrereleaseVersion -Version $null | Should -BeFalse
+		Test-IsPrereleaseVersion -Version '' | Should -BeFalse
+		Test-IsPrereleaseVersion -Version '   ' | Should -BeFalse
+	}
+}
+
+Describe 'Select-ChecksForVerification' {
+	It 'returns the list unchanged when the switch is off (full closure)' {
+		$checks = [System.Collections.Generic.List[object]]::new()
+		$checks.Add([PSCustomObject]@{ Id = 'Uno.A'; Version = '7.0.3'; Source = 't' })
+		$checks.Add([PSCustomObject]@{ Id = 'Uno.B'; Version = '7.1.0-dev.1'; Source = 't' })
+		$result = Select-ChecksForVerification -Checks $checks -PrereleaseDependenciesOnly $false
+		$result.Count | Should -Be 2
+	}
+
+	It 'keeps only prerelease coordinates when the switch is on' {
+		$checks = [System.Collections.Generic.List[object]]::new()
+		$checks.Add([PSCustomObject]@{ Id = 'Uno.A'; Version = '7.0.3'; Source = 't' })
+		$checks.Add([PSCustomObject]@{ Id = 'Uno.B'; Version = '7.1.0-dev.1'; Source = 't' })
+		$checks.Add([PSCustomObject]@{ Id = 'Uno.C'; Version = '9.0.3'; Source = 't' })
+		$result = Select-ChecksForVerification -Checks $checks -PrereleaseDependenciesOnly $true
+		$result.Count | Should -Be 1
+		$result[0].Id | Should -Be 'Uno.B'
+	}
+
+	It 'returns an empty list when every coordinate is stable (stable-branch PR)' {
+		$checks = [System.Collections.Generic.List[object]]::new()
+		$checks.Add([PSCustomObject]@{ Id = 'Uno.A'; Version = '7.0.3'; Source = 't' })
+		$checks.Add([PSCustomObject]@{ Id = 'Uno.C'; Version = '9.0.3'; Source = 't' })
+		$result = Select-ChecksForVerification -Checks $checks -PrereleaseDependenciesOnly $true
+		$result.Count | Should -Be 0
+	}
+}
+
+Describe 'ConvertTo-MissingDependencyReport' {
+	It 'shapes and sorts missing records (by Id) with their sources' {
+		$missing = @{}
+		$b = [PSCustomObject]@{ Id = 'Uno.B'; Version = '2.0.0-dev.1'; Sources = [System.Collections.Generic.List[string]]::new() }
+		$b.Sources.Add('manifest:packages.json:GroupB')
+		$a = [PSCustomObject]@{ Id = 'Uno.A'; Version = '1.0.0-dev.1'; Sources = [System.Collections.Generic.List[string]]::new() }
+		$a.Sources.Add('manifest:packages.json:GroupA')
+		$missing['Uno.B|2.0.0-dev.1'] = $b
+		$missing['Uno.A|1.0.0-dev.1'] = $a
+
+		$report = ConvertTo-MissingDependencyReport -MissingDependencies $missing
+		$report.Count | Should -Be 2
+		$report[0].Id | Should -Be 'Uno.A'
+		$report[1].Id | Should -Be 'Uno.B'
+		$report[0].Sources[0] | Should -Be 'manifest:packages.json:GroupA'
+	}
+
+	It 'returns an empty list when there are no missing deps' {
+		$report = ConvertTo-MissingDependencyReport -MissingDependencies @{}
+		$report.Count | Should -Be 0
+	}
 }
 
 Describe 'Test-ShouldExpandCoordinate' {

--- a/build/Verify-NuGetDependenciesOnNuGetOrg.ps1
+++ b/build/Verify-NuGetDependenciesOnNuGetOrg.ps1
@@ -21,6 +21,19 @@ param(
 	[ValidateRange(0, [int]::MaxValue)]
 	[int]$TransitiveDependencyDepth = 1,
 	[switch]$IncludeStableTransitiveVersions,
+	# PR fail-fast pass: verify ONLY prerelease (dev) coordinates on nuget.org, skipping every
+	# stable-versioned dependency (direct or transitive). Dev packages are published to nuget.org
+	# continuously, so a missing one is a genuine error worth failing a PR fast; stable versions may
+	# legitimately be unpublished while a stable release is staged on the internal feed first, and
+	# are gated later — only right before the nuget.org publish. Full-closure (switch off) is used
+	# for the dev-publish (main) path and the pre-prod-publish gate.
+	[switch]$PrereleaseDependenciesOnly,
+	# Report mode (non-blocking): collect missing dependencies but DO NOT throw / fail. Used by the
+	# PR job, which surfaces the result as a resolvable inline comment instead of failing the build.
+	# When -ReportOutputPath is set the missing set is written there as JSON (always, even if empty,
+	# so the consumer is deterministic).
+	[switch]$ReportOnly,
+	[string]$ReportOutputPath = "",
 	[string[]]$StableTransitiveIncludePrefixes = @('Uno.'),
 	[ValidateRange(0, [int]::MaxValue)]
 	[int]$TrackedTransitiveDependencyMaxDepth = 16
@@ -79,24 +92,44 @@ function Test-IsTrackedPackageId {
 	return $false
 }
 
+function Test-IsPrereleaseVersion {
+	# True when the version carries a SemVer prerelease label (contains '-'), e.g. 7.1.0-dev.1.
+	# Stable versions (7.0.3, 10.0.28000.2270) return false, as does a null/blank version.
+	param(
+		[AllowEmptyString()]
+		[AllowNull()]
+		[string]$Version
+	)
+
+	return (-not [string]::IsNullOrWhiteSpace($Version)) -and $Version.Contains('-')
+}
+
 function Test-ShouldVerifyTransitiveDependency {
 	# Whether a discovered transitive dependency must be verified on nuget.org.
 	# Prereleases are always verified. Stable versions are skipped (third-party / BCL
 	# stable packages are assumed present, and verifying the whole closure would be slow
 	# and noisy) unless -IncludeStableTransitiveVersions is set or the id is tracked
 	# (Uno.*), which can point at an unpublished stable.
+	# In the PR fail-fast pass (-PrereleaseDependenciesOnly) stable versions are ALWAYS
+	# skipped — even tracked ones — because a stable dependency may be intentionally
+	# unpublished while a stable release is staged on the internal feed first.
 	param(
 		[Parameter(Mandatory = $true)]
 		[string]$PackageId,
 		[string]$Version,
 		[bool]$IncludeStableTransitiveVersions,
 		[AllowEmptyCollection()]
-		[string[]]$IncludePrefixes
+		[string[]]$IncludePrefixes,
+		[bool]$PrereleaseDependenciesOnly
 	)
 
-	$isStable = -not [string]::IsNullOrWhiteSpace($Version) -and -not $Version.Contains('-')
-	if (-not $isStable) {
+	if (Test-IsPrereleaseVersion -Version $Version) {
 		return $true
+	}
+
+	# Stable version below this point.
+	if ($PrereleaseDependenciesOnly) {
+		return $false
 	}
 
 	if ($IncludeStableTransitiveVersions) {
@@ -267,6 +300,35 @@ function Add-DependencyCheck {
 	})
 }
 
+function Select-ChecksForVerification {
+	# PR fail-fast pass filter: when PrereleaseDependenciesOnly is set, keep only prerelease
+	# (dev) coordinates. Stable-versioned direct dependencies are dropped so a stable release
+	# staged on the internal feed (its stable deps not yet on nuget.org) does not fail a PR.
+	# When the switch is off, the list is returned unchanged (full-closure verification).
+	param(
+		[Parameter(Mandatory = $true)]
+		[AllowEmptyCollection()]
+		[System.Collections.Generic.List[object]]$Checks,
+		[bool]$PrereleaseDependenciesOnly
+	)
+
+	# Return with the unary comma so the List is passed back intact: a bare `return $list`
+	# is enumerated by the pipeline (collapsing an empty list to $null and a single-item list
+	# to a scalar), which would break the caller's List typing and later `.Add()` calls.
+	if (-not $PrereleaseDependenciesOnly) {
+		return ,$Checks
+	}
+
+	$filtered = New-Object System.Collections.Generic.List[object]
+	foreach ($check in $Checks) {
+		if (Test-IsPrereleaseVersion -Version ([string]$check.Version)) {
+			[void]$filtered.Add($check)
+		}
+	}
+
+	return ,$filtered
+}
+
 function Build-DependencySourcesMap {
 	param(
 		[Parameter(Mandatory = $true)]
@@ -321,6 +383,27 @@ function Add-MissingDependencyRecord {
 	if (-not $MissingDependencies[$missingKey].Sources.Contains($Source)) {
 		$MissingDependencies[$missingKey].Sources.Add($Source)
 	}
+}
+
+function ConvertTo-MissingDependencyReport {
+	# Shape the collected missing-dependency records into a plain, serializable list
+	# (Id / Version / Sources), sorted, for the PR report payload. Returned with a unary
+	# comma so an empty result keeps its List typing through the pipeline.
+	param(
+		[Parameter(Mandatory = $true)]
+		[hashtable]$MissingDependencies
+	)
+
+	$report = New-Object System.Collections.Generic.List[object]
+	foreach ($entry in ($MissingDependencies.Values | Sort-Object Id, Version)) {
+		$report.Add([PSCustomObject]@{
+			Id      = $entry.Id
+			Version = $entry.Version
+			Sources = @($entry.Sources)
+		})
+	}
+
+	return ,$report
 }
 
 function Get-ExactDependenciesFromPackageNuspec {
@@ -589,6 +672,9 @@ else {
 	Add-ChecksFromArtifacts -Checks $checks -PackagesPath $PackagesPath -PackageIdFilter $PackageIdFilter
 }
 
+# PR fail-fast pass: drop stable coordinates so only prerelease (dev) dependencies are verified.
+# No-op unless -PrereleaseDependenciesOnly is set (dev-publish / pre-prod-publish verify everything).
+$checks = Select-ChecksForVerification -Checks $checks -PrereleaseDependenciesOnly ([bool]$PrereleaseDependenciesOnly)
 
 $uniqueChecks = @($checks |
 	Sort-Object Id, Version -Unique)
@@ -657,7 +743,7 @@ if ($TransitiveDependencyDepth -gt 0) {
 			$transitiveDependencies = Get-ExactDependenciesFromPackageNuspec -PackageId $coordinate.Id -Version $coordinate.Version -HttpTimeoutSeconds $HttpTimeoutSeconds -MaxAttempts $MaxAttempts -RetryDelaySeconds $RetryDelaySeconds
 			foreach ($transitiveDependency in $transitiveDependencies) {
 				$depId = [string]$transitiveDependency.Id
-				if (-not (Test-ShouldVerifyTransitiveDependency -PackageId $depId -Version ([string]$transitiveDependency.Version) -IncludeStableTransitiveVersions ([bool]$IncludeStableTransitiveVersions) -IncludePrefixes $StableTransitiveIncludePrefixes)) {
+				if (-not (Test-ShouldVerifyTransitiveDependency -PackageId $depId -Version ([string]$transitiveDependency.Version) -IncludeStableTransitiveVersions ([bool]$IncludeStableTransitiveVersions) -IncludePrefixes $StableTransitiveIncludePrefixes -PrereleaseDependenciesOnly ([bool]$PrereleaseDependenciesOnly))) {
 					continue
 				}
 
@@ -722,26 +808,46 @@ foreach ($check in $stillMissing) {
 	Write-Host "Missing dependency '$($check.Id)' version '$($check.Version)' (source: $($check.Source))."
 }
 
+# Report mode always writes the missing set (even when empty) so the PR job can act deterministically.
+if ($ReportOnly -and -not [string]::IsNullOrWhiteSpace($ReportOutputPath)) {
+	$reportPayload = ConvertTo-MissingDependencyReport -MissingDependencies $missingDependencies
+	($reportPayload | ConvertTo-Json -Depth 5 -AsArray) | Set-Content -Path $ReportOutputPath -Encoding utf8
+	Write-Host "ReportOnly: wrote $($reportPayload.Count) missing dependency record(s) to '$ReportOutputPath'."
+}
+
 if ($missingDependencies.Count -gt 0) {
 	$missingList = $missingDependencies.Values |
 		Sort-Object Id, Version |
 		ForEach-Object { "$($_.Id) $($_.Version)" }
 
-	$summaryLines = @(
-		"## NuGet Dependency Verification",
-		"❌ Missing dependencies on nuget.org:"
-	)
-	$summaryLines += ($missingList | ForEach-Object { "- $_" })
-	$summaryLines += "Publish to nuget.org was blocked to avoid unresolved dependencies."
+	if ($ReportOnly) {
+		$summaryLines = @(
+			"## NuGet Dependency Verification",
+			"⚠️ Prerelease (dev) dependencies not yet on nuget.org (informational — not blocking this PR):"
+		)
+		$summaryLines += ($missingList | ForEach-Object { "- $_" })
+		$summaryLines += "These must be published before the dev/prod publish gate will pass."
+		Add-StepSummaryLines -Lines $summaryLines
 
-	Add-StepSummaryLines -Lines $summaryLines
+		Write-Host "ReportOnly: $($missingDependencies.Count) dependency/ies not on nuget.org (not failing)."
+	}
+	else {
+		$summaryLines = @(
+			"## NuGet Dependency Verification",
+			"❌ Missing dependencies on nuget.org:"
+		)
+		$summaryLines += ($missingList | ForEach-Object { "- $_" })
+		$summaryLines += "Publish to nuget.org was blocked to avoid unresolved dependencies."
 
-	$messageLines = @("The following dependencies are not available on nuget.org:")
-	$messageLines += ($missingList | ForEach-Object { " - $_" })
-	$messageLines += "Aborting publish to avoid pushing a package with unresolved dependencies."
-	$message = $messageLines -join [Environment]::NewLine
+		Add-StepSummaryLines -Lines $summaryLines
 
-	throw $message
+		$messageLines = @("The following dependencies are not available on nuget.org:")
+		$messageLines += ($missingList | ForEach-Object { " - $_" })
+		$messageLines += "Aborting publish to avoid pushing a package with unresolved dependencies."
+		$message = $messageLines -join [Environment]::NewLine
+
+		throw $message
+	}
 }
 
 # Safety net for the transitive walk: a coordinate skipped during expansion (not available at
@@ -751,7 +857,7 @@ $unwalkedButAvailable = @(
 	$deferredDuringExpansion | Where-Object { $availabilityCache.ContainsKey($_) -and [bool]$availabilityCache[$_] } | Sort-Object -Unique
 )
 
-if ($unwalkedButAvailable.Count -gt 0) {
+if ($unwalkedButAvailable.Count -gt 0 -and -not $ReportOnly) {
 	$summaryLines = @(
 		"## NuGet Dependency Verification",
 		"❌ Could not fully verify the transitive closure. These coordinates were skipped during dependency-tree expansion (not available at the time) but are now available, so their dependencies were not walked — re-run the check:"
@@ -767,16 +873,20 @@ if ($unwalkedButAvailable.Count -gt 0) {
 	throw $message
 }
 
-$verifiedLines = @($uniqueChecks | Sort-Object Id, Version | ForEach-Object { "- $($_.Id) $($_.Version)" })
-$successSummary = @(
-	"## NuGet Dependency Verification",
-	"✅ All checked package dependencies are available on nuget.org.",
-	"",
-	"<details><summary>Verified dependencies ($($uniqueChecks.Count))</summary>",
-	""
-)
-$successSummary += $verifiedLines
-$successSummary += @("", "</details>")
-Add-StepSummaryLines -Lines $successSummary
+# Success summary only when nothing was missing. In blocking mode a miss already threw above; in
+# report mode the run continues, so this guard prevents a misleading "all available" after a warning.
+if ($missingDependencies.Count -eq 0) {
+	$verifiedLines = @($uniqueChecks | Sort-Object Id, Version | ForEach-Object { "- $($_.Id) $($_.Version)" })
+	$successSummary = @(
+		"## NuGet Dependency Verification",
+		"✅ All checked package dependencies are available on nuget.org.",
+		"",
+		"<details><summary>Verified dependencies ($($uniqueChecks.Count))</summary>",
+		""
+	)
+	$successSummary += $verifiedLines
+	$successSummary += @("", "</details>")
+	Add-StepSummaryLines -Lines $successSummary
 
-Write-Host "All checked dependencies are available on nuget.org."
+	Write-Host "All checked dependencies are available on nuget.org."
+}


### PR DESCRIPTION
This PR makes two related CI changes to the release path. Both need to reach `release/stable/6.6` for the 6.6 SR2 prod release (backport after merge).

---

## 1. Prioritize release path over tests on merge builds

### Problem

On a **merge build** (push to `main` / `release/**`) the release path — **Build → Sign → Publish** — competes with the template **test matrix** (24×3 jobs) for hosted runners. In particular `sign` (`windows-latest`) queues **behind the 24 Windows test jobs**, so signing + publication only start once a runner frees up — delaying the release.

### Change

GitHub Actions has no native job priority, so it's expressed as a dependency: `generate-test-matrix` (which every test job already depends on) is gated on the **full release path** — it waits for `build` + the publish jobs before generating the matrix.

### Behavior

- **Merge build**: `build → sign → publish*` runs first (grabs the runners); the test matrix runs after publication. Release fast-forwards.
- **PRs / schedule / dispatch**: the publish jobs are skipped (`push`-only), so the skip-tolerant condition lets the matrix run right after `build` — tests prioritized, no regression.

---

## 2. Gate the nuget.org check on **publication only**; advise on PRs

### Problem

The nuget.org dependency check (added in #2181) blocked **every** trigger on the **full Uno.\* closure** being public. That's correct for dev, but **wrong for a stable release**: stable packages are built + signed + pushed to the **internal feed** and **deeply tested first**, and are published to **nuget.org only at the very end**. So a stable release build — or a PR bumping the SDK to not-yet-published stable versions (e.g. #2178) — failed on packages that are *intentionally* not public yet. A PR build doesn't even need nuget.org (it restores from the internal feed), so blocking it was guarding a non-problem.

### Change — the blocking gate lives only where we publish

| Path | Job | Scope |
|---|---|---|
| **Dev publish** (push to `main`) | `verify_dependencies_dev` → gates `publish_dev` | full closure |
| **Prod publish** (push to `release/**`) | `verify_dependencies_prod` → gates `publish_release_nuget_org` (runs `publish_release_uno → verify → publish_nuget_org`) | full closure |
| **Pull request** | `report_dependencies` (non-blocking) | prerelease (dev) deps, direct manifest entries |

- The publish gates guarantee we never push a package publicly while a dependency (or a previously-released stable, in release order) is missing from nuget.org.
- **PRs never block.** `report_dependencies` runs the check in report-only + prerelease-only mode and, for any **dev** dependency not yet on nuget.org, posts a **resolvable inline PR comment** on the manifest line. The build/tests are unaffected (internal feed). This also future-proofs internal-feed-only packages: they surface as advisory comments, not false failures.

### Script (`Verify-NuGetDependenciesOnNuGetOrg.ps1`)

- `-PrereleaseDependenciesOnly` — verify only prerelease-versioned coordinates (direct + transitive); stable versions skipped.
- `-ReportOnly` / `-ReportOutputPath` — collect missing deps and emit JSON **without failing** (for the PR advisory).
- Fixed a latent list-return bug (`return ,$list`) so an empty/filtered result keeps its `List` typing.

### New `build/Report-MissingDependenciesOnPr.ps1`

Reads the report JSON, groups packages by manifest line, and posts an **idempotent** (hidden per-`version:line` marker), **resolvable** review-thread comment per line. Never fails the job; `-DryRun` for local runs.

---

## Validation

- **Unit**: 44/44 Pester green (added `Test-IsPrereleaseVersion`, `Select-ChecksForVerification`, `ConvertTo-MissingDependencyReport`, prerelease-only transitive behavior).
- **End-to-end (real nuget.org)**: prerelease-only skips a fake stable + verifies a public dev pkg; full closure fails on the fake stable; stable-only manifest (the #2178 case) → 0 checked; report-only emits JSON + exits 0; poster `-DryRun` locates the correct line; the exact `gh api` review-comment call posts + is resolvable.
- **Live on this PR**: a temporary version bump made `report_dependencies` post a resolvable inline comment (github-actions[bot], anchored on the manifest line, non-blocking); the temp change has been reverted.
- **CI wiring**: `ci.yml` parses; job graph verified, no cycles; `Verify Dependencies (dev publish)` correctly **skips** on PRs.

> Follow-up to #2181. Both changes need to be on `release/stable/6.6` for the **6.6 SR2** prod release — backport after merge.

Related to https://github.com/unoplatform/private/issues/1102
