### PR TITLE
ci(templates): Verify deps inside the publish jobs; release tests run before the public publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,30 +69,14 @@ jobs:
     - name: "Build Package"
       uses: ./.github/actions/ci/build-packages
 
-  # The nuget.org dependency verification is a HARD GATE only on the publication paths:
-  #   * dev publish  (push to main)        -> verify_dependencies_dev  (this job) gates publish_dev
-  #   * prod publish (push to release/**)  -> verify_dependencies_prod gates publish_release_nuget_org
-  # On PRs it is NOT a gate: the build restores from the internal feed, so a dev package that is not
-  # yet on nuget.org does not block the PR -- report_dependencies surfaces it as a resolvable comment.
-
-  # Dev-publish gate: before pushing the -dev packages to nuget.org (push to main), verify the FULL
-  # Uno.* dependency closure is already resolvable there. publish_dev depends on this, so a missing
-  # dependency blocks the dev publish (but not the build/tests).
-  verify_dependencies_dev:
-    name: Verify Dependencies (dev publish)
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ env.CheckoutRef }}
-
-    - name: "Verify Uno.* dependency closure on nuget.org"
-      shell: pwsh
-      run: |
-        ./build/Verify-NuGetDependenciesOnNuGetOrg.ps1 -ManifestPath src/Uno.Sdk/packages.json -MaxAttempts 3 -RetryDelaySeconds 10 -HttpTimeoutSeconds 30
+  # The nuget.org dependency verification is a HARD GATE only on the publication paths, and it runs
+  # as the first step (after checkout) INSIDE the publish job itself (not as a separate job):
+  #   * dev publish  (push to main)       -> first step of publish_dev
+  #   * prod publish (push to release/**) -> first step of publish_release_nuget_org, which sits
+  #     behind the Production (release) approval, so verification runs only when we are actually
+  #     ready to publish the stable packages -- by then the dependency stables are already public.
+  # On PRs it is NOT a gate: the build restores from the internal feed, so a dev package not yet on
+  # nuget.org does not block the PR -- report_dependencies surfaces it as a resolvable comment.
 
   # Non-blocking PR advisory: surface any prerelease (dev) dependency the manifest references that is
   # not yet on nuget.org as a resolvable inline PR comment. Never blocks the PR -- the build restores
@@ -155,13 +139,18 @@ jobs:
     name: Publish Dev
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
-    needs: [sign, verify_dependencies_dev]
+    needs: sign
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
       with:
         ref: ${{ env.CheckoutRef }}
+    # First step after checkout: verify the full Uno.* closure is on nuget.org before publishing there.
+    - name: "Verify Uno.* dependency closure on nuget.org"
+      shell: pwsh
+      run: |
+        ./build/Verify-NuGetDependenciesOnNuGetOrg.ps1 -ManifestPath src/Uno.Sdk/packages.json -MaxAttempts 3 -RetryDelaySeconds 10 -HttpTimeoutSeconds 30
     - name: "Uno Feed Publish"
       uses: ./.github/actions/ci/nuget-uno-publish
       with:
@@ -171,7 +160,10 @@ jobs:
       with:
         token: ${{ secrets.NUGET_ORG_API_KEY }}
 
-  # Publish release packages to uno feed
+  # Publish release packages to the Uno production (internal) feed -- the FIRST approval gate of a
+  # stable release (environment: Production). Once approved, the internal packages exist so the test
+  # matrix can run against them; the public nuget.org publish is a SEPARATE, later approval, so tests
+  # run during the window between the two approvals (we take our time testing before going public).
   publish_release_uno:
     name: Publish Uno Production
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/') }}
@@ -189,16 +181,17 @@ jobs:
       with:
         token: ${{ secrets.UNO_NUGET_FEED_API_KEY }}
 
-  # Ordering gate for the nuget.org (production) publish on a stable release. Stable releases are
-  # built + signed + pushed to the Uno production feed and deeply tested FIRST; only then are the
-  # packages published to nuget.org. This job runs right after the production-feed publish and right
-  # before the nuget.org publish, verifying the FULL Uno.* dependency closure is already on nuget.org
-  # -- so we never push a stable package whose (previously-released) stable dependencies are not yet
-  # public. This enforces the correct order when releasing all the stables in sequence.
-  verify_dependencies_prod:
-    name: Verify Dependencies (pre-publish)
+  # Publish release packages to nuget.org -- the public stable publication and the SECOND approval
+  # gate (environment: Production), taken after the internal publish + tests. Its first step (after
+  # checkout) verifies the full Uno.* dependency closure is already on nuget.org, so we never push a
+  # stable package whose (previously-released) stable dependencies are not yet public. Because it runs
+  # only after this second approval, the check happens exactly when we are ready to go public -- by
+  # then the dependency stables have been published in order. Tests do NOT wait on this gate.
+  publish_release_nuget_org:
+    name: Publish NuGet.org Production
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/') }}
     runs-on: ubuntu-latest
+    environment: Production
     needs: publish_release_uno
 
     steps:
@@ -206,26 +199,12 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ env.CheckoutRef }}
-
+    # First step after checkout: verify the full Uno.* closure is on nuget.org before the public publish.
     - name: "Verify Uno.* dependency closure on nuget.org"
       shell: pwsh
       run: |
         ./build/Verify-NuGetDependenciesOnNuGetOrg.ps1 -ManifestPath src/Uno.Sdk/packages.json -MaxAttempts 3 -RetryDelaySeconds 10 -HttpTimeoutSeconds 30
-
-  # Publish release packages to nuget.org
-  publish_release_nuget_org:
-    name: Publish Nuget.org Production
-    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/') }}
-    runs-on: ubuntu-latest
-    environment: Production
-    needs: verify_dependencies_prod
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ env.CheckoutRef }}
-    - name: "Uno Feed Publish"
+    - name: "nuget.org Publish"
       uses: ./.github/actions/ci/nuget-org-publish
       with:
         token: ${{ secrets.NUGET_ORG_API_KEY }}
@@ -233,13 +212,13 @@ jobs:
       uses: ./.github/actions/ci/tag-release
 
   # Generate the template tests build matrix.
-  # Gated on the full release path so signing + publication are prioritized for the hosted
-  # runners on a merge build (push to main / release): the matrix waits for build -> sign ->
-  # publish*, then runs. On PRs / schedule / dispatch the publish jobs are skipped, so the
-  # skip-tolerant condition lets the matrix run once `build` finishes (tests prioritized).
-  # `build` is listed explicitly so this never starts before it in any event; the test jobs
-  # also require `build`. always() is required so the condition is evaluated when the publish
-  # jobs are skipped.
+  # On a merge build the matrix waits for build -> sign -> publish_dev (main) / publish_release_uno
+  # (the internal-feed release publish, the FIRST approval gate), then runs against the published
+  # internal packages. It deliberately does NOT wait for publish_release_nuget_org -- the public
+  # publish is a SECOND, later approval, and tests are meant to run during the window before it, so
+  # blocking on it would defeat the point. On PRs / schedule / dispatch the publish jobs are skipped,
+  # so the skip-tolerant condition lets the matrix run once `build` finishes.
+  # always() is required so the condition is evaluated when the publish jobs are skipped.
   generate-test-matrix:
     runs-on: ubuntu-latest
     name: Generate Test Matrix
@@ -247,13 +226,11 @@ jobs:
       - build
       - publish_dev
       - publish_release_uno
-      - publish_release_nuget_org
     if: >-
       ${{ always()
       && needs.build.result == 'success'
       && (needs.publish_dev.result == 'success' || needs.publish_dev.result == 'skipped')
-      && (needs.publish_release_uno.result == 'success' || needs.publish_release_uno.result == 'skipped')
-      && (needs.publish_release_nuget_org.result == 'success' || needs.publish_release_nuget_org.result == 'skipped') }}
+      && (needs.publish_release_uno.result == 'success' || needs.publish_release_uno.result == 'skipped') }}
 
     outputs:
       testMatrix: ${{ steps.generate-test-matrix-step.outputs.TestMatrix }}


### PR DESCRIPTION
## Problem

The nuget.org dependency verification was a **separate job** on each publish path (`verify_dependencies_dev` / `verify_dependencies_prod`). On a stable release merge build this misbehaves: `verify_dependencies_prod` ran **automatically right after the internal-feed publish** and **failed**, because stable dependencies (e.g. Uno.Themes/Toolkit) are intentionally not on nuget.org until the *end* of the release — see the failed `Verify Dependencies (pre-publish)` on the #2178 merge build.

The verification should instead live **inside the respective publish job as its first step (after checkout)**, so it runs exactly when we publish — and on a stable release that means *after* the release approval, by which point the dependency stables are public.

## Change

- **`publish_dev`** (push to `main`): first step (after checkout) verifies the full Uno.\* closure on nuget.org, then publishes the `-dev` packages. Automatic (no approval). `needs: sign` — separate `verify_dependencies_dev` job removed.
- **`publish_release_nuget_org`** (push to `release/**`): first step (after checkout) verifies the full closure, then publishes + tags. Behind the `Production` approval. Separate `verify_dependencies_prod` job removed; `needs: publish_release_uno`.
- **`generate-test-matrix`** no longer waits on `publish_release_nuget_org`, so the release test matrix runs **right after the internal-feed publish** and **not** during the wait for the public-publish approval.
- **`report_dependencies`** (the non-blocking PR advisory comment) is unchanged.
- Cleanup from review: renamed the job display name to `Publish NuGet.org Production`, and the mislabeled `Uno Feed Publish` step in that job to `nuget.org Publish` (it invokes the nuget.org publish action).

## Behaviour by trigger

| Trigger | Verify | Approval | Where verify runs |
|---|---|---|---|
| **PR** | advisory only (resolvable comment) | — | `report_dependencies` |
| **push `main`** (dev publish) | full closure, **blocking** | none (automatic) | first step of `publish_dev` |
| **push `release/**`** (public publish) | full closure, **blocking** | **yes** (release approval) | first step of `publish_release_nuget_org` |

## Stable release flow (two approval gates)

Both release publishes keep `environment: Production`, so each is its own approval gate:

1. Build → Sign
2. **[approval 1]** → **Publish Uno Production** (internal feed)
3. **Tests run** against the internal packages (right after step 2)
4. **[approval 2]** → **Publish NuGet.org Production** — first step re-verifies the closure on nuget.org, then publishes + tags

Tests (step 3) and the public-publish approval (step 4) are independent, so **the matrix runs during the window before we go public** — the point being that testing takes time. The nuget.org verify runs only *after* approval 2, when the dependency stables are already public (published in order).

> The dev publish (`main`) is intentionally **not** approval-gated — dev packages publish continuously.

Validated: `ci.yml` parses; job graph has no dangling `needs` and no cycles; verify is the first post-checkout step of both publish jobs; `generate-test-matrix` needs `[build, publish_dev, publish_release_uno]`. Scripts untouched (Pester 44/44 unchanged).

Related to https://github.com/unoplatform/private/issues/1102