### PR TITLE
chore: Add release/stable/6.7 branch to update matrix

### DIFF
--- a/.github/workflows/uno-updater.yml
+++ b/.github/workflows/uno-updater.yml
@@ -21,10 +21,9 @@ jobs:
       matrix:
         branch:
           - main
-          - release/stable/6.3
-          - release/stable/6.4
           - release/stable/6.5
           - release/stable/6.6
+          - release/stable/6.7
 
     steps:
     - name: Checkout


### PR DESCRIPTION
This pull request updates the branch matrix in the `.github/workflows/uno-updater.yml` workflow. The main change is the removal of support for the `release/stable/6.3` and `release/stable/6.4` branches, and the addition of support for the new `release/stable/6.7` branch.

Branch matrix updates:

* Removed `release/stable/6.3` and `release/stable/6.4` from the workflow, discontinuing their automated updates.
* Added `release/stable/6.7` to the workflow, enabling automated updates for this new release branch.