### PR TITLE
Version bump after 6.7 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.7-dev.{height}",
+  "version": "6.8-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
This pull request updates the branch matrix in the `.github/workflows/uno-updater.yml` workflow. The main change is the removal of support for the `release/stable/6.3` and `release/stable/6.4` branches, and the addition of support for the new `release/stable/6.7` branch.

Branch matrix updates:

* Removed `release/stable/6.3` and `release/stable/6.4` from the workflow, discontinuing their automated updates.
* Added `release/stable/6.7` to the workflow, enabling automated updates for this new release branch.
This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/6.7, based on #2195