### PR TITLE
chore: Shorten Android TV and Android Auto wizard card descriptions

### DIFF
--- a/src/Uno.Templates/content/unoapp/.template.config/TemplateWizard.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/TemplateWizard.json
@@ -283,7 +283,7 @@
 				"SymbolIds": [ "desktop", "windows" ]
 			},
 			{
-				"Title": "Android form factors",
+				"Title": "Android Devices",
 				"SectionType": "MultiSelect",
 				"SymbolIds": [ "includeAndroidTV", "includeAndroidAuto", "includeAndroidWear" ]
 			}

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -427,14 +427,14 @@
     },
     "includeAndroidTV": {
       "displayName": "Android TV",
-      "description": "Configures the Android head for Android TV (Leanback launcher, banner, focus highlight overrides). Single APK targets phones and TVs.",
+      "description": "Configures the Android head for Android TV. A single APK targets both phones and TVs.",
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false"
     },
     "includeAndroidAuto": {
       "displayName": "Android Auto",
-      "description": "Configures the Android head for Android Auto / Automotive OS using the AndroidX Car App Library.",
+      "description": "Adds Android Auto / Automotive OS support via the AndroidX Car App Library.",
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false"


### PR DESCRIPTION
Related to unoplatform/uno.studio#1068

Two wizard copy changes for the Android form factors section on the Platforms step:

**1. Shorten the Android TV / Android Auto card descriptions.** They overflow the wizard's card text area (~90 chars fit; they were 134 and 97 chars), which showed as text clipped mid-line:

- **Android TV**: "Configures the Android head for Android TV. A single APK targets both phones and TVs." (87 chars)
- **Android Auto**: "Adds Android Auto / Automotive OS support via the AndroidX Car App Library." (76 chars)

Wear OS (85 chars) already fits and is unchanged.

**2. Rename the section title** from "Android form factors" to **"Android Devices"** (`TemplateWizard.json`).

Note: unoplatform/uno.studio#1069 makes the wizard cards grow to fit long descriptions, so the fixes are complementary — this keeps the cards compact regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)