### PR TITLE
fix(sdk): Align AndroidX.Wear pins (unoplatform/uno#23991)

### DIFF
--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -295,12 +295,12 @@
   },
   {
     "group": "AndroidXWear",
-    "version": "1.3.0.16",
+    "version": "1.3.0.14",
     "packages": [
       "Xamarin.AndroidX.Wear"
     ],
     "versionOverride": {
-      "net10.0": "1.4.0.1"
+      "net10.0": "1.3.0.15"
     }
   },
   {


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno#23991

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`dotnet new unoapp` with the Wear OS feature enabled still fails restore on `net10.0-android` with 3× NU1605 (AndroidX package downgrades), even though unoplatform/uno#23993 fixed the pins.

The fix did land in `Uno.Sdk.Private` (verified in 6.8.0-dev.6: `AndroidXWear` 1.3.0.14 / net10 override 1.3.0.15), but the published `Uno.Sdk` packs this repo's local `src/Uno.Sdk/packages.json` over the Private manifest, and the `Uno.Sdk.Updater` never refreshes `Xamarin.*` groups (`UpdateGroup` skips them to avoid Java misalignment, and on dev versions `MergeLocalOverridesOnly` keeps the local manifest as baseline). As a result `Uno.Sdk` 6.8.0-dev.7 still ships the stale `AndroidXWear` 1.3.0.16 / net10 1.4.0.1 pin: Wear 1.4.0.1 floors RecyclerView/SwipeRefreshLayout/Fragment above the rest of the pin set, producing the NU1605 trio. (The other half of the fix — the Wear minSdk 26 default in `Uno.Common.Android.targets` — flows through the Private package repack and did ship.)

## What is the new behavior?

`AndroidXWear` is down-pinned to the wave-coherent set validated in unoplatform/uno#23993: 1.3.0.14 (base) / 1.3.0.15 (net10.0), matching `Uno.Sdk.Private`. Wear template apps restore cleanly on net9/net10, plain Android apps unaffected (all other AndroidX pins already match the uno repo manifest).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Associated with an issue (GitHub or internal)

## Other information

Because the updater intentionally skips `Xamarin.*` groups, AndroidX pin changes made in unoplatform/uno's `packages.json` do not propagate here automatically — they need to be mirrored manually (as this PR does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
