### PR TITLE
fix(sdk): pin Hot Design to 1.21.0-dev.2398, exclude from auto-update

### DIFF
--- a/.github/sdk-update-exclude.json
+++ b/.github/sdk-update-exclude.json
@@ -6,6 +6,12 @@
     // (backport status, not in our control: mono/SkiaSharp#4031).
     "SkiaSharp",
     "SvgSkia",
-    "WinAppSdk"
+    "WinAppSdk",
+    // Hot Design held at 1.21.0-dev.2398: builds >= 1.21.0-dev.2411 depend on the unreleased
+    // Uno 6.7 release bits (Uno.WinUI 6.7.16, Themes 7.1.1, Toolkit 9.1.3) which are internal-only
+    // until the 6.7 release ships (unoplatform/private#1105), so publishing fails the nuget.org
+    // dependency check. Studio Live is unaffected (it pins UnoHotDesignVersion itself).
+    // Remove this exclude and re-bump once Uno 6.7 is live on nuget.org.
+    "hotdesign"
   ]
 }

--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -141,7 +141,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "hotdesign",
-    "version": "1.21.0-dev.2457",
+    "version": "1.21.0-dev.2398",
     "packages": [
       "Uno.UI.HotDesign"
     ]

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -94,7 +94,7 @@
   },
   {
     "group": "hotdesign",
-    "version": "1.21.0-dev.2457",
+    "version": "1.21.0-dev.2398",
     "packages": [
       "Uno.UI.HotDesign"
     ]


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

- Bugfix
- Build or CI related changes

## What is the current behavior?

Every Uno.Sdk 6.8.0-dev publish fails `Verify-NuGetDependenciesOnNuGetOrg.ps1` and aborts (see https://github.com/unoplatform/uno.templates/actions/runs/31840039294/job/94895570952). Hot Design builds >= 1.21.0-dev.2411 are compiled against the unreleased Uno 6.7 release bits (`Uno.WinUI 6.7.16`, `Uno.Themes.WinUI 7.1.1`, `Uno.Toolkit.WinUI 9.1.3`), which are internal-only until the 6.7 release ships, and the SDK updater keeps bumping the `hotdesign` group to those versions.

## What is the new behavior?

- `hotdesign` group pinned back to **1.21.0-dev.2398**, the newest Hot Design whose dependency closure fully resolves on nuget.org (`Uno.WinUI 6.7.0-dev.938`, `Uno.Themes.WinUI 7.1.0-dev.1`, `Uno.Toolkit.WinUI 9.1.0-dev.2` — all verified public).
- `hotdesign` added to `.github/sdk-update-exclude.json` so automated SDK-update PRs stop re-bumping it (same mechanism as the SkiaSharp pin in 882fdd7b).
- Uno.Sdk 6.8.0-dev publishing to nuget.org is unblocked.

Studio Live is unaffected: it pins `UnoHotDesignVersion` in its own `Directory.Packages.props` and forwards it into workspaces, overriding the SDK default, restoring from the internal feed.

**Follow-up:** remove the exclude and re-bump Hot Design once Uno 6.7 is live on nuget.org.

## PR Checklist

- [x] Associated with an issue (GitHub or internal)

## Other information

Internal Issue (If applicable): https://github.com/unoplatform/private/issues/1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXgzFTHsknEfXzWLRxMhRG