### PR TITLE
ci(templates): run CI on feature branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,23 @@
 name: CI
 
 on:
+  # feature/** are the long-lived major-version branches (e.g. feature/7.0). Without them listed here
+  # a push to such a branch -- and every PR targeting it -- runs no CI at all. They get the full build
+  # plus the template test matrix; the test matrix consumes the local package artifact, not a feed, so
+  # it needs no publish step. Feature branches deliberately have NO publish lane: see the note above
+  # `publish_dev` for why, and how nuget.org stays unreachable from them.
   push:
     branches:
       - main
       - release/**
+      - feature/**
 
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - main
       - release/**
+      - feature/**
 
   schedule:
     - cron: '0 0 * * *' # Canary
@@ -77,6 +84,13 @@ jobs:
   #     ready to publish the stable packages -- by then the dependency stables are already public.
   # On PRs it is NOT a gate: the build restores from the internal feed, so a dev package not yet on
   # nuget.org does not block the PR -- report_dependencies surfaces it as a resolvable comment.
+  #
+  # Feature branches (feature/**) reach NEITHER publication path, by construction: `publish_dev`
+  # requires github.ref to equal refs/heads/main exactly, and publish_release_uno /
+  # publish_release_nuget_org require a refs/heads/release/ prefix. `sign` is likewise main/release
+  # only, so no feature ref can touch the PackageSign or Production environments either. A dedicated
+  # internal-feed-only preview lane for feature branches is intentionally not part of this workflow
+  # yet -- it needs a confirmed target feed and a credential with push rights to it.
 
   # Non-blocking PR advisory: surface any prerelease (dev) dependency the manifest references that is
   # not yet on nuget.org as a resolvable inline PR comment. Never blocks the PR -- the build restores


### PR DESCRIPTION
## What

Adds `feature/**` to both trigger lists in `.github/workflows/ci.yml` (`on.push.branches` and `on.pull_request.branches`).

Until now the CI workflow only triggered on `main` and `release/**`. A long-lived major-version branch such as `feature/7.0` therefore produced **no CI run at all** — neither on push, nor for any pull request targeting it. Every PR into that branch was merging completely unvalidated. This is the prerequisite that unblocks the rest of the work on the branch.

With this change a feature branch gets the same validation as `main`:

- `build` (packs `Uno.Sdk` + `Uno.Templates`)
- `generate-test-matrix` and the Linux / Windows / macOS template test matrices
- `test-validation`
- On PRs into the branch, `report_dependencies` posts its non-blocking advisory comment for prerelease dependencies not yet on nuget.org

The test matrix needs no publish step to work on a feature branch: `.github/actions/ci/run-tests` downloads the `nuget-packages` build artifact into `src/PackageCache` and registers it as a local NuGet source, so tests run against the packages this very run just built.

## What this does *not* change

No publish or signing behaviour is touched. The four gated jobs keep their existing conditions verbatim, and no `refs/heads/feature/*` ref can satisfy any of them:

| Job | Condition | Feature branch |
| --- | --- | --- |
| `sign` | `push && (ref == refs/heads/main \|\| startsWith(ref, refs/heads/release/))` | skipped |
| `publish_dev` | `push && ref == refs/heads/main` | skipped |
| `publish_release_uno` | `push && startsWith(ref, refs/heads/release/)` | skipped |
| `publish_release_nuget_org` | `push && startsWith(ref, refs/heads/release/)` | skipped |

So a feature branch reaches **neither the Uno feed nor nuget.org**, and never enters the `PackageSign` or `Production` environments. The nuget.org dependency verification (`build/Verify-NuGetDependenciesOnNuGetOrg.ps1`, run without `-ReportOnly`) remains a hard gate on the `main` and `release/**` publish paths, untouched.

`generate-test-matrix` already tolerates skipped publish ancestors (`always()` plus explicit `result == 'skipped'` checks), so it needed no change to run on a feature push.

I also added two comment blocks recording the intent, matching the existing commentary style of the file.

## Deliberately left out of this PR

The driving issue also asks for a feature-branch **preview publish lane** (internal feed only, never nuget.org). I did not implement it here, for two reasons I could not resolve from this repository:

1. **The target feed is unconfirmed.** The only precedent is the core repo routing `feature*` to a separate internal "Features" feed. Whether `uno.templates` preview packages belong there, and whether the existing publish credential has push rights to it, needs a decision from the release owners. Landing an unverified `dotnet nuget push` would mean a red job on every push to the branch — the opposite of what this PR is for.
2. **It has no value before the version stamp lands.** With the current `publicReleaseRefSpec`, a feature branch emits git-hash-suffixed versions of the *current* major. Publishing those to a preview feed is noise until the branch's version stamp is bumped, which is a separate change to `version.json` that I intentionally did not touch here.

Getting the triggers right is the load-bearing half and is independently correct, so I landed it on its own. The publish lane should be a follow-up once the feed and credential are confirmed.

Two further follow-ups noted while working, also out of scope here:

- `.github/workflows/conventional-commits.yml` triggers only on PRs to `main` and `release/*`, so the commit-message gate still does not run for PRs into a feature branch.
- `.github/workflows/uno-updater.yml`'s branch matrix is hardcoded and has no entry for the 7.0 branch. Adding one is blocked on the updater being able to resolve packages for that version from a feed it actually reads.

## Verification

What I actually ran:

- `python -c "import yaml; yaml.safe_load(...)"` on the modified `ci.yml` — parses cleanly; confirmed the parsed `push.branches` and `pull_request.branches` are both `[main, release/**, feature/**]`, and re-read the four publish/sign `if:` expressions out of the parsed document to confirm they are unchanged.
- `git diff` reviewed in full: 14 added lines, no deletions, one file, no stray files and no line-ending churn.

What I did **not** run: no build, pack or test execution — this change is workflow triggers and comments only, and touches no project or template content. The triggers themselves cannot be observed firing until this merges into `feature/7.0`; the first push to that branch afterwards is the real proof.

Relates to https://github.com/unoplatform/uno-private/issues/2299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
