### PR TITLE
ci(templates): add Features feed and fix duplicate NuGet source key

### DIFF
--- a/.github/actions/ci/canary-updater/action.yml
+++ b/.github/actions/ci/canary-updater/action.yml
@@ -34,4 +34,5 @@ runs:
             --versionOverrides=D:\a\1\s/build/templates/versionOverrides.json `
             --version=dev `
             --version=stable `
-            --feed=https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json
+            --feed=https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json `
+            --feed=https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/Features/nuget/v3/index.json

--- a/.github/actions/ci/run-tests/action.yml
+++ b/.github/actions/ci/run-tests/action.yml
@@ -205,7 +205,6 @@ runs:
     run: |
         dotnet nuget add source -n nuget_local ${{ github.workspace }}/src/PackageCache
         dotnet nuget add source -n uno_dev "https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json"
-        dotnet nuget add source -n uno_feat "https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/Features/nuget/v3/index.json"
         dotnet nuget add source -n net8 "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json"
 
   - name: 'Test all scenarios'

--- a/.github/actions/ci/run-tests/action.yml
+++ b/.github/actions/ci/run-tests/action.yml
@@ -205,6 +205,7 @@ runs:
     run: |
         dotnet nuget add source -n nuget_local ${{ github.workspace }}/src/PackageCache
         dotnet nuget add source -n uno_dev "https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json"
+        dotnet nuget add source -n uno_feat "https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/Features/nuget/v3/index.json"
         dotnet nuget add source -n net8 "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json"
 
   - name: 'Test all scenarios'

--- a/nuget.config
+++ b/nuget.config
@@ -3,6 +3,7 @@
 	<packageSources>
 		<add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
 		<add key="unoplatformdev" value="https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json" />
-		<add key="unoplatformdev" value="https://aka.ms/skiasharp-eap/index.json" />
+		<add key="unofeat" value="https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/Features/nuget/v3/index.json" />
+		<add key="skiasharp-eap" value="https://aka.ms/skiasharp-eap/index.json" />
 	</packageSources>
 </configuration>


### PR DESCRIPTION
Relates to https://github.com/unoplatform/uno-private/issues/2300

## What this changes

7.0 preview packages are published to the Azure DevOps **Features** feed, not **unoplatformdev**. Nothing in this repo currently trusts that feed, so a future 7.0 pin could not restore. This PR registers the Features feed where it is needed, and fixes a pre-existing duplicate-key bug in `nuget.config`.

1. **`nuget.config`** — the file declared two `<add>` entries under the same key `unoplatformdev` (the AzDO dev feed and the SkiaSharp EAP feed). The EAP entry now gets its own key `skiasharp-eap`, and the Features feed is added as `unofeat`.
2. **`.github/actions/ci/canary-updater/action.yml`** — a second `--feed=` pointing at Features, so `canaries/*` can track 7.0.

No pinned versions change. `src/Uno.Sdk/packages.json` and `Uno.Sdk.Updater.props` are untouched; this PR only makes the feed reachable.

## Why no change to `run-tests/action.yml`

An earlier revision of this PR also added `dotnet nuget add source -n uno_feat "<Features URL>"` to the `Setup nuget sources` step in `.github/actions/ci/run-tests/action.yml`. **That line has been removed — it was redundant and it never worked.** Two reasons, both verified rather than assumed:

**Generated test apps DO inherit the repo's `nuget.config`.** The test loop creates apps with a *relative* output path (`dotnet new $templateName -o $testName`, `run-tests/action.yml:331`) and the step's working directory is the workspace, so each app lands at `<workspace>/<testName>` — inside the repo tree. Generated apps carry no `nuget.config` of their own (`template.json` excludes it unless `enableDeveloperMode`, which no CI validation sets), so NuGet's config walk reaches `<workspace>/nuget.config`. The `unofeat` entry added in item 1 is therefore already visible to every generated app. Nothing further is required.

**`dotnet nuget add source` would have rejected it anyway.** The duplicate-URL check runs against the *merged* settings hierarchy, not merely the file being written to. Because the step's working directory is the workspace, the repo `nuget.config` is part of that merge, so the add fails with:

```
error: The source specified has already been added to the list of available package sources. Provide a unique source.
```

Note this is a **pre-existing** condition, not something this PR introduced: the `uno_dev` line already in that step adds the `unoplatformdev` URL, which has been in the repo `nuget.config` all along, so that line already fails on every run today. It goes unnoticed because GitHub Actions' `pwsh` shell exits with the *last* command's status and a native non-zero exit does not trip `$ErrorActionPreference = 'stop'` — the trailing `net8` add succeeds and the step stays green. The same latent duplicate exists in `.github/actions/ci/nuget-uno-publish/action.yml:26`. Both are left alone here as out of scope; the `nuget_local` and `net8` adds in the step are genuine and still needed, since neither URL is in `nuget.config`.

The `canary-updater` change was re-checked for the same hazard and is clear: those are `--feed=` arguments to `nugetupdater.exe`, not `dotnet nuget add source`, and the two `--feed` values are distinct URLs.

## Correction to the issue's diagnosis

The issue states the second duplicate entry "almost certainly shadows the first, meaning the repo's declared dev feed is the SkiaSharp EAP feed." **That is backwards.** NuGet keeps the *first* occurrence of a duplicate key within a file and silently drops later ones. So the AzDO dev feed was in use all along, and it is the SkiaSharp EAP source — added some time ago — that has never taken effect. Nobody noticed because the pinned SkiaSharp version resolves from nuget.org.

Verified two ways.

**Before**, `dotnet nuget list source --configfile nuget.config` from the repo root:

```
Registered Sources:
  1.  NuGet official package source [Enabled]
      https://api.nuget.org/v3/index.json
  2.  unoplatformdev [Enabled]
      https://pkgs.dev.azure.com/uno-platform/.../_packaging/unoplatformdev/nuget/v3/index.json
```

The SkiaSharp EAP URL does not appear at all. A controlled experiment with the same two URLs under one key in the *opposite* order printed only the SkiaSharp URL — first-wins in both directions, confirming this is ordering, not URL-specific.

**After**:

```
Registered Sources:
  1.  NuGet official package source [Enabled]
      https://api.nuget.org/v3/index.json
  2.  unoplatformdev [Enabled]
      https://pkgs.dev.azure.com/uno-platform/.../_packaging/unoplatformdev/nuget/v3/index.json
  3.  unofeat [Enabled]
      https://pkgs.dev.azure.com/uno-platform/.../_packaging/Features/nuget/v3/index.json
  4.  skiasharp-eap [Enabled]
      https://aka.ms/skiasharp-eap/index.json
```

Four distinct sources, no key collisions.

Note the side effect: the SkiaSharp EAP feed is now genuinely live for restores in this repo for the first time. Restore was re-run after the change and still succeeds (see below), but it is worth a reviewer's eye — if the EAP source is no longer wanted, deleting the line is the better fix than leaving it shadowed.

## Verification actually performed

- `dotnet nuget list source --configfile nuget.config` before and after — output above.
- Controlled duplicate-key ordering experiment in a scratch config — first-wins confirmed.
- **Duplicate-add reproduction.** In a scratch directory containing only a `nuget.config` with the Features URL, and with `APPDATA` redirected so the real user-level config was untouched, `dotnet nuget add source -n uno_feat "<Features URL>"` failed with `error: The source specified has already been added…`. Confirms the merged hierarchy — not just the write target — is what the duplicate check consults.
- **Full `Setup nuget sources` step replayed** against a copy of this PR's `nuget.config`, running all four adds in order and printing each exit code: `nuget_local` → 0, `uno_dev` → **1**, `uno_feat` → **1**, `net8` → 0. This is what motivated removing the `uno_feat` line and what establishes the `uno_dev` failure as pre-existing.
- **Inheritance confirmed**: `dotnet nuget list source` from a subdirectory of that workspace (standing in for a generated app, with no `nuget.config` of its own) lists `unofeat` alongside `nuget_local` and `net8` — so the Features feed does reach generated apps through the repo `nuget.config`.
- `dotnet package search Uno.WinUI --source <Features> --prerelease --exact-match` — returns `Uno.WinUI 7.0.0-dev.*` (latest observed `7.0.0-dev.463`), so 7.0 is provably reachable through the new source.
- `dotnet restore src/Uno.Templates.sln` — succeeds with all four sources registered.
- `dotnet pack src/Uno.Templates/Uno.Templates.csproj -c Release` — succeeds, `Uno.Templates.1.0.0.nupkg` produced.
- Both YAML files parse (`yaml.safe_load`); `run-tests/action.yml` is now byte-identical to the base branch.
- `nuget.config` parses as XML and reports 4 `packageSources` entries. CRLF line endings and the absent trailing newline are preserved.
- `--feed` repeatability for the canary updater was **not** assumed: `Uno.NuGet.Updater.Tool 1.2.10` was installed locally and its `--help` states `--feed … can be specified multiple times`.

**Not performed:** no CI run. `.github/workflows/ci.yml` triggers `push`/`pull_request` only on `main` and `release/**`, so a PR targeting `feature/7.0` does **not** run CI automatically — it needs a `workflow_dispatch` with `branch=feature/7.0`. The canary-updater edit was not executed end-to-end on a runner. No generated app was instantiated and restored against the new feed on a real runner; the inheritance claim above rests on the local simulation plus reading the template exclusion rules.

## Known follow-ups (out of scope here)

- **Hardcoded feed GUIDs will block the 7.0 pin.** `Uno.Sdk.Private 7.0.0-dev.*` exists only on the Features feed (`d26abad4-…`), but three code paths hardcode the unoplatformdev feed id `e7ce08df-…`: `src/Uno.Sdk/Uno.Sdk.csproj:26`, and `tools/Uno.Sdk.Updater/Services/NuGetClient.cs` lines 32 and 224. Those are raw HTTP GETs that never consult `nuget.config`, so this PR cannot fix them; they need parameterizing before 7.0 can be pinned. Left alone here deliberately — those files are owned by other in-flight work.
- **Silently failing `dotnet nuget add source` calls.** As described above, `run-tests/action.yml:207` and `nuget-uno-publish/action.yml:26` both re-add a URL that `nuget.config` already provides, and both fail without failing their step. Harmless today, but worth cleaning up (or making idempotent) separately.
- **`Verify-NuGetDependenciesOnNuGetOrg.ps1`** runs against `src/Uno.Sdk/packages.json` in `ci.yml` and requires every dependency to be on nuget.org. Features-feed-only 7.0 coordinates will fail that gate once the pin lands. A blocker for the pin, not for this PR.
- `src/Uno.Templates/content/unoapp/nuget.config` was intentionally not touched: `template.json` excludes it from generated output unless `enableDeveloperMode` is true (default false), so editing it would change nothing for ordinary generated apps.
- The Features feed is added on `feature/7.0` only, matching the issue's recommendation to keep the released lines honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
