### PR TITLE
chore(sdk): parameterize the Uno.Sdk.Private repack feed

### DIFF
--- a/src/Uno.Sdk/Uno.Sdk.csproj
+++ b/src/Uno.Sdk/Uno.Sdk.csproj
@@ -16,6 +16,18 @@
 		<Description>Provides a base SDK for Uno Platform projects.</Description>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<!--
+			Azure DevOps coordinates of the feed the Uno.Sdk.Private package is repacked from.
+			Override with -p:SdkDownloadFeedId=... or the SdkDownloadFeedId environment variable.
+			Known feeds:
+			  e7ce08df-613a-41a3-8449-d42784dd45ce  unoplatformdev (default - main, release/stable/*)
+			  d26abad4-c545-4e56-9ac7-fe42c6311c28  Features (feature/*)
+		-->
+		<SdkDownloadOrganizationId Condition=" '$(SdkDownloadOrganizationId)' == '' ">1dd81cbd-cb35-41de-a570-b0df3571a196</SdkDownloadOrganizationId>
+		<SdkDownloadFeedId Condition=" '$(SdkDownloadFeedId)' == '' ">e7ce08df-613a-41a3-8449-d42784dd45ce</SdkDownloadFeedId>
+	</PropertyGroup>
+
 	<Target Name="DownloadPrivateSdk"
 			BeforeTargets="ExtractSdkAssets">
 		<Error Text="No Sdk Version was found. Please ensure that the Uno.Sdk.Updater is run before building the Uno.Sdk project." Condition="'$(SdkVersion)' == ''" />
@@ -23,10 +35,15 @@
 		<PropertyGroup>
 			<SdkBuildOutputPath>$([System.IO.Path]::Combine($(IntermediateOutputPath), 'sdk'))</SdkBuildOutputPath>
 			<SdkDownloadFolder>$([System.IO.Path]::Combine($(SdkBuildOutputPath), 'downloads'))</SdkDownloadFolder>
-			<SdkDownloadUri>https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_apis/packaging/feeds/e7ce08df-613a-41a3-8449-d42784dd45ce/nuget/packages/$(SdkPackageId.ToLowerInvariant())/versions/$(SdkVersion)/content</SdkDownloadUri>			<SdkNuGetFile>$([System.IO.Path]::Combine($(SdkDownloadFolder), '$(SdkPackageId.ToLowerInvariant()).$(SdkVersion).nupkg'))</SdkNuGetFile>
+			<SdkDownloadUri>https://pkgs.dev.azure.com/uno-platform/$(SdkDownloadOrganizationId)/_apis/packaging/feeds/$(SdkDownloadFeedId)/nuget/packages/$(SdkPackageId.ToLowerInvariant())/versions/$(SdkVersion)/content</SdkDownloadUri>
+			<SdkNuGetFile>$([System.IO.Path]::Combine($(SdkDownloadFolder), '$(SdkPackageId.ToLowerInvariant()).$(SdkVersion).nupkg'))</SdkNuGetFile>
 		</PropertyGroup>
 
 		<MakeDir Directories="$(SdkDownloadFolder)" />
+
+		<!-- The feeds are disjoint per version range, so name the feed to make a 404 self-explaining. -->
+		<Message Importance="high" Condition="!Exists($(SdkNuGetFile))"
+				 Text="Downloading $(SdkPackageId) $(SdkVersion) from feed $(SdkDownloadFeedId)" />
 
 		<DownloadFile Condition="!Exists($(SdkNuGetFile))"
 					  SourceUrl="$(SdkDownloadUri)"

--- a/src/Uno.Sdk/Uno.Sdk.csproj
+++ b/src/Uno.Sdk/Uno.Sdk.csproj
@@ -19,7 +19,8 @@
 	<PropertyGroup>
 		<!--
 			Azure DevOps coordinates of the feed the Uno.Sdk.Private package is repacked from.
-			Override with -p:SdkDownloadFeedId=... or the SdkDownloadFeedId environment variable.
+			Both SdkDownloadOrganizationId and SdkDownloadFeedId can be overridden with -p:<name>=...
+			or an environment variable of the same name.
 			Known feeds:
 			  e7ce08df-613a-41a3-8449-d42784dd45ce  unoplatformdev (default - main, release/stable/*)
 			  d26abad4-c545-4e56-9ac7-fe42c6311c28  Features (feature/*)
@@ -42,10 +43,10 @@
 		<MakeDir Directories="$(SdkDownloadFolder)" />
 
 		<!-- The feeds are disjoint per version range, so name the feed to make a 404 self-explaining. -->
-		<Message Importance="high" Condition="!Exists($(SdkNuGetFile))"
+		<Message Importance="high" Condition="!Exists('$(SdkNuGetFile)')"
 				 Text="Downloading $(SdkPackageId) $(SdkVersion) from feed $(SdkDownloadFeedId)" />
 
-		<DownloadFile Condition="!Exists($(SdkNuGetFile))"
+		<DownloadFile Condition="!Exists('$(SdkNuGetFile)')"
 					  SourceUrl="$(SdkDownloadUri)"
 					  DestinationFileName="$(SdkPackageId.ToLowerInvariant()).$(SdkVersion).nupkg"
 					  DestinationFolder="$(SdkDownloadFolder)" />
@@ -59,7 +60,7 @@
 			<SdkNuGetExtractionPath>$([System.IO.Path]::Combine($(SdkBuildOutputPath), 'extract', '$(SdkVersion)'))</SdkNuGetExtractionPath>
 		</PropertyGroup>
 
-		<Unzip Condition="Exists($(SdkNuGetFile)) AND !Exists($(SdkNuGetExtractionPath))"
+		<Unzip Condition="Exists('$(SdkNuGetFile)') AND !Exists('$(SdkNuGetExtractionPath)')"
 			   SourceFiles="$(SdkNuGetFile)"
 			   DestinationFolder="$(SdkNuGetExtractionPath)" />
 	</Target>

--- a/tools/Uno.Sdk.Updater/Services/NuGetClient.cs
+++ b/tools/Uno.Sdk.Updater/Services/NuGetClient.cs
@@ -12,7 +12,23 @@ namespace Uno.Sdk.Services;
 internal class NuGetApiClient : IDisposable
 {
     private const string UnoWinUIPackageId = "Uno.WinUI";
-    private static PackageValidationRecord _validation = new ();
+
+    /*
+        Azure DevOps coordinates of the feed Uno.Sdk.Private is discovered on and downloaded from.
+        Override with the SdkDownloadFeedId / SdkDownloadOrganizationId environment variables - the
+        same names as the MSBuild properties in src/Uno.Sdk/Uno.Sdk.csproj, so a single variable
+        points both the updater and the repack build at the same feed.
+        Known feeds:
+          e7ce08df-613a-41a3-8449-d42784dd45ce  unoplatformdev (default - main, release/stable/*)
+          d26abad4-c545-4e56-9ac7-fe42c6311c28  Features (feature/*)
+    */
+    private const string DefaultDownloadOrganizationId = "1dd81cbd-cb35-41de-a570-b0df3571a196";
+    private const string DefaultDownloadFeedId = "e7ce08df-613a-41a3-8449-d42784dd45ce";
+
+    private static readonly string _downloadOrganizationId = GetSetting("SdkDownloadOrganizationId", DefaultDownloadOrganizationId);
+    private static readonly string _downloadFeedId = GetSetting("SdkDownloadFeedId", DefaultDownloadFeedId);
+
+    private static PackageValidationRecord _validation = new();
     private static Dictionary<string, IEnumerable<NuGetVersion>> _cachedVersions = [];
 
     private HttpClient PublicNuGetClient { get; } = new HttpClient
@@ -27,9 +43,15 @@ internal class NuGetApiClient : IDisposable
 
     public NuGetVersion? UnoVersion { get; set; }
 
+    private static string GetSetting(string name, string defaultValue)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        return string.IsNullOrWhiteSpace(value) ? defaultValue : value;
+    }
+
     public async Task<Stream> DownloadPackageAsync(string packageId, string version)
     {
-        var downloadUrl = $"/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_apis/packaging/feeds/e7ce08df-613a-41a3-8449-d42784dd45ce/nuget/packages/{packageId}/versions/{version}/content";
+        var downloadUrl = $"/uno-platform/{_downloadOrganizationId}/_apis/packaging/feeds/{_downloadFeedId}/nuget/packages/{packageId}/versions/{version}/content";
         using var response = await PrivateNuGetClient.GetAsync(downloadUrl);
 
         if (!response.IsSuccessStatusCode)
@@ -85,7 +107,7 @@ internal class NuGetApiClient : IDisposable
 
         var validatedOutput = new List<NuGetVersion>();
         Console.WriteLine($"Validating available versions for {packageId}...");
-        foreach(var version in latestVersions)
+        foreach (var version in latestVersions)
         {
             if (await ValidatePackage(packageId, version))
             {
@@ -132,7 +154,7 @@ internal class NuGetApiClient : IDisposable
     }
 
     private bool RequiresValidation(string packageId) =>
-        UnoVersion is not null && 
+        UnoVersion is not null &&
         packageId.Contains("Uno", StringComparison.InvariantCultureIgnoreCase) &&
         !packageId.StartsWith("Uno.Sdk", StringComparison.InvariantCultureIgnoreCase);
 
@@ -187,7 +209,7 @@ internal class NuGetApiClient : IDisposable
             if (unoDependencies.Any())
             {
                 var transitiveDependencies = unoDependencies.ToDictionary(x => x.Attribute("id")!.Value, x => NuGetVersion.Parse(x.Attribute("version")!.Value));
-                foreach((var packageId, var version) in transitiveDependencies)
+                foreach ((var packageId, var version) in transitiveDependencies)
                 {
                     if (_validation.HasBeenChecked(packageId, version))
                     {
@@ -221,7 +243,7 @@ internal class NuGetApiClient : IDisposable
     {
         try
         {
-            var response = await PrivateNuGetClient.GetFromJsonAsync<VersionsResponse>($"/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/e7ce08df-613a-41a3-8449-d42784dd45ce/nuget/v3/flat2/{packageId.ToLowerInvariant()}/index.json");
+            var response = await PrivateNuGetClient.GetFromJsonAsync<VersionsResponse>($"/uno-platform/{_downloadOrganizationId}/_packaging/{_downloadFeedId}/nuget/v3/flat2/{packageId.ToLowerInvariant()}/index.json");
             return response?.Versions ?? [];
         }
         catch

--- a/tools/Uno.Sdk.Updater/Services/NuGetClient.cs
+++ b/tools/Uno.Sdk.Updater/Services/NuGetClient.cs
@@ -28,7 +28,7 @@ internal class NuGetApiClient : IDisposable
     private static readonly string _downloadOrganizationId = GetSetting("SdkDownloadOrganizationId", DefaultDownloadOrganizationId);
     private static readonly string _downloadFeedId = GetSetting("SdkDownloadFeedId", DefaultDownloadFeedId);
 
-    private static PackageValidationRecord _validation = new();
+    private static readonly PackageValidationRecord _validation = new();
     private static Dictionary<string, IEnumerable<NuGetVersion>> _cachedVersions = [];
 
     private HttpClient PublicNuGetClient { get; } = new HttpClient


### PR DESCRIPTION
Relates to https://github.com/unoplatform/uno-private/issues/2298

## What

`src/Uno.Sdk` is a repackaging shim: it downloads the `Uno.Sdk.Private` nupkg from an Azure DevOps feed over HTTP, unzips it, and re-packs the props/targets/dlls as the public `Uno.Sdk`. `tools/Uno.Sdk.Updater` is the other half of the same loop: it discovers the newest `Uno.Sdk.Private` version on that feed, downloads it, and regenerates the `<SdkVersion>` in `src/Uno.Sdk/Uno.Sdk.Updater.props` that the csproj then consumes. The feed was a literal GUID at all three of those call sites, so there was no way to point the pair at a different feed without editing sources.

This extracts the two Azure DevOps coordinates into overridable settings:

- `SdkDownloadFeedId` — defaults to the existing feed
- `SdkDownloadOrganizationId` — defaults to the existing organization

**`src/Uno.Sdk/Uno.Sdk.csproj`** declares them in a file-level `PropertyGroup` with `Condition=" '$(X)' == '' "`, so they can be supplied either as `-p:SdkDownloadFeedId=...` on the command line or as an environment variable of the same name (MSBuild surfaces environment variables as properties, and the empty-check lets one win).

**`tools/Uno.Sdk.Updater/Services/NuGetClient.cs`** reads the same two names from the environment, falling back to the same default GUIDs, and uses them at both of its private-feed call sites — `GetPrivatePackageVersions` (the flat2 index used for version discovery) and `DownloadPackageAsync` (the package content URL). One variable therefore moves the updater and the repack build together; parameterizing only the csproj would have let the SDK *build* against another feed while the updater could still neither discover nor fetch a version from it.

Two small pieces of housekeeping in the same `DownloadPrivateSdk` target:

- `SdkDownloadUri` and `SdkNuGetFile` were jammed onto one physical line separated by tabs. Split onto separate lines.
- Added a `Message` naming the resolved feed just before `DownloadFile`. The feeds hold disjoint version ranges, so pulling a version the target feed does not carry previously surfaced as a bare `MSB3923 ... 404 (Not Found)` with a long URL and no hint about which knob was wrong.

`dotnet format` on `tools/Uno.Sdk.Updater` also normalized four pre-existing whitespace nits inside `NuGetClient.cs` (`new ()`, two `foreach(`, one trailing space). They are in the commit for honesty about what the formatter did; no other file was reformatted.

No version is bumped and no default changes.

## Scope — deliberately not included

The default feed is **not** flipped on this branch. This branch still pins a 6.8 `SdkVersion` in the generated `src/Uno.Sdk/Uno.Sdk.Updater.props`, and that version does not exist on the other feed — changing the default here alone would be an immediate build break. Flipping the default belongs with the version bump and updater re-run, once the corresponding first-party packages exist.

`src/Uno.Sdk/Uno.Sdk.Updater.props` was intentionally left untouched even though it is the natural home for a per-branch default: it is fully regenerated by `tools/Uno.Sdk.Updater` (`CreateSdkProps` writes the whole file) and carries a "do not make manual changes" header, so anything added there is erased by the next SDK update run.

### No CI caller yet — deliberate

Nothing in `.github/` sets either variable today, so the new setting currently has no caller. That is intentional for this PR, and it does **not** require plumbing in `.github/actions/ci/build-packages/action.yml`:

- Composite-action steps inherit the workflow's and job's `env`, so a workflow-level `env:` entry reaches both the `Pack Uno.Sdk` step's `dotnet build` (as an MSBuild property) and the `Run Uno Sdk Updater` step in `.github/actions/sdk-update/action.yml` (as an environment variable read by the C#). No action input or `-p:` pass-through is needed for either.
- `.github/workflows/ci.yml` already drives MSBuild this exact way — `WindowsSdkPackageVersion`, `AllowUnsafeBlocks` and `RestoreEnablePackagePruning` are all plain entries in its top-level `env:` block. Adding an input to `build-packages` would introduce a second, inconsistent mechanism for the same job.

Adding a caller now would mean either wiring a knob that always resolves to its default, or flipping the feed — which, per the section above, breaks the build until the version bump lands.

**Follow-up needed:** on the branch that bumps to 7.0, add `SdkDownloadFeedId: <Features feed GUID>` to the `env:` block in `.github/workflows/ci.yml` in the same change that re-runs the updater and updates `Uno.Sdk.Updater.props`. Also note that `.github/workflows/ci.yml` currently triggers only on `main` and `release/**`, so a `feature/**` trigger is a prerequisite for that to run at all.

## Verification performed locally

### Uno.Sdk repack (csproj)

All runs deleted `src/Uno.Sdk/obj` first, because `DownloadPrivateSdk` and `ExtractSdkAssets` are both guarded by `!Exists(...)` and a stale download silently masks changes.

1. **Baseline, before the change** — `dotnet build src/Uno.Sdk/Uno.Sdk.csproj -c Release -p:PackageVersion=6.8.0-dev.46`. Succeeded, 0 warnings, 0 errors. Recorded a SHA-256 of every entry in the produced `Uno.Sdk.6.8.0-dev.46.nupkg` (90 entries).
2. **Default path, after the change** — same command. Succeeded, 0 warnings, 0 errors; log prints the original feed GUID; the downloaded `uno.sdk.private.6.8.0-dev.46.nupkg` is the same 2,152,177 bytes. Comparing the two output nupkgs entry by entry: **88 of 90 entries are hash-identical**. The only two differences are the OPC `.psmdcp` core-properties part, whose filename embeds a fresh random GUID on every pack, and `_rels/.rels`, which references that filename by name. Its *content* hash is identical. That is NuGet's normal pack nondeterminism, not an effect of this change.
3. **`packages.json` separation preserved** — the `targets/netstandard2.0/packages.json` inside the output package is byte-identical to this repo's own `src/Uno.Sdk/packages.json` (verified by hash), not the private package's copy, in both the 6.x and the override build.
4. **Override path proven end to end** — built with `-p:SdkDownloadFeedId=<other feed> -p:SdkVersion=<7.0 dev version> -p:PackageVersion=<same>`. Succeeded. The nupkg downloaded from the overridden feed, `ExtractSdkAssets` unzipped it, and `BundleSdkAssets` rewrote `Sdk/Sdk.props` `<UnoSdkVersion>` to the passed `PackageVersion` — confirmed by reading it back out of the packed output.
5. **Environment-variable override proven** — setting `SdkDownloadFeedId` in the environment (no `-p:`) changed the resolved feed in the build log, confirming the CI-friendly path works.

### Uno.Sdk.Updater (C#)

6. **Builds clean** — `NBGV_SemVer2=7.0.0-dev.1 dotnet build tools/Uno.Sdk.Updater/Uno.Sdk.Updater.csproj -c Release` → `Build succeeded. 1 Warning(s), 0 Error(s)`. The single warning is the pre-existing `CS0219` for the unused `description` local in `Program.cs`, present before this change too.
7. **`dotnet format`** — `dotnet format tools/Uno.Sdk.Updater/Uno.Sdk.Updater.csproj --include tools/Uno.Sdk.Updater/Services/NuGetClient.cs` run and its output committed; a re-run reports no further changes.
8. **Both call sites exercised against the live feed, before vs. after.** Built the assembly on the parent commit and on this commit, then drove `GetPrivatePackageVersions("Uno.Sdk.Private")` and `DownloadPackageAsync("Uno.Sdk.Private", …)` on each through a throwaway reflection harness (not committed):

   | assembly | env | discovery | download |
   |---|---|---|---|
   | before | none | 387 versions, newest `6.8.0-dev.86` | `6.8.0-dev.86` → 2,152,208 bytes |
   | after | none | 387 versions, newest `6.8.0-dev.86` | `6.8.0-dev.86` → 2,152,208 bytes |
   | before | `SdkDownloadFeedId=<Features feed>` | **387 versions, newest `6.8.0-dev.86`** (override ignored) | `7.0.0-dev.463` → **0 bytes** (`Stream.Null`) |
   | after | `SdkDownloadFeedId=<Features feed>` | 147 versions, newest `7.0.0-dev.463` | `7.0.0-dev.463` → 609,421 bytes |

   Rows 1 and 2 are identical, so the default path is unchanged. Row 3 is the reported defect reproduced: before this commit the updater silently stayed on the old feed and returned an empty stream for a 7.0 package. Row 4 shows both sites now follow the override. The 387-version default-feed result also matches a plain `curl` of the flat2 index (387 versions, newest `6.8.0-dev.86`), so the harness is measuring the real request.

## Not verified

- No CI run on this branch. `.github/workflows/ci.yml` triggers only on `main` and `release/**`, so nothing runs automatically here; validating on a feature branch needs a `workflow_dispatch`.
- The updater was not run end to end (`dotnet run --project tools/Uno.Sdk.Updater`), because a full run rewrites `src/Uno.Sdk/packages.json`, `ReadMe.md` and `Uno.Sdk.Updater.props` in place. The two methods that talk to the feed were exercised directly instead, as above.
- Templates were not packed or instantiated. This PR touches only the SDK repack project and the updater tool, no template content.

## Pre-existing behaviour worth noting, not changed here

The private package's `targets/Uno.Build.targets` embeds its SDK version as a bare literal in some diagnostic `Error` conditions. `BundleSdkAssets`'s `ReplaceFileText` only rewrites text between `<UnoSdkVersion>` tags, so those literals survive the repack. This is equally true on the current 6.x path and is upstream behaviour; widening the regex would clobber other version elements, so it was left alone.

`GetPrivatePackageVersions` swallows every exception and returns an empty list, so a wrong or unreachable feed surfaces only as the later `No Uno Version was found.` This predates the change and is unaffected by it, but it does mean a typo'd `SdkDownloadFeedId` will not name itself the way the csproj's new `Message` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
