### PR TITLE
feat(templates)!: align the Android head on UnoPlatformHostBuilder

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/Android/Main.Android.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/Android/Main.Android.cs
@@ -9,6 +9,7 @@ using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Microsoft.UI.Xaml.Media;
+using Uno.UI.Hosting;
 //+:cnd:noEmit
 #if (!useSkiaRenderer)
 using Com.Nostra13.Universalimageloader.Core;
@@ -41,7 +42,7 @@ public class Application : Microsoft.UI.Xaml.NativeApplication
 #endif
 //-:cnd:noEmit
     public Application(IntPtr javaReference, JniHandleOwnership transfer)
-        : base(() => new App(), javaReference, transfer)
+        : base(javaReference, transfer)
     {
 //+:cnd:noEmit
 #if (!useSkiaRenderer)
@@ -49,6 +50,12 @@ public class Application : Microsoft.UI.Xaml.NativeApplication
 #endif
 //-:cnd:noEmit
     }
+
+    protected override UnoPlatformHost CreateHost() =>
+        UnoPlatformHostBuilder.Create()
+            .App(() => new App())
+            .UseAndroid()
+            .Build();
 
 //+:cnd:noEmit
 #if (!useSkiaRenderer)


### PR DESCRIPTION
Relates to https://github.com/unoplatform/uno.templates/issues/2211

## Scope was inferred — please correct it

The source issue body is an **entirely unfilled enhancement template**: every section ("What would you like to be added", "Why is this needed", "For which Platform", "Anything else") is blank, and there are no comments. The only signal is the title, *"Use Host builder on Android [7.0]"*.

So the scope below was **inferred from the repository**, not read from the issue. A maintainer should confirm or correct it before this is taken as final.

**Inferred goal:** Android is the last platform head in the `unoapp` template that does not construct its host through `UnoPlatformHostBuilder`. iOS (`Platforms/iOS/Main.iOS.cs`), Desktop (`Platforms/Desktop/Program.cs`) and WebAssembly (`Platforms/WebAssembly/Program.cs`) all already use `UnoPlatformHostBuilder.Create().App(() => new App()).UseX().Build()`. This PR brings Android onto the same shape and does nothing else.

## What changed

One file: `src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/Android/Main.Android.cs`.

- Added `using Uno.UI.Hosting;`.
- The `Application` constructor now chains `: base(javaReference, transfer)` instead of `: base(() => new App(), javaReference, transfer)`.
- Added an override that builds the host explicitly:

```csharp
protected override UnoPlatformHost CreateHost() =>
    UnoPlatformHostBuilder.Create()
        .App(() => new App())
        .UseAndroid()
        .Build();
```

.NET for Android has no managed entry point (the SDK rewrites `OutputType` from `Exe` to `Library`), so unlike the other heads the builder cannot live in a `Main` method — it goes on `NativeApplication.CreateHost()` instead.

Deliberately untouched: the `#if (!useDependencyInjection && useLoggingFallback)` static constructor calling `App.InitializeLogging()` (it must still run before the host is built, matching what the other heads do inline), the `#if (!useSkiaRenderer)` `ConfigureUniversalImageLoader()` call and method, the `ApplicationAttribute` block including the `#if useAndroidTV` banner, `MainActivity.Android.cs`, and the `MsalActivity` / `WebAuthenticationBrokerActivity` conditional files.

## This is DRAFT — the required API does not exist in the pinned package line

I was asked to determine whether the host-builder path is reachable from the packages this repo currently pins (`src/Uno.Sdk/packages.json` → `6.8.0-dev.46`). **It is not.** Evidence actually gathered:

1. Downloaded `Uno.WinUI.Runtime.Skia.Android` **6.8.0-dev.46** from nuget.org and scanned both `lib/net9.0-android35.0` and `lib/net10.0-android36.0` assemblies. `AndroidHost` is present (positive control), but **`UseAndroid`, `UnoPlatformHostBuilder` and `CreateHost` are all absent**.
2. On the 6.8 line in `unoplatform/uno`, `NativeApplication` is a non-abstract `class` whose only constructor is `NativeApplication(AppBuilder, IntPtr, JniHandleOwnership)` — the exact constructor this PR stops calling — and there is no `CreateHost`.
3. No `7.x` version of `uno.winui` exists on either package source in this repo's `NuGet.config`: nuget.org's flat container tops out at `6.8.0-dev.86`, and the `unoplatformdev` Azure DevOps feed likewise has no `7.x` entry.

Concretely, the APIs this PR needs and that 6.8 does not provide:

- `Microsoft.UI.Xaml.NativeApplication` being abstract with `protected abstract UnoPlatformHost CreateHost()`
- the `NativeApplication(IntPtr, JniHandleOwnership)` constructor (6.8 only has the `AppBuilder`-taking one)
- `UseAndroid()` on the Skia Android host builder

Against 6.8 this template head does not compile, and every `*-template-tests` job in CI restores and builds generated apps — so this must not be merged until `src/Uno.Sdk/packages.json` points at an Uno.WinUI build that carries the reshaped `NativeApplication`. That package bump is a separate prerequisite and is intentionally not in this PR (`packages.json` and `version.json` are owned elsewhere).

## Separate question this surfaces (not fixed here)

In the reshaped `NativeApplication` there is no `#if ANDROID_SKIA` branch left, i.e. the Android **native** renderer path is gone. The template still offers `renderer: native`, which drives the `#if (!useSkiaRenderer)` UniversalImageLoader block kept in this file. That option appears to have no Android implementation left to target. I left the block structurally intact rather than silently deleting it — it needs a product decision and probably its own issue.

## Verification actually performed

- `dotnet pack src/Uno.Templates/Uno.Templates.csproj -c Release` succeeds (`Uno.Templates.1.0.0.nupkg` produced). ✅
- `git status` clean apart from the one intended file; full diff read before committing; no build output staged. ✅
- `grep -rn 'NativeApplication\|Main.Android' build/ tools/ .github/` returns nothing, so no build script or CI step pattern-matches the old head. ✅
- No JSON or YAML files touched, so no parser validation was applicable. ✅
- **Not done:** installing the packed template and running `dotnet new unoapp -platforms android`. The Android build would fail regardless for the API reasons above, and installing would have replaced an already-installed `Uno.Templates` package on the machine that I could not reliably restore. Reported rather than faked. ❌
- **Not done:** `dotnet format`. `Uno.Templates.csproj` sets `EnableDefaultItems=false` and ships `content/**` as package content, never as `Compile` items, so this file is not part of any compiled project and `dotnet format` has nothing to act on. Indentation was matched to the surrounding file (4 spaces) by hand. ❌

🤖 Generated with [Claude Code](https://claude.com/claude-code)
