### PR TITLE
feat(templates): adopt the UIKit scene lifecycle in the iOS head

### DIFF
--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/iOS/Info.plist
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/iOS/Info.plist
@@ -33,6 +33,23 @@
 		<string>Assets.xcassets/icon.appiconset</string>
 		<key>UIApplicationSupportsIndirectInputEvents</key>
 		<true/>
+		<key>UIApplicationSceneManifest</key>
+		<dict>
+			<key>UIApplicationSupportsMultipleScenes</key>
+			<true/>
+			<key>UISceneConfigurations</key>
+			<dict>
+				<key>UIWindowSceneSessionRoleApplication</key>
+				<array>
+					<dict>
+						<key>UISceneConfigurationName</key>
+						<string>Default Configuration</string>
+						<key>UISceneDelegateClassName</key>
+						<string>SceneDelegate</string>
+					</dict>
+				</array>
+			</dict>
+		</dict>
 
 		<!--
 		Adjust this to your application's encryption usage.

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/iOS/SceneDelegate.iOS.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/iOS/SceneDelegate.iOS.cs
@@ -1,0 +1,9 @@
+using Foundation;
+using Uno.UI.Runtime.Skia.AppleUIKit;
+
+namespace MyExtensionsApp._1.iOS;
+
+[Register("SceneDelegate")]
+public class SceneDelegate : UnoUISceneDelegate
+{
+}


### PR DESCRIPTION
## Summary

Wires the generated iOS head into the UIKit **scene** lifecycle. This is **unconditional** — every generated iOS head gets it, with no template option.

## Why this is not optional

Apple is retiring the window-based `UIApplicationDelegate` life cycle. An app whose `Info.plist` carries no `UIApplicationSceneManifest` already logs a warning on iOS 26, and Apple DTS has stated the consequence plainly:

> "UIScene lifecycle will soon be required. Failure to adopt will result in an assert in the future."
>
> "Failing to adopt the scene-based life cycle in the **next major iOS release** will prevent the app from launching."
>
> — [Apple Developer Forums thread 820807](https://developer.apple.com/forums/thread/820807), see also Technical Note TN3187

The trigger condition Apple names is precisely what this PR adds: a missing `UIApplicationSceneManifest`, or no `application(_:configurationForConnecting:options:)`. So a generated iOS app without this **stops launching** on the next major release. That rules out an opt-in — and equally rules out an opt-out checkbox, which would just be a footgun for shipping apps that fail to launch.

## What it emits

Two halves that only work as a pair:

1. **`Platforms/iOS/Info.plist`** — a `UIApplicationSceneManifest` entry declaring `UIApplicationSupportsMultipleScenes` and one default scene configuration naming `SceneDelegate` as `UISceneDelegateClassName`.
2. **`Platforms/iOS/SceneDelegate.iOS.cs`** — a `[Register("SceneDelegate")]` subclass of `Uno.UI.Runtime.Skia.AppleUIKit.UnoUISceneDelegate`.

The registered name and `UISceneDelegateClassName` match exactly, which is what lets UIKit resolve the delegate at launch.

No template plumbing is needed: `Platforms/iOS/**/*` is already excluded when iOS is not selected, so both files are naturally scoped to the iOS head. Net diff is **two files, +26 lines** — no `template.json` symbols, no `TemplateWizard.json` entries.

## On multi-window

Multi-window on iPadOS falls out of scene adoption, but it is a *consequence*, not the reason. `UIApplicationSupportsMultipleScenes` is currently `true`; it could be flipped to `false` later without giving up lifecycle compliance, if single-window behaviour is wanted. Worth a maintainer opinion, but it does not block the lifecycle work.

## ⚠️ Blocked on the 7.0 package line — do not merge yet

`Uno.UI.Runtime.Skia.AppleUIKit.UnoUISceneDelegate` comes from unoplatform/uno#19083, which **has merged** (2026-09-01, `43b608ba`) — the namespace was re-confirmed against the merged commit, not the review head.

However it has **not reached the package line this branch resolves**. `src/Uno.Sdk/packages.json` pins Core at `6.8.0-dev.130`, and the type is absent from every cached 6.x `Uno.WinUI.Runtime.Skia.AppleUIKit` package — it appears only from `7.0.0-dev.645` onward. Generating an iOS app on the current pin therefore fails:

```
Platforms\iOS\SceneDelegate.iOS.cs(7,30): error CS0246: The type or namespace name
'UnoUISceneDelegate' could not be found
```

Previously this was tolerable because the option defaulted off. **Now that it is unconditional, this breaks every generated iOS app until `packages.json` moves to a 7.0 package line carrying the type.** That version move belongs to the 7.0 package-line work, not here.

**This must not merge until `packages.json` resolves a package containing `UnoUISceneDelegate`.** CI enforces that on its own: the `macos-template-tests` leg runs the `MauiBlank_macOS` / `MauiRecommended_macOS` validations, which generate an app with `-platforms ... ios` and build it, so the `CS0246` above fails the run until the package line moves. Review is welcome meanwhile — the red macOS leg is the signal that the version bump is outstanding, not a defect in this change.

Relates to https://github.com/unoplatform/uno.templates/issues/2203

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4hG8PDawQsDBqY62tf2wG
