### PR TITLE
chore(templates): make the Windows TFM floor a single source of truth

### DIFF
--- a/tools/TemplateTfmSwitchGenerator/Program.cs
+++ b/tools/TemplateTfmSwitchGenerator/Program.cs
@@ -1,58 +1,59 @@
-using System.Text.Json;
 using TemplateTfmSwitchGenerator;
 
-var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+var checkOnly = args.Any(argument => argument is "--check");
+var repoRoot = RepositoryLayout.FindRoot();
+var outdated = new List<string>();
+
+void Apply(string path, string original, string updated, bool hasBom)
 {
-    WriteIndented = true,
-};
-Platform[] platforms = [
-    new Platform("platforms == android", "platforms != android", "android"),
-    new Platform("platforms == ios", "platforms != ios", "ios"),
-    new Platform("platforms == windows", "platforms != windows", "windows10.0.26100"),
-    new Platform("platforms == wasm", "platforms != wasm", "browserwasm"),
-    new Platform("platforms == desktop", "platforms != desktop", "desktop"),
-    new Platform("useUnitTests == true", "useUnitTests == false", null)
-];
-
-string[] runtimes = ["net9.0", "net10.0"];
-
-var cases = new List<TemplateSwitchCase>();
-foreach (var runtime in runtimes)
-{
-    var results = GenerateTemplateSwitchCases(platforms, runtime);
-    cases.AddRange(results);
-}
-
-var json = JsonSerializer.Serialize(cases, options)
-    .Replace(@"\u0026", "&")
-    .Replace(@"\u0027", "'");
-File.WriteAllText("template.json", json);
-Console.WriteLine(json);
-
-static IEnumerable<TemplateSwitchCase> GenerateTemplateSwitchCases(Platform[] platforms, string runtime)
-{
-    var cases = new List<TemplateSwitchCase>();
-    var initialCondition = $"tfm == '{runtime}' && ";
-    GenerateCases(platforms, 0, initialCondition, "", cases, runtime);
-    return cases;
-}
-
-static void GenerateCases(Platform[] platforms, int index, string currentCondition, string currentTfm, List<TemplateSwitchCase> cases, string runtime)
-{
-    if (index == platforms.Length)
+    if (string.Equals(original, updated, StringComparison.Ordinal))
     {
-        var finalizedCondition = $"({currentCondition.Trim(' ', '&')})";
-        cases.Add(new TemplateSwitchCase(finalizedCondition, currentTfm.TrimEnd(';', ' ')));
         return;
     }
 
-    string trueCondition = platforms[index].TrueCondition;
-    string falseCondition = platforms[index].FalseCondition;
-    string trueTfm = platforms[index].GetTfm(runtime) + ";";
+    outdated.Add(Path.GetRelativePath(repoRoot, path));
 
-    // Include true condition
-    GenerateCases(platforms, index + 1, $"{currentCondition}{trueCondition} && ", $"{currentTfm}{trueTfm}", cases, runtime);
-
-    // Include false condition
-    GenerateCases(platforms, index + 1, $"{currentCondition}{falseCondition} && ", currentTfm, cases, runtime);
+    if (!checkOnly)
+    {
+        TextFile.Write(path, updated, hasBom);
+    }
 }
+
+var templateJsonPath = RepositoryLayout.Resolve(repoRoot, RepositoryLayout.SingleProjectTemplateJson);
+var (templateJson, templateJsonHasBom) = TextFile.Read(templateJsonPath);
+var cases = SwitchCaseGenerator.Generate(TemplateTfms.Platforms, TemplateTfms.Runtimes);
+
+Apply(
+    templateJsonPath,
+    templateJson,
+    TemplateJsonPatcher.PatchSwitchCases(templateJson, TemplateTfms.SingleProjectTfmsSymbol, cases),
+    templateJsonHasBom);
+
+foreach (var mirror in RepositoryLayout.EnumerateWindowsTfmMirrors(repoRoot))
+{
+    var (content, hasBom) = TextFile.Read(mirror);
+    Apply(mirror, content, WindowsTfmRewriter.Rewrite(content, TemplateTfms.WindowsPlatformVersion), hasBom);
+}
+
+Console.WriteLine($"Windows platform version: {TemplateTfms.WindowsPlatformVersion}");
+Console.WriteLine($"Runtimes: {string.Join(", ", TemplateTfms.Runtimes)}");
+Console.WriteLine($"Generated {cases.Count} '{TemplateTfms.SingleProjectTfmsSymbol}' switch cases.");
+
+if (outdated.Count == 0)
+{
+    Console.WriteLine("Template TFMs are up to date.");
+    return 0;
+}
+
+foreach (var file in outdated)
+{
+    Console.WriteLine(checkOnly ? $"  out of date: {file}" : $"  updated: {file}");
+}
+
+if (checkOnly)
+{
+    Console.Error.WriteLine("Template TFMs are out of date. Run 'dotnet run --project tools/TemplateTfmSwitchGenerator' and commit the result.");
+    return 1;
+}
+
+return 0;

--- a/tools/TemplateTfmSwitchGenerator/ReadMe.md
+++ b/tools/TemplateTfmSwitchGenerator/ReadMe.md
@@ -1,0 +1,37 @@
+# TemplateTfmSwitchGenerator
+
+Owns the target frameworks the templates emit.
+
+`TemplateTfms.cs` is the single source of truth:
+
+| Member | Controls |
+| --- | --- |
+| `WindowsPlatformVersion` | the platform version of every Windows TFM (`netX.0-windows<version>`) |
+| `Runtimes` | the .NET versions offered by the `tfm` template parameter |
+| `Platforms` | the platform conditions expanded into switch cases |
+
+Running the tool applies those values to:
+
+- the `singleProjectTfms` generated switch symbol in
+  `src/Uno.Templates/content/unoapp/.template.config/template.json` (patched in place,
+  the rest of the file is left untouched);
+- every hand-written Windows TFM in `src/Uno.Templates/content` — currently
+  `.run/MyExtensionsApp.1.run.xml`, `MyExtensionsApp.1.MauiControls.csproj` and
+  `unolib/CrossTargetedLibrary.csproj`.
+
+## Usage
+
+Update the templates after changing `TemplateTfms.cs`:
+
+```shell
+dotnet run --project tools/TemplateTfmSwitchGenerator
+```
+
+Report drift without writing anything (exits with `1` when the templates are out of date):
+
+```shell
+dotnet run --project tools/TemplateTfmSwitchGenerator -- --check
+```
+
+Do not hand-edit the generated switch cases or the Windows TFMs listed above — change
+`TemplateTfms.cs` and re-run the tool instead.

--- a/tools/TemplateTfmSwitchGenerator/RepositoryLayout.cs
+++ b/tools/TemplateTfmSwitchGenerator/RepositoryLayout.cs
@@ -1,0 +1,52 @@
+namespace TemplateTfmSwitchGenerator;
+
+/// <summary>
+/// Locates the files the generator owns, relative to the repository root.
+/// </summary>
+public static class RepositoryLayout
+{
+    public const string SingleProjectTemplateJson = "src/Uno.Templates/content/unoapp/.template.config/template.json";
+
+    private const string TemplateContentRoot = "src/Uno.Templates/content";
+
+    private static readonly string[] MirrorExtensions = [".csproj", ".props", ".targets", ".xml", ".json", ".sln", ".slnx"];
+
+    public static string FindRoot()
+    {
+        foreach (var start in new[] { AppContext.BaseDirectory, Directory.GetCurrentDirectory() })
+        {
+            for (var directory = new DirectoryInfo(start); directory is not null; directory = directory.Parent)
+            {
+                if (File.Exists(Resolve(directory.FullName, SingleProjectTemplateJson)))
+                {
+                    return directory.FullName;
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"Could not locate the repository root: no '{SingleProjectTemplateJson}' found above the generator.");
+    }
+
+    public static string Resolve(string repoRoot, string relativePath) =>
+        Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+
+    /// <summary>
+    /// Template content carrying a hand-written Windows TFM. The template.json is excluded
+    /// because its switch cases are generated rather than rewritten.
+    /// </summary>
+    public static IEnumerable<string> EnumerateWindowsTfmMirrors(string repoRoot)
+    {
+        var contentRoot = Resolve(repoRoot, TemplateContentRoot);
+        var templateJson = Resolve(repoRoot, SingleProjectTemplateJson);
+
+        return Directory.EnumerateFiles(contentRoot, "*", SearchOption.AllDirectories)
+            .Where(file => MirrorExtensions.Contains(Path.GetExtension(file), StringComparer.OrdinalIgnoreCase))
+            .Where(file => !IsBuildOutput(contentRoot, file))
+            .Where(file => !string.Equals(file, templateJson, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsBuildOutput(string contentRoot, string file) =>
+        Path.GetRelativePath(contentRoot, file)
+            .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Any(segment => segment is "bin" or "obj");
+}

--- a/tools/TemplateTfmSwitchGenerator/SwitchCaseGenerator.cs
+++ b/tools/TemplateTfmSwitchGenerator/SwitchCaseGenerator.cs
@@ -1,0 +1,36 @@
+namespace TemplateTfmSwitchGenerator;
+
+/// <summary>
+/// Expands every platform combination into the switch cases consumed by the
+/// <c>singleProjectTfms</c> generated symbol.
+/// </summary>
+public static class SwitchCaseGenerator
+{
+    public static IReadOnlyList<TemplateSwitchCase> Generate(Platform[] platforms, string[] runtimes)
+    {
+        var cases = new List<TemplateSwitchCase>();
+        foreach (var runtime in runtimes)
+        {
+            GenerateCases(platforms, 0, $"tfm == '{runtime}' && ", string.Empty, cases, runtime);
+        }
+
+        return cases;
+    }
+
+    private static void GenerateCases(Platform[] platforms, int index, string currentCondition, string currentTfm, List<TemplateSwitchCase> cases, string runtime)
+    {
+        if (index == platforms.Length)
+        {
+            var finalizedCondition = $"({currentCondition.Trim(' ', '&')})";
+            cases.Add(new TemplateSwitchCase(finalizedCondition, currentTfm.TrimEnd(';', ' ')));
+            return;
+        }
+
+        var trueCondition = platforms[index].TrueCondition;
+        var falseCondition = platforms[index].FalseCondition;
+        var trueTfm = platforms[index].GetTfm(runtime) + ";";
+
+        GenerateCases(platforms, index + 1, $"{currentCondition}{trueCondition} && ", $"{currentTfm}{trueTfm}", cases, runtime);
+        GenerateCases(platforms, index + 1, $"{currentCondition}{falseCondition} && ", currentTfm, cases, runtime);
+    }
+}

--- a/tools/TemplateTfmSwitchGenerator/TemplateJsonPatcher.cs
+++ b/tools/TemplateTfmSwitchGenerator/TemplateJsonPatcher.cs
@@ -1,0 +1,56 @@
+namespace TemplateTfmSwitchGenerator;
+
+/// <summary>
+/// Rewrites the <c>cases</c> array of a generated switch symbol in place, leaving the
+/// rest of the template.json (formatting, comments and line endings) untouched.
+/// </summary>
+public static class TemplateJsonPatcher
+{
+    public static string PatchSwitchCases(string json, string symbolName, IReadOnlyList<TemplateSwitchCase> cases)
+    {
+        var newLine = json.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
+        var lines = json.Split(newLine).ToList();
+
+        var symbolIndex = lines.FindIndex(line => line.TrimStart().StartsWith($"\"{symbolName}\":", StringComparison.Ordinal));
+        if (symbolIndex < 0)
+        {
+            throw new InvalidOperationException($"Could not find the '{symbolName}' symbol in the template.json.");
+        }
+
+        var casesIndex = lines.FindIndex(symbolIndex, line => line.TrimStart().StartsWith("\"cases\":", StringComparison.Ordinal));
+        if (casesIndex < 0)
+        {
+            throw new InvalidOperationException($"The '{symbolName}' symbol does not declare a 'cases' array.");
+        }
+
+        var indent = lines[casesIndex][..^lines[casesIndex].TrimStart().Length];
+        var closingIndex = lines.FindIndex(casesIndex + 1, line => line.StartsWith($"{indent}]", StringComparison.Ordinal));
+        if (closingIndex < 0)
+        {
+            throw new InvalidOperationException($"The 'cases' array of the '{symbolName}' symbol is not closed at the expected indentation.");
+        }
+
+        lines.RemoveRange(casesIndex + 1, closingIndex - casesIndex - 1);
+        lines.InsertRange(casesIndex + 1, RenderCases(cases, indent));
+
+        return string.Join(newLine, lines);
+    }
+
+    private static IEnumerable<string> RenderCases(IReadOnlyList<TemplateSwitchCase> cases, string indent)
+    {
+        var itemIndent = $"{indent}  ";
+        var propertyIndent = $"{itemIndent}  ";
+
+        for (var i = 0; i < cases.Count; i++)
+        {
+            var separator = i == cases.Count - 1 ? string.Empty : ",";
+            yield return $"{itemIndent}{{";
+            yield return $"{propertyIndent}\"condition\": \"{Escape(cases[i].Condition)}\",";
+            yield return $"{propertyIndent}\"value\": \"{Escape(cases[i].Value)}\"";
+            yield return $"{itemIndent}}}{separator}";
+        }
+    }
+
+    private static string Escape(string value) =>
+        value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal);
+}

--- a/tools/TemplateTfmSwitchGenerator/TemplateSwitchCase.cs
+++ b/tools/TemplateTfmSwitchGenerator/TemplateSwitchCase.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace TemplateTfmSwitchGenerator;
 
-public record TemplateSwitchCase([property: JsonPropertyName("condition")]string Condition, [property: JsonPropertyName("value")] string Value);
+public record TemplateSwitchCase(string Condition, string Value);

--- a/tools/TemplateTfmSwitchGenerator/TemplateTfms.cs
+++ b/tools/TemplateTfmSwitchGenerator/TemplateTfms.cs
@@ -1,0 +1,27 @@
+namespace TemplateTfmSwitchGenerator;
+
+/// <summary>
+/// Single source of truth for the target frameworks the templates emit.
+/// </summary>
+public static class TemplateTfms
+{
+    /// <summary>
+    /// Windows platform version appended to every Windows TFM the templates emit
+    /// (both the generated switch cases and the hand-written mirrors).
+    /// </summary>
+    public const string WindowsPlatformVersion = "10.0.26100";
+
+    public const string SingleProjectTfmsSymbol = "singleProjectTfms";
+
+    public static string[] Runtimes { get; } = ["net9.0", "net10.0"];
+
+    public static Platform[] Platforms { get; } =
+    [
+        new Platform("platforms == android", "platforms != android", "android"),
+        new Platform("platforms == ios", "platforms != ios", "ios"),
+        new Platform("platforms == windows", "platforms != windows", $"windows{WindowsPlatformVersion}"),
+        new Platform("platforms == wasm", "platforms != wasm", "browserwasm"),
+        new Platform("platforms == desktop", "platforms != desktop", "desktop"),
+        new Platform("useUnitTests == true", "useUnitTests == false", null)
+    ];
+}

--- a/tools/TemplateTfmSwitchGenerator/TextFile.cs
+++ b/tools/TemplateTfmSwitchGenerator/TextFile.cs
@@ -1,0 +1,23 @@
+using System.Text;
+
+namespace TemplateTfmSwitchGenerator;
+
+/// <summary>
+/// Reads and writes UTF-8 text files, preserving whether the original carried a BOM.
+/// </summary>
+public static class TextFile
+{
+    private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+    private static readonly UTF8Encoding Utf8Bom = new(encoderShouldEmitUTF8Identifier: true);
+
+    public static (string Text, bool HasBom) Read(string path)
+    {
+        var bytes = File.ReadAllBytes(path);
+        var hasBom = bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF;
+
+        return (Encoding.UTF8.GetString(hasBom ? bytes.AsSpan(3) : bytes), hasBom);
+    }
+
+    public static void Write(string path, string text, bool hasBom) =>
+        File.WriteAllText(path, text, hasBom ? Utf8Bom : Utf8NoBom);
+}

--- a/tools/TemplateTfmSwitchGenerator/WindowsTfmRewriter.cs
+++ b/tools/TemplateTfmSwitchGenerator/WindowsTfmRewriter.cs
@@ -1,0 +1,18 @@
+using System.Text.RegularExpressions;
+
+namespace TemplateTfmSwitchGenerator;
+
+/// <summary>
+/// Aligns hand-written Windows TFMs in the template content with
+/// <see cref="TemplateTfms.WindowsPlatformVersion"/>.
+/// </summary>
+public static partial class WindowsTfmRewriter
+{
+    public static string Rewrite(string content, string platformVersion) =>
+        WindowsTfm().Replace(content, match => $"-windows{platformVersion}{match.Groups["revision"].Value}");
+
+    // Matches the platform version of a Windows TFM, e.g. "-windows10.0.26100" or
+    // "-windows10.0.26100.0" - the optional revision is preserved as authored.
+    [GeneratedRegex(@"-windows\d+\.\d+\.\d+(?<revision>\.\d+)?")]
+    private static partial Regex WindowsTfm();
+}


### PR DESCRIPTION
## What cannot be validated yet

This is a **draft**. Windows App SDK 2.x is not reachable from this branch: `src/Uno.Sdk/packages.json`
still consumes a 6.8 `Uno.Sdk.Private`, `WinAppSdk` is listed in `.github/sdk-update-exclude.json` so the
updater will not move it, and `version.json` caps the updater's search below 7.0. Nothing here has been
built against Windows App SDK 2.x, and the Windows TFM floor has **not** been confirmed or moved — that
needs an empirical build once a 7.0 SDK is consumable.

**Must land upstream first**, before any of the 2.x work in this repo can be finished:

1. A 7.0 `Uno.Sdk.Private` (carrying the 2.x `packages.json`) reachable from this branch — which also
   needs `version.json` moved to `7.0-dev.{height}` and the rest of the package groups retargeted
   together, otherwise generated apps stop restoring.
2. The `WinAppSdk` exclusion lifted once (1) holds.

So this PR deliberately lands only the mechanical, reviewable part.

## What this changes

The Windows platform version the templates emit was hardcoded in
`tools/TemplateTfmSwitchGenerator/Program.cs` and then fanned out into 64 generated switch cases in
`src/Uno.Templates/content/unoapp/.template.config/template.json` plus three hand-written mirrors
(`.run/MyExtensionsApp.1.run.xml`, `MyExtensionsApp.1.MauiControls.csproj`,
`unolib/CrossTargetedLibrary.csproj`) that the generator did not touch. Moving the floor meant editing
four files by hand, and the generator's output had to be pasted into `template.json` manually because it
wrote a bare `template.json` containing only the serialized case array into its working directory.

Now `tools/TemplateTfmSwitchGenerator/TemplateTfms.cs` is the single source of truth — Windows platform
version, runtimes and platform conditions — and the tool applies it everywhere:

- `template.json` is **patched in place**: only the `singleProjectTfms` `cases` array is replaced, and the
  rest of the file (comments, formatting, line endings, BOM) is preserved byte for byte. No more manual
  paste step.
- Every hand-written Windows TFM under `src/Uno.Templates/content` is rewritten to match, preserving the
  authored revision suffix (the `.run.xml` uses `-windows<version>.0`, the csprojs use `-windows<version>`).
- `--check` reports drift without writing and exits non-zero, so the invariant can be enforced later.

Changing the floor for 2.x then becomes a one-line edit plus a regeneration, instead of a 64-case
find-and-replace.

**There is no template content change in this PR.** Regenerating at the current `10.0.26100` floor is a
byte-identical no-op, which is the proof that the tool reproduces what is on the branch today. That also
keeps this out of the way of the other in-flight PRs touching `template.json`.

## Verification performed

- `dotnet build tools/TemplateTfmSwitchGenerator -c Release` — succeeds, 0 warnings.
- `dotnet format tools/TemplateTfmSwitchGenerator/TemplateTfmSwitchGenerator.csproj --verify-no-changes` — clean.
- `dotnet run --project tools/TemplateTfmSwitchGenerator` on a clean tree — reports 128 generated cases
  and writes nothing; `git status` stays clean. Byte-identical regeneration.
- Round trip: set the constant to a throwaway `10.0.99999`, regenerated → exactly the four expected files
  changed (64 case values in `template.json`, one line in each mirror, `.0` revision suffix preserved in
  the `.run.xml`); set it back to `10.0.26100`, regenerated → tree clean again.
- The `template.json` written by the patcher parses as JSONC (`JsonCommentHandling.Skip`,
  `AllowTrailingCommas`, i.e. the template engine's own tolerance — the existing `//` comments are
  untouched) with 128 cases, 64 of them carrying a Windows TFM.
- `--check` against a deliberately drifted `.run.xml` reports the file and exits 1; against a clean tree
  exits 0.
- `dotnet pack src/Uno.Templates/Uno.Templates.csproj -c Release` — succeeds.
- Installed that package into an isolated `DOTNET_CLI_HOME` and instantiated:
  `dotnet new unoapp -tfm net10.0 -platforms windows -platforms desktop -platforms android`
  → `net10.0-android;net10.0-windows10.0.26100;net10.0-desktop`, and `dotnet new unolib -tfm net10.0`
  → `net10.0;net10.0-ios;net10.0-android;net10.0-windows10.0.26100;net10.0-browserwasm;net10.0-desktop`.

**Not verified:** anything involving Windows App SDK 2.x. No generated app was restored or built (the
template's `dotnet restore` post-action fails on this branch for unrelated reasons — no 7.0 SDK on the
feed), nothing was launched via `dotnet run`, no MSIX was produced or installed, and the
`windows-template-tests` CI leg was not exercised (CI does not trigger on this branch).

## Deliberately not included

- **No `WinAppSdk` version bump in `src/Uno.Sdk/packages.json`.** A 2.x version is not on the feed for this
  branch, and bumping it would break restore for everyone here. It is also inseparable from moving the Core
  group to 7.0 and retargeting the Themes/Toolkit/Extensions/Hot Design groups with it — that belongs in the
  ecosystem retarget, not here.
- **No change to the `10.0.26100` floor itself.** Whether 2.x needs a higher Windows platform version can
  only be settled by building a generated Windows head against a 7.0 SDK. The point of this PR is that when
  the answer is known, moving it is a one-line change.
- **No CI / updater trigger changes, no `version.json`, no `nuget.config`** — owned by other in-flight PRs.
- **No docs, runtime-installer or MSIX manifest updates** — those depend on the confirmed 2.x version.

Relates to https://github.com/unoplatform/uno-private/issues/2291

🤖 Generated with [Claude Code](https://claude.com/claude-code)
