### PR TITLE
feat(templates)!: make Skia the only renderer choice

### DIFF
--- a/.github/actions/ci/generate-test-matrix/action.yml
+++ b/.github/actions/ci/generate-test-matrix/action.yml
@@ -17,8 +17,8 @@ runs:
             # The format is "TestName;[PlatformFilter];TemplateName;Arguments"
             # macOS is generally not selected unless building the whole targets list, because of expensive CI
 
-            "NativeRecommended;;unoapp;-skip --renderer native -preset=recommended",
-            "NativeBlank;;unoapp;-skip --renderer native -preset=blank",
+            "SkiaExplicitRecommended;;unoapp;-skip --renderer skia -preset=recommended",
+            "SkiaExplicitBlank;;unoapp;-skip --renderer skia -preset=blank",
 
             "DefaultArgs;;unoapp;-skip ",
             "Recommended;;unoapp;-skip -preset recommended",
@@ -47,10 +47,10 @@ runs:
 
             "mauilib_MacOS;macOS;unomauilib;"
             "unolib_MacOS;macOS;unolib;"
-            "unolibNative_MacOS;macOS;unolib;--renderer native"
+            "unolibSkia_MacOS;macOS;unolib;--renderer skia"
             "mauilib_Windows;Windows;unomauilib;"
             "unolib_Windows;Windows;unolib;"
-            "unolibNative_Windows;Windows;unolib;--renderer native"
+            "unolibSkia_Windows;Windows;unolib;--renderer skia"
 
             # Disabling this test for now as it was specific to net7
             # https://github.com/unoplatform/uno.templates/issues/22

--- a/src/Uno.Templates/content/unoapp/.template.config/TemplateWizard.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/TemplateWizard.json
@@ -10,20 +10,7 @@
 			"NavigationId": "Platforms",
 			"Description": "Select which platforms the application is going to target",
 			"Tag": {
-				"Requires": {
-					"renderer": {
-						"RequiredValues": [
-							{
-								"value": "native",
-								"display": "Native"
-							},
-							{
-								"value": "skia",
-								"display": "Skia"
-							}
-						]
-					}
-				}
+				"Value": "Skia"
 			}
 		},
 		{
@@ -242,11 +229,6 @@
 				// This feature will be re-enabled once multi-threading becomes available again.
 				//"SymbolIds": [ "toolkit", "mauiEmbedding", "server", "wasmMultiThreading", "wasmPwaManifest", "vscode", "enableDeveloperMode", "mediaElement" ]
 				"SymbolIds": [ "sample", "toolkit", "shell", "mauiEmbedding", "server", "wasmPwaManifest", "vscode", "enableDeveloperMode", "mediaPlayerElement" ]
-			}
-			,
-			{
-				"SectionType": "SingleSelect",
-				"SymbolId": "renderer"
 			}
 		],
 		"Framework": [
@@ -583,39 +565,13 @@
 		"platforms.android": {
 			"Icon": "/Assets/Platforms.Android.svg",
 			"Tag": {
-				"Requires": {
-					"renderer": {
-						"RequiredValues": [
-							{
-								"value": "native",
-								"display": "Native"
-							},
-							{
-								"value": "skia",
-								"display": "Skia"
-							}
-						]
-					}
-				}
+				"Value": "Skia"
 			}
 		},
 		"platforms.ios": {
 			"Icon": "/Assets/Platforms.iOS.svg",
 			"Tag": {
-				"Requires": {
-					"renderer": {
-						"RequiredValues": [
-							{
-								"value": "native",
-								"display": "Native"
-							},
-							{
-								"value": "skia",
-								"display": "Skia"
-							}
-						]
-					}
-				}
+				"Value": "Skia"
 			}
 		},
 		"platforms.desktop": {
@@ -627,20 +583,7 @@
 		"platforms.wasm": {
 			"Icon": "/Assets/Platforms.Wasm.svg",
 			"Tag": {
-				"Requires": {
-					"renderer": {
-						"RequiredValues": [
-							{
-								"value": "native",
-								"display": "Native"
-							},
-							{
-								"value": "skia",
-								"display": "Skia"
-							}
-						]
-					}
-				}
+				"Value": "Skia"
 			}
 		},
 		"platforms.windows": {
@@ -730,9 +673,6 @@
 		},
 		"renderer.skia": {
 			"Icon": "/Assets/Features.SkiaRendering.svg"
-		},
-		"renderer.native": {
-			"Icon": "/Assets/Features.NativeRendering.svg"
 		},
 		"vscode": {
 			"Icon": "/Assets/Features.VSCode.svg"

--- a/src/Uno.Templates/content/unoapp/.template.config/template.json
+++ b/src/Uno.Templates/content/unoapp/.template.config/template.json
@@ -383,7 +383,7 @@
     },
     "renderer": {
       "displayName": "Renderer",
-      "description": "Controls the renderer used for iOS, Android, and WebAssembly targets",
+      "description": "Controls the renderer used for iOS, Android, and WebAssembly targets. Skia is the only renderer available.",
       "type": "parameter",
       "datatype": "choice",
       "allowMultipleValues": false,
@@ -394,11 +394,6 @@
           "choice": "skia",
           "description": "Use Skia based rendering for mobile and web",
           "displayName": "Skia"
-        },
-        {
-          "choice": "native",
-          "description": "Use native APIs based renderer",
-          "displayName": "Native"
         }
       ]
     },
@@ -406,11 +401,6 @@
       "type": "computed",
       "datatype": "bool",
       "value": "(renderer == 'skia')"
-    },
-    "useNativeRenderer": {
-      "type": "computed",
-      "datatype": "bool",
-      "value": "(renderer == 'native')"
     },
     "server": {
       "displayName": "Server",

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -112,9 +112,7 @@
       <!--#if (useThemeService)-->
       ThemeService;
       <!--#endif-->
-      <!--#if (useSkiaRenderer)-->
       SkiaRenderer;
-      <!--#endif-->
       <!--#if (useAndroidTV)-->
       AndroidTV;
       <!--#endif-->

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/Android/Main.Android.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/Android/Main.Android.cs
@@ -9,11 +9,6 @@ using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Microsoft.UI.Xaml.Media;
-//+:cnd:noEmit
-#if (!useSkiaRenderer)
-using Com.Nostra13.Universalimageloader.Core;
-#endif
-//-:cnd:noEmit
 
 namespace MyExtensionsApp._1.Droid;
 
@@ -43,27 +38,6 @@ public class Application : Microsoft.UI.Xaml.NativeApplication
     public Application(IntPtr javaReference, JniHandleOwnership transfer)
         : base(() => new App(), javaReference, transfer)
     {
-//+:cnd:noEmit
-#if (!useSkiaRenderer)
-        ConfigureUniversalImageLoader();
-#endif
-//-:cnd:noEmit
     }
-
-//+:cnd:noEmit
-#if (!useSkiaRenderer)
-    private static void ConfigureUniversalImageLoader()
-    {
-        // Create global configuration and initialize ImageLoader with this config
-        ImageLoaderConfiguration config = new ImageLoaderConfiguration
-            .Builder(Context)
-            .Build();
-
-        ImageLoader.Instance.Init(config);
-
-        ImageSource.DefaultImageLoader = ImageLoader.Instance.LoadImageAsync;
-    }
-#endif
-//-:cnd:noEmit
 }
 

--- a/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/Android/Main.Android.cs
+++ b/src/Uno.Templates/content/unoapp/MyExtensionsApp.1/Platforms/Android/Main.Android.cs
@@ -8,7 +8,6 @@ using Android.OS;
 using Android.Runtime;
 using Android.Views;
 using Android.Widget;
-using Microsoft.UI.Xaml.Media;
 
 namespace MyExtensionsApp._1.Droid;
 

--- a/src/Uno.Templates/content/unolib/.template.config/template.json
+++ b/src/Uno.Templates/content/unolib/.template.config/template.json
@@ -73,8 +73,7 @@
     "enableQuotelessLiterals": true,
     "defaultValue": "skia",
     "choices": [
-      { "choice": "skia",   "displayName": "Skia" },
-      { "choice": "native", "displayName": "Native" }
+      { "choice": "skia",   "displayName": "Skia" }
     ]
   },
   "useSkiaRenderer": {

--- a/src/Uno.Templates/content/unolib/.template.config/template.json
+++ b/src/Uno.Templates/content/unolib/.template.config/template.json
@@ -67,20 +67,23 @@
       "defaultValue": "true"
     },
     "renderer": {
-    "type": "parameter",
-    "datatype": "choice",
-    "allowMultipleValues": false,
-    "enableQuotelessLiterals": true,
-    "defaultValue": "skia",
-    "choices": [
-      { "choice": "skia",   "displayName": "Skia" }
-    ]
-  },
-  "useSkiaRenderer": {
-    "type": "computed",
-    "datatype": "bool",
-    "value": "(renderer == 'skia')"
-  }
+      "type": "parameter",
+      "datatype": "choice",
+      "allowMultipleValues": false,
+      "enableQuotelessLiterals": true,
+      "defaultValue": "skia",
+      "choices": [
+        {
+          "choice": "skia",
+          "displayName": "Skia"
+        }
+      ]
+    },
+    "useSkiaRenderer": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "(renderer == 'skia')"
+    }
   },
   "primaryOutputs": [
     {

--- a/src/Uno.Templates/content/unolib/CrossTargetedLibrary.csproj
+++ b/src/Uno.Templates/content/unolib/CrossTargetedLibrary.csproj
@@ -14,9 +14,7 @@
     -->
     
     <UnoFeatures>
-    <!--#if (useSkiaRenderer)-->
       SkiaRenderer;
-    <!--#endif-->
     </UnoFeatures>
   </PropertyGroup>
 


### PR DESCRIPTION
## What this changes

The `renderer` parameter exposed by `dotnet new unoapp` / `dotnet new unolib` (and by the IDE wizard through `TemplateWizard.json`) no longer offers a `native` choice. Skia is the only renderer the templates can scaffold.

The `renderer` parameter itself is deliberately **kept** with a single `skia` choice rather than deleted. CI legs and user scripts pass `--renderer skia` explicitly; removing the symbol would turn those invocations into an unknown-parameter hard error, whereas reducing the choice set keeps them working and simply makes the picker honest.

### Template contract

- `unoapp/.template.config/template.json` — removed the `native` choice from `renderer`, removed the now-unreachable `useNativeRenderer` computed symbol, and clarified the parameter description.
- `unolib/.template.config/template.json` — removed the `native` choice.
- `dotnetcli.host.json` is unchanged, so `-renderer` / `--renderer` keeps its existing long and short names.

### Wizard data contract

- `unoapp/.template.config/TemplateWizard.json` — the Platforms navigation element and the `platforms.android` / `platforms.ios` / `platforms.wasm` entries now carry a flat `"Tag": { "Value": "Skia" }`, which is exactly how `platforms.desktop` was already written. The `renderer.native` icon entry and the single-choice `renderer` `SingleSelect` section are removed (a one-option picker is dead UI). The `renderer` symbol stays in `ExportableSymbols` and the presets still pass `"renderer": "skia"`.

### Template content

- `MyExtensionsApp.1.csproj` and `CrossTargetedLibrary.csproj` — the `SkiaRenderer` UnoFeature is emitted unconditionally instead of behind `<!--#if (useSkiaRenderer)-->`. The feature itself is retained: the SDK still needs it to select the Skia runtime packages.
- `Platforms/Android/Main.Android.cs` — removed the three `#if (!useSkiaRenderer)` regions (the `Com.Nostra13.Universalimageloader.Core` import, the `ConfigureUniversalImageLoader()` call, and the method itself). That code only ever ran on the native renderer.

### CI matrix

- `.github/actions/ci/generate-test-matrix/action.yml` — the four validations that passed `--renderer native` would now hard-fail on an out-of-range choice value. They are retargeted to explicit `--renderer skia` (`SkiaExplicitRecommended`, `SkiaExplicitBlank`, `unolibSkia_MacOS`, `unolibSkia_Windows`) rather than deleted, so matrix size is unchanged and the surviving parameter value stays covered.

## Deliberately out of scope

- **No package version changes.** `src/Uno.Sdk/packages.json` and `version.json` are untouched; the templates still restore against the currently pinned package set. Bumping to 7.0 previews is a separate, still-blocked change.
- **`Uno.UniversalImageLoader` stays in `src/Uno.Sdk/packages.json`.** That manifest is injected by the shipping SDK for all consumers, not just this template, so removing the entry would break users still on the native renderer. It should only be dropped once no supported SDK line offers that renderer.
- **`useSkiaRenderer` computed symbol is kept** even though nothing references it any more. It is harmless, and keeping it avoids breaking any renderer-conditional content added on a parallel 7.0 branch.

## Verification actually performed

All of the following were run locally on this branch:

- `dotnet pack src/Uno.Templates/Uno.Templates.csproj -c Release` — succeeded.
- Installed the packed `.nupkg` into an isolated template store and ran:
  - `dotnet new unoapp -skip` (default) — OK
  - `dotnet new unoapp -skip --renderer skia -preset recommended` — OK
  - `dotnet new unoapp -skip -platforms android ios wasm desktop` — OK, generated TFMs are still `net10.0-android;net10.0-ios;net10.0-browserwasm;net10.0-desktop`, unchanged by this PR
  - `dotnet new unolib` and `dotnet new unolib --renderer skia` — OK
  - `dotnet new unoapp --renderer native` and `dotnet new unolib --renderer native` — both now **rejected**: `'native' is not a valid value for --renderer. The possible values are: skia`
- Generated apps inspected: `SkiaRenderer;` is present in `<UnoFeatures>` for both templates; the generated `Main.Android.cs` no longer contains any Universal Image Loader code.
- Restored **and built** a generated desktop-head app (`-platforms desktop`) and a generated Android-head app (`-platforms android`), both pinned to a published `Uno.Sdk` — `Build succeeded. 0 Warning(s) 0 Error(s)` in both cases. The Android build is what proves the edited `Main.Android.cs` still compiles.
- All four touched/adjacent JSON files (`unoapp` `template.json`, `TemplateWizard.json`, `unolib` `template.json`, `dotnetcli.host.json`) parsed with a JSONC-tolerant parser (comments and trailing commas allowed — existing comments were left intact).
- `generate-test-matrix/action.yml` parsed with `yaml.safe_load`.

## What was NOT verified

- **The repo CI will not run on this PR.** `.github/workflows/ci.yml` only triggers on `main` and `release/**`; enabling it for feature branches is a separate in-flight change. So the ~100-leg template matrix has not executed against these edits. A `workflow_dispatch` run against this branch would be the way to confirm.
- I did not build the iOS or WebAssembly heads locally, only desktop and Android.
- The generated apps were pinned to a published `Uno.Sdk` for the restore/build check, because a locally packed `Uno.Templates` stamps a `1.0.0` SDK version that does not exist on any feed. The dev-feed `6.8.0-dev` package set was not exercised locally.
- `TemplateWizard.json` is consumed by the VS wizard living in a separate repo. Removing the `renderer` `SingleSelect` section and the `native` choice needs a heads-up to that repo's owners in case the wizard hard-fails on a missing `SymbolId`. I could not test the wizard from here.
- `.github/actions/ci/run-tests/action.yml` line ~298 still gates a `net8.0` skip on `--renderer native`. That file is owned by another in-flight PR so I left it alone; it is currently dead code either way, because `generate-test-matrix` only emits `net9.0` and `net10.0` legs.
- `dotnet format` was not run on `Main.Android.cs`: it is template content containing `#if` symbols that are not real C# preprocessor symbols and it is not part of any compiled project in this repo. The 0-warning Android head build above is the substitute check.

## Merge notes

This is a **breaking** change to the template/picker contract and is intentionally targeted at `feature/7.0`. It must not be merged to `main` or any `release/**` branch, where dropping the native renderer would be an unannounced regression for 6.x users.

`template.json` is also edited by two other in-flight 7.0 PRs (windows TFM floor, iOS scene manifest). The edits here are confined to the `renderer` / `useNativeRenderer` symbol block, so the three should merge cleanly.

Relates to https://github.com/unoplatform/uno-private/issues/2118

🤖 Generated with [Claude Code](https://claude.com/claude-code)
