### PR TITLE
chore(sdk): Uno.Sdk update — Hot Design 1.20.443

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -141,7 +141,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "hotdesign",
-    "version": "1.20.434",
+    "version": "1.20.443",
     "packages": [
       "Uno.UI.HotDesign"
     ]

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -94,7 +94,7 @@
   },
   {
     "group": "hotdesign",
-    "version": "1.20.434",
+    "version": "1.20.443",
     "packages": [
       "Uno.UI.HotDesign"
     ]


### PR DESCRIPTION
Bumps the Hot Design entry in the Uno.Sdk manifest from 1.20.434 to **1.20.443**, which is on the unoplatformdev feed (build [230366](https://dev.azure.com/uno-platform/uno-private/_build/results?buildId=230366&view=results)).

- `src/Uno.Sdk/packages.json`: `hotdesign` 1.20.434 → 1.20.443
- `src/Uno.Sdk/ReadMe.md`: same

Every other group in the manifest is already at its current stable (Core 6.7.65, CSharpMarkup 6.7.7, settings 1.13.4, AppMcp 1.3.2, Themes 7.1.1, Toolkit 9.1.3, Extensions 7.3.1).

Part of the 6.7 release cascade — tracked in unoplatform/private#1105. A follow-up Uno.Sdk update will be needed once the core-6.7.65 rebuilds land (unoplatform/uno.csharpmarkup#901, unoplatform/uno.app-mcp#141, unoplatform/uno.hotdesign#7889).