### PR TITLE
chore(sdk): unpin Hot Design now that Uno 6.7 is on nuget.org

### DIFF
--- a/.github/sdk-update-exclude.json
+++ b/.github/sdk-update-exclude.json
@@ -6,12 +6,6 @@
     // (backport status, not in our control: mono/SkiaSharp#4031).
     "SkiaSharp",
     "SvgSkia",
-    "WinAppSdk",
-    // Hot Design held at 1.21.0-dev.2398: builds >= 1.21.0-dev.2411 depend on the unreleased
-    // Uno 6.7 release bits (Uno.WinUI 6.7.16, Themes 7.1.1, Toolkit 9.1.3) which are internal-only
-    // until the 6.7 release ships (unoplatform/private#1105), so publishing fails the nuget.org
-    // dependency check. Studio Live is unaffected (it pins UnoHotDesignVersion itself).
-    // Remove this exclude and re-bump once Uno 6.7 is live on nuget.org.
-    "hotdesign"
+    "WinAppSdk"
   ]
 }


### PR DESCRIPTION
Closes the post-release task from [unoplatform/private#1105](https://github.com/unoplatform/private/issues/1105#issuecomment-5332440907).

Hot Design was excluded from the SDK auto-updater in #2218 because builds >= `1.21.0-dev.2411` depend on the then-unreleased Uno 6.7 bits, which failed the nuget.org dependency check.

**6.7 is now live on nuget.org**, so that blocker is gone — verified against the nuget.org flat container:

| Dependency of `Uno.UI.HotDesign` | Declared | On nuget.org |
|---|---|---|
| `Uno.WinUI` (+ `DevServer`, `DevServer.Messaging`, `Lottie`) | `>= 6.7.16` | `6.7.65` ✅ |
| `Uno.Themes.WinUI` | `7.1.1` | `7.1.1` ✅ |
| `Uno.Toolkit.WinUI` | `9.1.3` | `9.1.3` ✅ |
| `Uno.Core.Extensions.Logging.Singleton` | `4.1.1` | `4.1.1` ✅ |

This PR only removes the `hotdesign` entry (and its now-stale comment) from `.github/sdk-update-exclude.json`. The version bump in `src/Uno.Sdk/packages.json` is deliberately left to the SDK updater, so `hotdesign` moves with the same logic as every other group — currently pinned at `1.21.0-dev.2398`, latest on the dev feed is `1.22.0-dev.43`.

The `SkiaSharp` / `SvgSkia` / `WinAppSdk` excludes are untouched.