### PR TITLE
chore(ci): Freeze first-party groups in the Uno.Sdk updater for 7.0 (6.7)

### DIFF
--- a/.github/sdk-update-exclude.json
+++ b/.github/sdk-update-exclude.json
@@ -6,6 +6,27 @@
     // (backport status, not in our control: mono/SkiaSharp#4031).
     "SkiaSharp",
     "SvgSkia",
-    "WinAppSdk"
+    "WinAppSdk",
+
+    // --- Uno Platform 7.0 freeze ---
+    // Held while 7.0 publishes to nuget.org. The updater cannot tell a 7.0-only release from a
+    // servicing one: IsCompatibleWithUnoWinUI compares the *minimum* Uno.WinUI version a nuspec
+    // declares (a 7.0 package still floors at 6.x), many of these declare no Uno dependency at all,
+    // and Uno.Sdk.* is never validated. The minor+1 bound is skipped on a prerelease Uno.Sdk.Private.
+    // uno-updater.yml auto-merges unattended -> unfreeze per group as each library ships for 7.0.
+    "Themes",
+    "Toolkit",
+    "Extensions",
+    "CSharpMarkup",
+    "Resizetizer",
+    "UnoFonts",
+    "settings",
+    "hotdesign",
+    "AppMcp",
+    "sdkextras",
+    "CoreLogging",
+    "OSLogging",
+    "WasmBootstrap",
+    "Dsp"
   ]
 }


### PR DESCRIPTION
**GitHub Issue:** relates to unoplatform/uno-private#2067

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes
- Project automation

## What is the current behavior?

`.github/workflows/uno-updater.yml` runs on `cron: '0 */6 * * *'`. It runs `tools/Uno.Sdk.Updater` against `src/Uno.Sdk/packages.json`, opens a PR through `peter-evans/create-pull-request`, and then immediately calls `enable-pull-request-automerge`. There is no human gate on that path.

`.github/sdk-update-exclude.json` listed only third-party groups (`SkiaSharp`, `SvgSkia`, `WinAppSdk`) — **not one first-party group**. Now that Uno Platform 7.0 packages are publishing to nuget.org, nothing left in the updater can tell a 7.0-only release apart from a servicing one:

1. **`IsCompatibleWithUnoWinUI` tests a floor, not a ceiling.** It reads the `Uno.WinUI` dependency out of the candidate's nuspec and asserts `UnoVersion >= unoWinUIVersion`. NuGet dependency versions are *minimums*, and a package that moves to 7.0 keeps a 6.x floor. `Uno.WinUI.Markup 7.0.0-dev.5` declares `Uno.WinUI 6.7.0-dev.41`, so it passes against a 6.x SDK. This check can never detect a package that has moved forward.
2. **Several first-party packages are never checked at all.** `Uno.Fonts.*`, `Uno.Resizetizer`, `Uno.Settings.DevServer` and `Uno.Dsp.Tasks` declare no `Uno` dependency in their nuspec, so `IsCompatibleWithUnoWinUI` returns `true` unconditionally. `Uno.Sdk.Extras` is skipped outright, because `RequiresValidation` excludes any id starting with `Uno.Sdk`.
3. **The `minor+1` upper bound is conditional.** In `NuGetApiClient.GetVersionAsync` it is applied only `if (UnoVersion.HasValue && !UnoVersion.Value.IsPreview)` — so on a prerelease `Uno.Sdk.Private` line there is no upper bound whatsoever. Where it does apply, it bounds the *dependency's own* version numbering, which says nothing about Uno major compatibility.

The `majorUpgradeDisabledGroups` list in `Program.cs` covers only `SkiaSharp`, `WasmBootstrap`, `MicrosoftLoggingConsole`, `WindowsCompatibility` and `Maui` — no first-party UI group.

### Evidence (Runtime)

I ran the updater itself against this servicing line, unmodified:

```
NBGV_SemVer2=6.7.999 dotnet run -c Release --project tools/Uno.Sdk.Updater \
  -- --exclude-file ".github/sdk-update-exclude.json"
```

It resolves `Uno.Sdk.Private` 6.7.103 and today reports `No changes were made to the Uno.Sdk.` — **so this branch is not currently mis-resolving anything, and this PR is preventive.** It is worth being precise about why it is safe today, because the reason is weaker than it looks.

The only thing holding the line is the `minor+1` numeric bound, which is a heuristic over each dependency's *own* version numbering. It happens to block the current 7.0 builds because they sit two minors out (`Themes` 7.1.1 vs 8.0.0-dev.3, `Toolkit` 9.1.3 vs 9.2.0-dev.19). It stops holding the moment a 7.0-compatible release lands *within the next minor* of that line, and two groups are already positioned for exactly that:

- `Resizetizer` is pinned here at `1.13.0-dev.17` — the same preview `main` carries. When `Uno.Resizetizer 1.13.0` ships, this branch takes it: it is below the `1.14.0` bound, stable versions are preferred over dev builds, and the package declares no nuspec dependencies at all, so validation returns `true` unconditionally.
- `sdkextras` is pinned here at `6.4.0-dev.13`, likewise matching `main`. `Uno.Sdk.Extras` is skipped by `RequiresValidation` entirely, so nothing checks it.

For the same reason, the validation step contributes nothing on this branch: the one rejection it does log (`Uno.Extensions.Authentication.WinUI 7.4.0-dev.29 is not a valid dependency`) lands only because that package's `Uno.WinUI` floor happens to have moved to 6.8. A 7.0 package that keeps a 6.x floor sails through.

With this PR's exclude list applied, the run logs `Loaded 17 exclusion(s)` and `Skipping '<group>' due to exclusion list.` for all 14 new groups.

## What is the new behavior?

The first-party groups are added to `.github/sdk-update-exclude.json`, so `UpdateGroup` short-circuits them and leaves their pinned versions alone.

Exclusions are matched in `Program.cs` as `ExcludeConfig.Excluded.Contains(group.Group)`, against a `HashSet<string>(StringComparer.OrdinalIgnoreCase)` — an exact, case-insensitive match on the **`group` name** in `packages.json`, not on a package id and not a prefix. Every added entry is a group name that exists in this branch's `packages.json`.

Groups added (14): `Themes`, `Toolkit`, `Extensions`, `CSharpMarkup`, `Resizetizer`, `UnoFonts`, `settings`, `hotdesign`, `AppMcp`, `sdkextras`, `CoreLogging`, `OSLogging`, `WasmBootstrap`, `Dsp`.

Deliberately **not** frozen:

- **`Core`** — this is the `Uno.Sdk.Private` version itself, already bounded by `UpdaterBuildContext.MinVersion`/`MaxVersion`. Freezing it would defeat the updater entirely.
- **`UniversalImageLoading`** — `Uno.UniversalImageLoader`, a repackaged third-party Android image loader on a dormant stable-only `1.9.x` line, not part of the 7.0 release train.
- **`Prism`** — third-party, and its packages do carry a real `Uno.WinUI` nuspec dependency.

**This is a holding measure, not a permanent pin.** Each group should be unfrozen individually as that library ships its 7.0-compatible release — not all at once.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Associated with an issue (GitHub or internal)

## Other information

Existing entries and their explanatory comments are preserved, and the file keeps its JSON-with-comments style (the updater parses it with `JsonCommentHandling.Skip`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vRaBaNK2HnyWeg3TBzEu6
