### PR TITLE
feat!: Move the WinAppSdk group to 2.4.0

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -17,7 +17,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | UnoResizetizerVersion | 1.13.0-dev.17 |
 | SkiaSharpVersion | 3.119.2 |
 | SvgSkiaVersion | 3.0.6 |
-| WinAppSdkVersion | 1.7.250909003 |
+| WinAppSdkVersion | 2.4.0 |
 | WinAppSdkBuildToolsVersion | 10.0.28000.2705 |
 | WinAppSdkBuildToolsWinAppVersion | 0.6.1 |
 | MicrosoftLoggingVersion** | 9.0.19 |
@@ -168,7 +168,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "WinAppSdk",
-    "version": "1.7.250909003",
+    "version": "2.4.0",
     "packages": [
       "Microsoft.WindowsAppSDK"
     ]

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -121,7 +121,7 @@
   },
   {
     "group": "WinAppSdk",
-    "version": "1.7.250909003",
+    "version": "2.4.0",
     "packages": [
       "Microsoft.WindowsAppSDK"
     ]


### PR DESCRIPTION
GitHub Issue (If applicable): relates to unoplatform/uno-private#2297

## PR Type

- Feature
- Build or CI related changes

## What is the current behavior?

The shipped `Uno.Sdk` manifest pins `Microsoft.WindowsAppSDK` at **1.7.250909003**, while `unoplatform/uno` builds and tests against **2.4.0**:

| Project in `unoplatform/uno` (on `master` today) | Pinned |
|---|---|
| `SamplesApp/SamplesApp.csproj:213` | 2.3.1 |
| `Uno.UI.RuntimeTests.Windows.csproj:65` | 2.3.1 |
| `Uno.UI.Extras.Windows.csproj:72` | 2.3.1 |
| `Uno.WinAppSDKSyncGenerator.References.csproj:15` | 2.3.1 |

unoplatform/uno#24378 moves all of those to 2.4.0 as well. So an app built on the Windows head gets a WinAppSDK a **full major behind** the surface Uno is validated against. `WinAppSdk` sits in `.github/sdk-update-exclude.json`, so the updater can never move it — it only changes by hand, which is why the gap has persisted.

## What is the new behavior?

The `WinAppSdk` group moves to **2.4.0**, matching unoplatform/uno#24378 which puts core on the same version uniformly.

**Why 2.4.0.** Core is moving to the same version in unoplatform/uno#24378, which also fixes a `1.0.0` WinAppSDK floor that `Uno.WinUI`'s nuspec has been publishing. Landing both together is what makes the version uniform end to end; landing this one alone would ship customers a version core has not built against, so **these two should merge together**.

`ReadMe.md` is updated in lockstep (the version table row and its embedded copy of the manifest); the embedded manifest was verified byte-identical to `packages.json` after the edit.

## Validation

**Inspection + consistency check only.** No build was run: this is a version-table change whose effect is on generated customer apps, which is what the template test matrix in CI exercises. Treat CI on this PR as the real validation — in particular the Windows test groups.

Worth a reviewer's attention: this is a **major** WinAppSDK move for every consuming app, so the Windows groups going green is the load-bearing signal here.

## PR Checklist

- [ ] Tested code with current supported SDKs
- [ ] Docs have been added/updated
- [ ] Unit Tests and/or UI Tests
- [ ] Wasm UI Tests unaffected
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (internal)

**Breaking change:** yes, for Windows-head apps — a WinAppSDK major. Intentional for the 7.0 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vRaBaNK2HnyWeg3TBzEu6

