### PR TITLE
feat!: Sweep the AndroidX and Material bindings to current

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -247,7 +247,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.Google.Android.Material"
     ],
     "versionOverride": {
-      "net10.0": "1.12.0.5"
+      "net10.0": "1.14.0.6"
     }
   },
   {
@@ -257,7 +257,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.AndroidX.Legacy.Support.V4"
     ],
     "versionOverride": {
-      "net10.0": "1.0.0.33"
+      "net10.0": "1.0.0.37"
     }
   },
   {
@@ -267,7 +267,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.AndroidX.Core.SplashScreen"
     ],
     "versionOverride": {
-      "net10.0": "1.0.1.14"
+      "net10.0": "1.2.0.3"
     }
   },
   {
@@ -277,7 +277,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.AndroidX.AppCompat"
     ],
     "versionOverride": {
-      "net10.0": "1.7.1.1"
+      "net10.0": "1.8.0"
     }
   },
   {
@@ -287,7 +287,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.AndroidX.RecyclerView"
     ],
     "versionOverride": {
-      "net10.0": "1.4.0.3"
+      "net10.0": "1.4.0.6"
     }
   },
   {
@@ -297,7 +297,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.AndroidX.Activity"
     ],
     "versionOverride": {
-      "net10.0": "1.10.1.3"
+      "net10.0": "1.13.0.1"
     }
   },
   {
@@ -307,7 +307,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.AndroidX.Browser"
     ],
     "versionOverride": {
-      "net10.0": "1.8.0.11"
+      "net10.0": "1.10.0.1"
     }
   },
   {
@@ -317,7 +317,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.AndroidX.SwipeRefreshLayout"
     ],
     "versionOverride": {
-      "net10.0": "1.1.0.29"
+      "net10.0": "1.2.0.3"
     }
   },
   {
@@ -327,7 +327,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.AndroidX.Leanback"
     ],
     "versionOverride": {
-      "net10.0": "1.0.0.31"
+      "net10.0": "1.2.0.4"
     }
   },
   {
@@ -337,7 +337,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.AndroidX.Car.App.App"
     ],
     "versionOverride": {
-      "net10.0": "1.4.0.3"
+      "net10.0": "1.7.0.4"
     }
   },
   {
@@ -347,7 +347,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.AndroidX.Wear"
     ],
     "versionOverride": {
-      "net10.0": "1.3.0.15"
+      "net10.0": "1.4.0.2"
     }
   },
   {
@@ -357,7 +357,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.AndroidX.Wear.Tiles"
     ],
     "versionOverride": {
-      "net10.0": "1.4.1"
+      "net10.0": "1.6.2"
     }
   },
   {
@@ -370,7 +370,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.AndroidX.Navigation.Common"
     ],
     "versionOverride": {
-      "net10.0": "2.9.2.1"
+      "net10.0": "2.9.8.1"
     }
   },
   {
@@ -381,7 +381,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.AndroidX.Collection.Ktx"
     ],
     "versionOverride": {
-      "net10.0": "1.5.0.3"
+      "net10.0": "1.6.0.1"
     }
   },
   {

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -200,7 +200,7 @@
       "Xamarin.Google.Android.Material"
     ],
     "versionOverride": {
-      "net10.0": "1.12.0.5"
+      "net10.0": "1.14.0.6"
     }
   },
   {
@@ -210,7 +210,7 @@
       "Xamarin.AndroidX.Legacy.Support.V4"
     ],
     "versionOverride": {
-      "net10.0": "1.0.0.33"
+      "net10.0": "1.0.0.37"
     }
   },
   {
@@ -220,7 +220,7 @@
       "Xamarin.AndroidX.Core.SplashScreen"
     ],
     "versionOverride": {
-      "net10.0": "1.0.1.14"
+      "net10.0": "1.2.0.3"
     }
   },
   {
@@ -230,7 +230,7 @@
       "Xamarin.AndroidX.AppCompat"
     ],
     "versionOverride": {
-      "net10.0": "1.7.1.1"
+      "net10.0": "1.8.0"
     }
   },
   {
@@ -240,7 +240,7 @@
       "Xamarin.AndroidX.RecyclerView"
     ],
     "versionOverride": {
-      "net10.0": "1.4.0.3"
+      "net10.0": "1.4.0.6"
     }
   },
   {
@@ -250,7 +250,7 @@
       "Xamarin.AndroidX.Activity"
     ],
     "versionOverride": {
-      "net10.0": "1.10.1.3"
+      "net10.0": "1.13.0.1"
     }
   },
   {
@@ -260,7 +260,7 @@
       "Xamarin.AndroidX.Browser"
     ],
     "versionOverride": {
-      "net10.0": "1.8.0.11"
+      "net10.0": "1.10.0.1"
     }
   },
   {
@@ -270,7 +270,7 @@
       "Xamarin.AndroidX.SwipeRefreshLayout"
     ],
     "versionOverride": {
-      "net10.0": "1.1.0.29"
+      "net10.0": "1.2.0.3"
     }
   },
   {
@@ -280,7 +280,7 @@
       "Xamarin.AndroidX.Leanback"
     ],
     "versionOverride": {
-      "net10.0": "1.0.0.31"
+      "net10.0": "1.2.0.4"
     }
   },
   {
@@ -290,7 +290,7 @@
       "Xamarin.AndroidX.Car.App.App"
     ],
     "versionOverride": {
-      "net10.0": "1.4.0.3"
+      "net10.0": "1.7.0.4"
     }
   },
   {
@@ -300,7 +300,7 @@
       "Xamarin.AndroidX.Wear"
     ],
     "versionOverride": {
-      "net10.0": "1.3.0.15"
+      "net10.0": "1.4.0.2"
     }
   },
   {
@@ -310,7 +310,7 @@
       "Xamarin.AndroidX.Wear.Tiles"
     ],
     "versionOverride": {
-      "net10.0": "1.4.1"
+      "net10.0": "1.6.2"
     }
   },
   {
@@ -323,7 +323,7 @@
       "Xamarin.AndroidX.Navigation.Common"
     ],
     "versionOverride": {
-      "net10.0": "2.9.2.1"
+      "net10.0": "2.9.8.1"
     }
   },
   {
@@ -334,7 +334,7 @@
       "Xamarin.AndroidX.Collection.Ktx"
     ],
     "versionOverride": {
-      "net10.0": "1.5.0.3"
+      "net10.0": "1.6.0.1"
     }
   },
   {


### PR DESCRIPTION
GitHub Issue (If applicable): relates to unoplatform/uno-private#2297

## PR Type

- Feature

## What is the current behavior?

`UpdateGroup` skips every group whose packages start with `Xamarin`:

```csharp
// tools/Uno.Sdk.Updater/Program.cs:344-350
// Skip AndroidX packages to avoid Java misalignment
else if (group.Packages.Any(x => x.StartsWith("Xamarin")) ...)
    Console.WriteLine($"Skipping '{group.Group}' to avoid Java misalignment.");
```

That skip is correct — these bindings have to move as a coordinated set, not one at a time — but it also means they never move at all unless someone does it deliberately. A major is that moment.

## What is the new behavior?

The `net10.0` override of all 14 AndroidX/Material groups moves to current:

| Group | net10.0 was | now |
|---|---|---|
| AndroidMaterial | 1.12.0.5 | **1.14.0.6** |
| AndroidXAppCompat | 1.7.1.1 | **1.8.0** |
| AndroidXActivity | 1.10.1.3 | **1.13.0.1** |
| AndroidXBrowser | 1.8.0.11 | **1.10.0.1** |
| AndroidXCarApp | 1.4.0.3 | **1.7.0.4** |
| AndroidXCollection | 1.5.0.3 | **1.6.0.1** |
| AndroidXLeanback | 1.0.0.31 | **1.2.0.4** |
| AndroidXLegacySupportV4 | 1.0.0.33 | **1.0.0.37** |
| AndroidXNavigation | 2.9.2.1 | **2.9.8.1** |
| AndroidXRecyclerView | 1.4.0.3 | **1.4.0.6** |
| AndroidXSplashScreen | 1.0.1.14 | **1.2.0.3** |
| AndroidXSwipeRefreshLayout | 1.1.0.29 | **1.2.0.3** |
| AndroidXWear | 1.3.0.15 | **1.4.0.2** |
| AndroidXWearTiles | 1.4.1 | **1.6.2** |

**Only the `net10.0` overrides move.** The base values are the net9 ones and are deliberately untouched.

## Validation

Every package in every group was checked against nuget.org for the target version — not just one probe package per group, since a group is only usable if *all* of its packages publish the same version. All 14 groups have the candidate available for every package they list; zero mismatches.

`ReadMe.md`'s embedded copy of the manifest was regenerated and verified byte-identical to `packages.json`.

**No Android build was run locally.** Java/AndroidX misalignment is exactly the failure this skip list exists to prevent, and it shows up at Android build time, not at restore. **The Android test groups in CI are the real gate for this PR** — if they go red, the right response is to bisect the set rather than to lower individual versions blindly.

## Other information

Related, and *not* fixed here: `PackageManifest.GetGroupVersion` looks the override up by exact TFM key (`VersionOverride.TryGetValue(_targetFrameworkVersion, ...)`), and `TargetFrameworkVersion` is the part before the `-`. Every override in this manifest is keyed `net10.0` only, so a **net11** app silently falls back to the net9-era base version — for these groups and for Maui, WasmBootstrap, MicrosoftLoggingConsole and WindowsCompatibility too. Uno Platform 7.0 ships net11 assemblies, so this becomes real as soon as net11 templates exist. It wants fixing in `unoplatform/uno` (nearest-lower-TFM lookup) rather than by adding a second key to 18 groups here.

## PR Checklist

- [ ] Tested code with current supported SDKs
- [ ] Docs have been added/updated
- [ ] Unit Tests and/or UI Tests
- [ ] Wasm UI Tests unaffected
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (internal)

**Breaking change:** yes for Android apps — coordinated binding bump. Intentional for the 7.0 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vRaBaNK2HnyWeg3TBzEu6
