### PR TITLE
ci: Publish dev packages from servicing/* branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,23 @@
 name: CI
 
+# A servicing/* branch continues a previous version line after main has moved on
+# to a newer one, so it builds, signs and publishes dev packages the same way main
+# does. The same pattern is added to the CI triggers, the sign and publish_dev jobs
+# and version.json's publicReleaseRefSpec. It deliberately does NOT reach the
+# publish_release_* jobs, which stay behind the Production approval gates.
+
 on:
   push:
     branches:
       - main
+      - servicing/**
       - release/**
 
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - main
+      - servicing/**
       - release/**
 
   schedule:
@@ -24,7 +32,7 @@ on:
   
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/release/') && !contains(github.ref, 'refs/heads/main')}}
+  cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/release/') && !contains(github.ref, 'refs/heads/servicing/') && !contains(github.ref, 'refs/heads/main')}}
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -111,7 +119,7 @@ jobs:
   # Sign the nuget packages
   sign:
     name: Sign Package
-    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) }}
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/servicing/') || startsWith(github.ref, 'refs/heads/release/')) }}
     runs-on: windows-latest
 
     environment: PackageSign
@@ -137,7 +145,7 @@ jobs:
   # Publish dev packages to uno feed and nuget.org
   publish_dev:
     name: Publish Dev
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/servicing/')) }}
     runs-on: ubuntu-latest
     needs: sign
 

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - servicing/*
       - release/* 
 
 env:

--- a/version.json
+++ b/version.json
@@ -6,6 +6,7 @@
   },
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
+    "^refs/heads/servicing/.*$",
     "^refs/heads/release/stable/\\d+(?:\\.\\d+)?$"
   ],
   "cloudBuild": {


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Release-process change, tracked internally as part of the Uno 7.0 release preparation. -->

## PR Type

- Build or CI related changes

## What is the current behavior?

`main` **is** this repo's dev line: it carries `6.8-dev.{height}` and `publish_dev` pushes `6.8.0-dev.*` to the Uno feed and nuget.org on every merge, ungated.

`release/stable/X.Y` is cut at release time and set to a stable version. Both of its publish jobs — `publish_release_uno` and `publish_release_nuget_org` — run under `environment: Production`, which has required reviewers and a protected-branches policy. That is correct for a stable release, but it means a `release/stable/*` branch **cannot** carry a dev channel: every dev build would need two human approvals.

`servicing/*` is not wired into this pipeline at all, so cutting such a branch today produces a branch that builds nothing.

## What is the new behavior?

`servicing/*` gets the same build → sign → `publish_dev` path that `main` uses, and nothing else:

| Change | Why |
|---|---|
| `servicing/**` in `push.branches` and `pull_request.branches` | CI runs on the branch at all, and on PRs into it |
| `servicing/` in the `sign` job condition | packages are signed, as on `main`. `environment: PackageSign` has no protection rules or branch policy, so no gate is introduced |
| `servicing/` in the `publish_dev` job condition | the ungated dev publish to the Uno feed **and** nuget.org runs, matching `main` |
| `servicing/` excluded from `concurrency.cancel-in-progress` | servicing builds publish, so an in-flight build must not be cancelled by a newer push — same treatment `main` and `release/` already get |
| `^refs/heads/servicing/.*$` in `publicReleaseRefSpec` | NBGV emits `6.8.0-dev.N` rather than a height-plus-commit-hash version |
| `servicing/*` in `.github/workflows/conventional-commits.yml` | `main`'s branch protection will be mirrored onto `servicing/6.8`. The check must report for PRs into a servicing branch, otherwise those PRs sit forever on a check that never runs |

### Deliberately not changed

- **`publish_release_uno` / `publish_release_nuget_org`** keep their `startsWith(refs/heads/release/)` conditions. Servicing must not reach the `Production` gates — that is the whole reason it is a separate branch pattern.
- **The four test-matrix jobs** already gate on `needs.publish_dev.result == 'success' || 'skipped'`, so they pick servicing up with no edit.
- **`uno-updater.yml`** is untouched. The Uno.Sdk updater has no notion of a release line: on a branch whose Uno version is a prerelease it selects the *highest* prerelease of every group, which is now the 7.0 line. Adding `servicing/6.8` to its matrix would pull 7.0-line packages into a 6.8 SDK within six hours — which is exactly how `Themes 8.0.0-dev.3` ended up pinned in the current 6.8 manifest. Servicing versions will be bumped by hand until the updater understands release lines.

## PR Checklist

- [x] Associated with an issue (internal — Uno 7.0 release preparation)

## Other information

This is step 1 of the uno.templates 7.0 line split. It lands on its own so that `servicing/6.8` can be cut from a `main` that already contains the plumbing. `main`'s move to `7.0-dev` and the 7.0 manifest retarget follow in a separate PR.
