### PR TITLE
chore: Move main to the 7.0 line

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -41,17 +41,16 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | MauiVersion** | 10.0.100 |
 
 \* UnoVersion cannot be changed via MSBuild. You must change the SDK Version to change the UnoVersion.
-\*\* This version may have a different version for .NET 10.0.
+\*\* This version may have a different version for .NET 11.0.
 
 ```json
 [
   {
     "group": "Core",
-    "version": "6.8.0-dev.130",
+    "version": "7.0.0-dev.647",
     "packages": [
       "Uno.WinUI",
       "Uno.UI.Adapter.Microsoft.Extensions.Logging",
-      "Uno.WinUI.Maps",
       "Uno.WinUI.GooglePlay",
       "Uno.WinUI.Foldable",
       "Uno.WinUI.MSAL",
@@ -62,12 +61,9 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Uno.WinUI.Runtime.Skia.MacOS",
       "Uno.WinUI.Runtime.Skia.Win32",
       "Uno.WinUI.Runtime.Skia.X11",
-      "Uno.WinUI.WebAssembly",
       "Uno.WinUI.Runtime.Skia.Android",
       "Uno.WinUI.Runtime.Skia.AppleUIKit",
       "Uno.WinUI.Runtime.Skia.WebAssembly.Browser",
-      "Uno.WinUI.Runtime.WebAssembly",
-      "Uno.WinUI.MediaPlayer.WebAssembly",
       "Uno.WinUI.MediaPlayer.Skia.X11",
       "Uno.WinUI.MediaPlayer.Skia.Win32",
       "Uno.WinUI.WebView.Skia.X11",
@@ -78,15 +74,12 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "WasmBootstrap",
-    "version": "9.0.23",
+    "version": "10.1.0-dev.214",
     "packages": [
       "Uno.Wasm.Bootstrap",
       "Uno.Wasm.Bootstrap.DevServer",
       "Uno.Wasm.Bootstrap.Server"
-    ],
-    "versionOverride": {
-      "net10.0": "10.1.0-dev.214"
-    }
+    ]
   },
   {
     "group": "OSLogging",
@@ -101,13 +94,6 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
     "version": "4.1.1",
     "packages": [
       "Uno.Core.Extensions.Logging.Singleton"
-    ]
-  },
-  {
-    "group": "UniversalImageLoading",
-    "version": "1.9.37",
-    "packages": [
-      "Uno.UniversalImageLoader"
     ]
   },
   {
@@ -147,7 +133,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "SkiaSharp",
-    "version": "3.119.2",
+    "version": "4.151.1",
     "packages": [
       "SkiaSharp.Skottie",
       "SkiaSharp.Views.Uno.WinUI",
@@ -167,7 +153,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "WinAppSdk",
-    "version": "1.7.250909003",
+    "version": "2.3.1",
     "packages": [
       "Microsoft.WindowsAppSDK"
     ]
@@ -188,22 +174,22 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "MicrosoftLoggingConsole",
-    "version": "9.0.19",
+    "version": "10.0.11",
     "packages": [
       "Microsoft.Extensions.Logging.Console"
     ],
     "versionOverride": {
-      "net10.0": "10.0.11"
+      "net11.0": "11.0.0-preview.7.26381.103"
     }
   },
   {
     "group": "WindowsCompatibility",
-    "version": "9.0.19",
+    "version": "10.0.11",
     "packages": [
       "Microsoft.Windows.Compatibility"
     ],
     "versionOverride": {
-      "net10.0": "10.0.11"
+      "net11.0": "11.0.0-preview.7.26381.103"
     }
   },
   {
@@ -241,22 +227,22 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "AndroidMaterial",
-    "version": "1.12.0.4",
+    "version": "1.12.0.5",
     "packages": [
       "Xamarin.Google.Android.Material"
     ],
     "versionOverride": {
-      "net10.0": "1.12.0.5"
+      "net11.0": "1.14.0.5"
     }
   },
   {
     "group": "AndroidXLegacySupportV4",
-    "version": "1.0.0.23",
+    "version": "1.0.0.33",
     "packages": [
       "Xamarin.AndroidX.Legacy.Support.V4"
     ],
     "versionOverride": {
-      "net10.0": "1.0.0.33"
+      "net11.0": "1.0.0.37"
     }
   },
   {
@@ -266,102 +252,102 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.AndroidX.Core.SplashScreen"
     ],
     "versionOverride": {
-      "net10.0": "1.0.1.14"
+      "net11.0": "1.2.0.3"
     }
   },
   {
     "group": "AndroidXAppCompat",
-    "version": "1.7.0.7",
+    "version": "1.7.1.1",
     "packages": [
       "Xamarin.AndroidX.AppCompat"
     ],
     "versionOverride": {
-      "net10.0": "1.7.1.1"
+      "net11.0": "1.7.1.4"
     }
   },
   {
     "group": "AndroidXRecyclerView",
-    "version": "1.4.0.2",
+    "version": "1.4.0.5",
     "packages": [
       "Xamarin.AndroidX.RecyclerView"
     ],
     "versionOverride": {
-      "net10.0": "1.4.0.3"
+      "net11.0": "1.4.0.6"
     }
   },
   {
     "group": "AndroidXActivity",
-    "version": "1.10.1.2",
+    "version": "1.12.4.1",
     "packages": [
       "Xamarin.AndroidX.Activity"
     ],
     "versionOverride": {
-      "net10.0": "1.10.1.3"
+      "net11.0": "1.13.0.1"
     }
   },
   {
     "group": "AndroidXBrowser",
-    "version": "1.8.0.10",
+    "version": "1.8.0.11",
     "packages": [
       "Xamarin.AndroidX.Browser"
     ],
     "versionOverride": {
-      "net10.0": "1.8.0.11"
+      "net11.0": "1.10.0.1"
     }
   },
   {
     "group": "AndroidXSwipeRefreshLayout",
-    "version": "1.1.0.28",
+    "version": "1.2.0.2",
     "packages": [
       "Xamarin.AndroidX.SwipeRefreshLayout"
     ],
     "versionOverride": {
-      "net10.0": "1.1.0.29"
+      "net11.0": "1.2.0.3"
     }
   },
   {
     "group": "AndroidXLeanback",
-    "version": "1.0.0.30",
+    "version": "1.0.0.31",
     "packages": [
       "Xamarin.AndroidX.Leanback"
     ],
     "versionOverride": {
-      "net10.0": "1.0.0.31"
+      "net11.0": "1.2.0.4"
     }
   },
   {
     "group": "AndroidXCarApp",
-    "version": "1.4.0.2",
+    "version": "1.4.0.3",
     "packages": [
       "Xamarin.AndroidX.Car.App.App"
     ],
     "versionOverride": {
-      "net10.0": "1.4.0.3"
+      "net11.0": "1.7.0.4"
     }
   },
   {
     "group": "AndroidXWear",
-    "version": "1.3.0.14",
+    "version": "1.4.0.1",
     "packages": [
       "Xamarin.AndroidX.Wear"
     ],
     "versionOverride": {
-      "net10.0": "1.3.0.15"
+      "net11.0": "1.4.0.2"
     }
   },
   {
     "group": "AndroidXWearTiles",
-    "version": "1.4.0.1",
+    "version": "1.4.1",
     "packages": [
       "Xamarin.AndroidX.Wear.Tiles"
     ],
     "versionOverride": {
-      "net10.0": "1.4.1"
+      "net11.0": "1.6.1"
     }
   },
   {
     "group": "AndroidXNavigation",
-    "version": "2.8.9.2",
+    "version": "2.9.2.1",
     "packages": [
       "Xamarin.AndroidX.Navigation.UI",
       "Xamarin.AndroidX.Navigation.Fragment",
@@ -369,35 +355,41 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Xamarin.AndroidX.Navigation.Common"
     ],
     "versionOverride": {
-      "net10.0": "2.9.2.1"
+      "net11.0": "2.9.8.1"
     }
   },
   {
     "group": "AndroidXCollection",
-    "version": "1.5.0.2",
+    "version": "1.5.0.5",
     "packages": [
       "Xamarin.AndroidX.Collection",
       "Xamarin.AndroidX.Collection.Ktx"
     ],
     "versionOverride": {
-      "net10.0": "1.5.0.3"
+      "net11.0": "1.6.0.1"
     }
   },
   {
     "group": "Maui",
-    "version": "9.0.120",
+    "version": "10.0.100",
     "packages": [
       "Microsoft.Maui.Controls",
-      "Microsoft.Maui.Controls.Compatibility",
       "Microsoft.Maui.Graphics"
     ],
     "versionOverride": {
-      "net10.0": "10.0.100"
+      "net11.0": "11.0.0-preview.7.26406.9"
     }
   },
   {
+    "group": "MauiCompatibility",
+    "version": "10.0.100",
+    "packages": [
+      "Microsoft.Maui.Controls.Compatibility"
+    ]
+  },
+  {
     "group": "CSharpMarkup",
-    "version": "6.8.0-dev.3",
+    "version": "7.0.0-dev.7",
     "packages": [
       "Uno.WinUI.Markup",
       "Uno.Extensions.Markup.Generators"
@@ -405,7 +397,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "Extensions",
-    "version": "7.4.0-dev.29",
+    "version": "8.0.0-dev.2",
     "packages": [
       "Uno.Extensions.Authentication.WinUI",
       "Uno.Extensions.Authentication.MSAL.WinUI",
@@ -435,7 +427,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "Toolkit",
-    "version": "9.2.0-dev.19",
+    "version": "10.0.0-dev.1",
     "packages": [
       "Uno.Toolkit.WinUI",
       "Uno.Toolkit.WinUI.Cupertino",
@@ -448,7 +440,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "Themes",
-    "version": "8.0.0-dev.3",
+    "version": "8.0.0-dev.7",
     "packages": [
       "Uno.Material.WinUI",
       "Uno.Material.WinUI.Markup",
@@ -474,7 +466,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "AppMcp",
-    "version": "1.4.0-dev.1",
+    "version": "2.0.0-dev.2",
     "packages": [
       "Uno.UI.App.Mcp"
     ]

--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -4,42 +4,41 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 
 | MSBuild Property | Default Version |
 |----------------|:---------------:|
-| UnoVersion* | 6.8.0-dev.130 |
-| UnoExtensionsVersion | 7.4.0-dev.29 |
-| UnoToolkitVersion | 9.2.0-dev.19 |
-| UnoThemesVersion | 8.0.0-dev.3 |
-| UnoCSharpMarkupVersion | 6.8.0-dev.3 |
-| UnoWasmBootstrapVersion** | 9.0.23 |
+| UnoVersion* | 7.0.0-dev.647 |
+| UnoExtensionsVersion | 8.0.0-dev.2 |
+| UnoToolkitVersion | 10.0.0-dev.1 |
+| UnoThemesVersion | 8.0.0-dev.7 |
+| UnoCSharpMarkupVersion | 7.0.0-dev.7 |
+| UnoWasmBootstrapVersion** | 10.1.0-dev.214 |
 | UnoLoggingVersion | 1.7.0 |
 | UnoCoreLoggingSingletonVersion | 4.1.1 |
-| UnoUniversalImageLoaderVersion | 1.9.37 |
 | UnoDspTasksVersion | 1.4.0 |
 | UnoResizetizerVersion | 1.13.0-dev.17 |
-| SkiaSharpVersion | 3.119.2 |
+| SkiaSharpVersion | 4.151.1 |
 | SvgSkiaVersion | 3.0.6 |
-| WinAppSdkVersion | 1.7.250909003 |
+| WinAppSdkVersion | 2.3.1 |
 | WinAppSdkBuildToolsVersion | 10.0.28000.2705 |
 | WinAppSdkBuildToolsWinAppVersion | 0.6.1 |
-| MicrosoftLoggingVersion** | 9.0.19 |
-| WindowsCompatibilityVersion** | 9.0.19 |
+| MicrosoftLoggingVersion** | 10.0.11 |
+| WindowsCompatibilityVersion** | 10.0.11 |
 | MicrosoftIdentityClientVersion | 4.88.0 |
 | CommunityToolkitMvvmVersion | 8.4.2 |
 | PrismVersion | 9.0.537 |
-| AndroidMaterialVersion | 1.12.0.4 |
-| AndroidXLegacySupportV4Version | 1.0.0.23 |
+| AndroidMaterialVersion | 1.12.0.5 |
+| AndroidXLegacySupportV4Version | 1.0.0.33 |
 | AndroidXSplashScreenVersion | 1.0.1.14 |
-| AndroidXAppCompatVersion | 1.7.0.7 |
-| AndroidXRecyclerViewVersion | 1.4.0.2 |
-| AndroidXActivityVersion | 1.10.1.2 |
-| AndroidXBrowserVersion | 1.8.0.10 |
-| AndroidXSwipeRefreshLayoutVersion | 1.1.0.28 |
-| AndroidXLeanbackVersion | 1.0.0.30 |
-| AndroidXCarAppVersion | 1.4.0.2 |
-| AndroidXWearVersion | 1.3.0.14 |
-| AndroidXWearTilesVersion | 1.4.0.1 |
-| AndroidXNavigationVersion | 2.8.9.2 |
-| AndroidXCollectionVersion | 1.5.0.2 |
-| MauiVersion** | 9.0.120 |
+| AndroidXAppCompatVersion | 1.7.1.1 |
+| AndroidXRecyclerViewVersion | 1.4.0.5 |
+| AndroidXActivityVersion | 1.12.4.1 |
+| AndroidXBrowserVersion | 1.8.0.11 |
+| AndroidXSwipeRefreshLayoutVersion | 1.2.0.2 |
+| AndroidXLeanbackVersion | 1.0.0.31 |
+| AndroidXCarAppVersion | 1.4.0.3 |
+| AndroidXWearVersion | 1.4.0.1 |
+| AndroidXWearTilesVersion | 1.4.1 |
+| AndroidXNavigationVersion | 2.9.2.1 |
+| AndroidXCollectionVersion | 1.5.0.5 |
+| MauiVersion** | 10.0.100 |
 
 \* UnoVersion cannot be changed via MSBuild. You must change the SDK Version to change the UnoVersion.
 \*\* This version may have a different version for .NET 10.0.

--- a/src/Uno.Sdk/Uno.Sdk.Updater.props
+++ b/src/Uno.Sdk/Uno.Sdk.Updater.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageTags></PackageTags>
     <SdkPackageId>Uno.Sdk.Private</SdkPackageId>
-    <SdkVersion>6.8.0-dev.130</SdkVersion>
+    <SdkVersion>7.0.0-dev.647</SdkVersion>
     <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -1,11 +1,10 @@
 ﻿[
   {
     "group": "Core",
-    "version": "6.8.0-dev.130",
+    "version": "7.0.0-dev.647",
     "packages": [
       "Uno.WinUI",
       "Uno.UI.Adapter.Microsoft.Extensions.Logging",
-      "Uno.WinUI.Maps",
       "Uno.WinUI.GooglePlay",
       "Uno.WinUI.Foldable",
       "Uno.WinUI.MSAL",
@@ -16,12 +15,9 @@
       "Uno.WinUI.Runtime.Skia.MacOS",
       "Uno.WinUI.Runtime.Skia.Win32",
       "Uno.WinUI.Runtime.Skia.X11",
-      "Uno.WinUI.WebAssembly",
       "Uno.WinUI.Runtime.Skia.Android",
       "Uno.WinUI.Runtime.Skia.AppleUIKit",
       "Uno.WinUI.Runtime.Skia.WebAssembly.Browser",
-      "Uno.WinUI.Runtime.WebAssembly",
-      "Uno.WinUI.MediaPlayer.WebAssembly",
       "Uno.WinUI.MediaPlayer.Skia.X11",
       "Uno.WinUI.MediaPlayer.Skia.Win32",
       "Uno.WinUI.WebView.Skia.X11",
@@ -32,15 +28,12 @@
   },
   {
     "group": "WasmBootstrap",
-    "version": "9.0.23",
+    "version": "10.1.0-dev.214",
     "packages": [
       "Uno.Wasm.Bootstrap",
       "Uno.Wasm.Bootstrap.DevServer",
       "Uno.Wasm.Bootstrap.Server"
-    ],
-    "versionOverride": {
-      "net10.0": "10.1.0-dev.214"
-    }
+    ]
   },
   {
     "group": "OSLogging",
@@ -55,13 +48,6 @@
     "version": "4.1.1",
     "packages": [
       "Uno.Core.Extensions.Logging.Singleton"
-    ]
-  },
-  {
-    "group": "UniversalImageLoading",
-    "version": "1.9.37",
-    "packages": [
-      "Uno.UniversalImageLoader"
     ]
   },
   {
@@ -101,7 +87,7 @@
   },
   {
     "group": "SkiaSharp",
-    "version": "3.119.2",
+    "version": "4.151.1",
     "packages": [
       "SkiaSharp.Skottie",
       "SkiaSharp.Views.Uno.WinUI",
@@ -121,7 +107,7 @@
   },
   {
     "group": "WinAppSdk",
-    "version": "1.7.250909003",
+    "version": "2.3.1",
     "packages": [
       "Microsoft.WindowsAppSDK"
     ]
@@ -142,22 +128,22 @@
   },
   {
     "group": "MicrosoftLoggingConsole",
-    "version": "9.0.19",
+    "version": "10.0.11",
     "packages": [
       "Microsoft.Extensions.Logging.Console"
     ],
     "versionOverride": {
-      "net10.0": "10.0.11"
+      "net11.0": "11.0.0-preview.7.26381.103"
     }
   },
   {
     "group": "WindowsCompatibility",
-    "version": "9.0.19",
+    "version": "10.0.11",
     "packages": [
       "Microsoft.Windows.Compatibility"
     ],
     "versionOverride": {
-      "net10.0": "10.0.11"
+      "net11.0": "11.0.0-preview.7.26381.103"
     }
   },
   {
@@ -195,22 +181,22 @@
   },
   {
     "group": "AndroidMaterial",
-    "version": "1.12.0.4",
+    "version": "1.12.0.5",
     "packages": [
       "Xamarin.Google.Android.Material"
     ],
     "versionOverride": {
-      "net10.0": "1.12.0.5"
+      "net11.0": "1.14.0.5"
     }
   },
   {
     "group": "AndroidXLegacySupportV4",
-    "version": "1.0.0.23",
+    "version": "1.0.0.33",
     "packages": [
       "Xamarin.AndroidX.Legacy.Support.V4"
     ],
     "versionOverride": {
-      "net10.0": "1.0.0.33"
+      "net11.0": "1.0.0.37"
     }
   },
   {
@@ -220,102 +206,102 @@
       "Xamarin.AndroidX.Core.SplashScreen"
     ],
     "versionOverride": {
-      "net10.0": "1.0.1.14"
+      "net11.0": "1.2.0.3"
     }
   },
   {
     "group": "AndroidXAppCompat",
-    "version": "1.7.0.7",
+    "version": "1.7.1.1",
     "packages": [
       "Xamarin.AndroidX.AppCompat"
     ],
     "versionOverride": {
-      "net10.0": "1.7.1.1"
+      "net11.0": "1.7.1.4"
     }
   },
   {
     "group": "AndroidXRecyclerView",
-    "version": "1.4.0.2",
+    "version": "1.4.0.5",
     "packages": [
       "Xamarin.AndroidX.RecyclerView"
     ],
     "versionOverride": {
-      "net10.0": "1.4.0.3"
+      "net11.0": "1.4.0.6"
     }
   },
   {
     "group": "AndroidXActivity",
-    "version": "1.10.1.2",
+    "version": "1.12.4.1",
     "packages": [
       "Xamarin.AndroidX.Activity"
     ],
     "versionOverride": {
-      "net10.0": "1.10.1.3"
+      "net11.0": "1.13.0.1"
     }
   },
   {
     "group": "AndroidXBrowser",
-    "version": "1.8.0.10",
+    "version": "1.8.0.11",
     "packages": [
       "Xamarin.AndroidX.Browser"
     ],
     "versionOverride": {
-      "net10.0": "1.8.0.11"
+      "net11.0": "1.10.0.1"
     }
   },
   {
     "group": "AndroidXSwipeRefreshLayout",
-    "version": "1.1.0.28",
+    "version": "1.2.0.2",
     "packages": [
       "Xamarin.AndroidX.SwipeRefreshLayout"
     ],
     "versionOverride": {
-      "net10.0": "1.1.0.29"
+      "net11.0": "1.2.0.3"
     }
   },
   {
     "group": "AndroidXLeanback",
-    "version": "1.0.0.30",
+    "version": "1.0.0.31",
     "packages": [
       "Xamarin.AndroidX.Leanback"
     ],
     "versionOverride": {
-      "net10.0": "1.0.0.31"
+      "net11.0": "1.2.0.4"
     }
   },
   {
     "group": "AndroidXCarApp",
-    "version": "1.4.0.2",
+    "version": "1.4.0.3",
     "packages": [
       "Xamarin.AndroidX.Car.App.App"
     ],
     "versionOverride": {
-      "net10.0": "1.4.0.3"
+      "net11.0": "1.7.0.4"
     }
   },
   {
     "group": "AndroidXWear",
-    "version": "1.3.0.14",
+    "version": "1.4.0.1",
     "packages": [
       "Xamarin.AndroidX.Wear"
     ],
     "versionOverride": {
-      "net10.0": "1.3.0.15"
+      "net11.0": "1.4.0.2"
     }
   },
   {
     "group": "AndroidXWearTiles",
-    "version": "1.4.0.1",
+    "version": "1.4.1",
     "packages": [
       "Xamarin.AndroidX.Wear.Tiles"
     ],
     "versionOverride": {
-      "net10.0": "1.4.1"
+      "net11.0": "1.6.1"
     }
   },
   {
     "group": "AndroidXNavigation",
-    "version": "2.8.9.2",
+    "version": "2.9.2.1",
     "packages": [
       "Xamarin.AndroidX.Navigation.UI",
       "Xamarin.AndroidX.Navigation.Fragment",
@@ -323,35 +309,41 @@
       "Xamarin.AndroidX.Navigation.Common"
     ],
     "versionOverride": {
-      "net10.0": "2.9.2.1"
+      "net11.0": "2.9.8.1"
     }
   },
   {
     "group": "AndroidXCollection",
-    "version": "1.5.0.2",
+    "version": "1.5.0.5",
     "packages": [
       "Xamarin.AndroidX.Collection",
       "Xamarin.AndroidX.Collection.Ktx"
     ],
     "versionOverride": {
-      "net10.0": "1.5.0.3"
+      "net11.0": "1.6.0.1"
     }
   },
   {
     "group": "Maui",
-    "version": "9.0.120",
+    "version": "10.0.100",
     "packages": [
       "Microsoft.Maui.Controls",
-      "Microsoft.Maui.Controls.Compatibility",
       "Microsoft.Maui.Graphics"
     ],
     "versionOverride": {
-      "net10.0": "10.0.100"
+      "net11.0": "11.0.0-preview.7.26406.9"
     }
   },
   {
+    "group": "MauiCompatibility",
+    "version": "10.0.100",
+    "packages": [
+      "Microsoft.Maui.Controls.Compatibility"
+    ]
+  },
+  {
     "group": "CSharpMarkup",
-    "version": "6.8.0-dev.3",
+    "version": "7.0.0-dev.7",
     "packages": [
       "Uno.WinUI.Markup",
       "Uno.Extensions.Markup.Generators"
@@ -359,7 +351,7 @@
   },
   {
     "group": "Extensions",
-    "version": "7.4.0-dev.29",
+    "version": "8.0.0-dev.2",
     "packages": [
       "Uno.Extensions.Authentication.WinUI",
       "Uno.Extensions.Authentication.MSAL.WinUI",
@@ -389,7 +381,7 @@
   },
   {
     "group": "Toolkit",
-    "version": "9.2.0-dev.19",
+    "version": "10.0.0-dev.1",
     "packages": [
       "Uno.Toolkit.WinUI",
       "Uno.Toolkit.WinUI.Cupertino",
@@ -402,7 +394,7 @@
   },
   {
     "group": "Themes",
-    "version": "8.0.0-dev.3",
+    "version": "8.0.0-dev.7",
     "packages": [
       "Uno.Material.WinUI",
       "Uno.Material.WinUI.Markup",
@@ -428,7 +420,7 @@
   },
   {
     "group": "AppMcp",
-    "version": "1.4.0-dev.1",
+    "version": "2.0.0-dev.2",
     "packages": [
       "Uno.UI.App.Mcp"
     ]

--- a/tools/Uno.Sdk.Updater/ReadMe.md
+++ b/tools/Uno.Sdk.Updater/ReadMe.md
@@ -12,7 +12,6 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | UnoWasmBootstrapVersion** | $WasmBootstrap$ |
 | UnoLoggingVersion | $OSLogging$ |
 | UnoCoreLoggingSingletonVersion | $CoreLogging$ |
-| UnoUniversalImageLoaderVersion | $UniversalImageLoading$ |
 | UnoDspTasksVersion | $Dsp$ |
 | UnoResizetizerVersion | $Resizetizer$ |
 | SkiaSharpVersion | $SkiaSharp$ |
@@ -42,7 +41,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | MauiVersion** | $Maui$ |
 
 \* UnoVersion cannot be changed via MSBuild. You must change the SDK Version to change the UnoVersion.
-\*\* This version may have a different version for .NET 10.0.
+\*\* This version may have a different version for .NET 11.0.
 
 ```json
 $PackagesJson$

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.8-dev.{height}",
+  "version": "7.0-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Release-process change, tracked internally as part of the Uno 7.0 release preparation. -->

## PR Type

- Build or CI related changes

## What is the current behavior?

`main` carries `6.8-dev.{height}` and publishes `6.8.0-dev.*`. It is the only branch producing a dev SDK, so once Uno 7.0 lands there is nothing left serving apps still on Uno 6.x — which is what clients validate fixes against before we backport to a 6.7 service release.

The manifest has also already drifted: the updater selects the highest prerelease of every group with no notion of a release line, so **`Themes 8.0.0-dev.3` — a 7.0-era version — is currently pinned inside the 6.8 SDK**. Toolkit, Extensions, CSharpMarkup and AppMcp would follow as their 7.0 lines publish.

## What is the new behavior?

`main` becomes the 7.0 line. `servicing/6.8` is then cut from `main`'s last 6.8 commit (follow-up) and continues `6.8.0-dev.*`.

**The version bump and the manifest retarget are one commit on purpose.** Bumping `version.json` alone would immediately publish a `7.0.0-dev.1` to nuget.org whose manifest still pins the 6.8 lines.

### Manifest changes

| Change | Why |
|---|---|
| Uno groups → 7.0 lines: Core `7.0.0-dev.647`, CSharpMarkup `7.0.0-dev.7`, Extensions `8.0.0-dev.2`, Toolkit `10.0.0-dev.1`, Themes `8.0.0-dev.7`, AppMcp `2.0.0-dev.2` | the 7.0 SDK must pin 7.0-line packages |
| Core drops `Uno.WinUI.Maps`, `Uno.WinUI.WebAssembly`, `Uno.WinUI.Runtime.WebAssembly`, `Uno.WinUI.MediaPlayer.WebAssembly` | all four stop at `6.8.0-dev.149` with no 7.x. `uno` master's own manifest already drops exactly these four |
| `MauiCompatibility` split out of `Maui`, **and** `SdkVersion` → `7.0.0-dev.647` | see below — these must land together |
| `SkiaSharp` `3.119.2` → `4.151.1` | `Uno.WinUI 7.0.0-dev.647` declares `SkiaSharp 4.151.1` on both `net10.0` and `net11.0`; leaving 3.x is an NU1605 downgrade |
| `WinAppSdk` `1.7.250909003` → `2.3.1` | matches `uno` master for the net10/net11 Windows heads |
| TFM axis re-baselined: base takes the net10 values, overrides move `net10.0` → `net11.0` | `Uno.WinUI 7.0.0-dev.647` ships `net10.0`, `net10.0-windows`, `net11.0`, `net11.0-windows`, so net10 is now the base TFM and net11 the override |
| `UniversalImageLoading` group removed | nothing emits `Uno.UniversalImageLoader` any more — the reference lived in `ProjectSystem.Android.targets` under `!UnoFeatures.Contains(';skiarenderer;')` and went with the native Android renderer |

`ReadMe.md`'s version table is regenerated to match, and its `UnoUniversalImageLoaderVersion` row is dropped.

### Why the Maui split and the SdkVersion bump are atomic

The resolver that knows the `MauiCompatibility` group ships in the **private** SDK, and `Uno.Sdk.Updater` merges groups by **name only** — it never reconciles a group's `packages` array. Split the group without the matching resolver and `Microsoft.Maui.Controls.Compatibility` ends up in *both* groups; `PackageManifest.GetPackageVersion` resolves with `SingleOrDefault` and **throws**, which is a hard build failure for consumers rather than a warning. `SdkVersion 7.0.0-dev.647` is the first published private SDK above the `#24360` merge, which lands at height 645.

### No net10 regressions

Where the old `net10.0` override was higher than `uno` master's new base, the higher value is kept rather than mirrored — `Maui` stays at `10.0.100` (not `10.0.90`) and `WasmBootstrap` stays at `10.1.0-dev.214` (not `10.0.96`). Dropping to `10.0.96` would lose the `EmccFlags` / `WasmEnableThreads` property-syntax fixes and the `uno-config.js` verbatim-write fix.

### Verified before pushing

All **139** package + version pairs in the resulting manifest were checked against nuget.org and are present. The first run flagged the four discontinued `Core` packages above, which is exactly what `publish_dev`'s `Verify-NuGetDependenciesOnNuGetOrg.ps1` would have failed on.

## PR Checklist

- [x] Associated with an issue (internal — Uno 7.0 release preparation)

## Other information

`settings` (`1.14.0-dev.8`) and `hotdesign` (`1.23.0-dev.4`) are intentionally left on their current pins — neither has a 7.0-era package published yet. They need a follow-up once those lines exist.

Follow-ups after this merges: cut `servicing/6.8` from this PR's merge-base, mirror `main`'s branch protection onto it, and repair the `Themes` pin there back to the 6.8-compatible `7.2.0-dev.5`.
