### PR TITLE
chore: Bump version to 7.0-dev for the Uno 7.0 line

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.8-dev.{height}",
+  "version": "7.0-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Release-process change, tracked internally as part of the Uno 7.0 release preparation. -->

## PR Type

- Build or CI related changes

## What is the current behavior?

`main` carries `6.8-dev.{height}` and is the only branch producing a dev `Uno.Sdk`. Every other repo in the programme has already moved its default branch to its 7.0-era line — `uno` to `7.0-dev`, Toolkit to `10.0`, Themes to `8.0`, Extensions to `8.0`, C# Markup to `7.0`, App MCP to `2.0` — so uno.templates is the last one still on the 6.x line.

## What is the new behavior?

`main` moves to `7.0-dev.{height}`, giving a clean version-line cut. `servicing/6.8` is then cut from this PR's merge-base and continues publishing `6.8.0-dev.*` for apps on Uno 6.x, using the `servicing/*` pipeline path added in #2248.

### Why the bump has to come first

`main` and a `servicing/6.8` branch cut from it currently compute the **same** NBGV height — both resolve to `6.8.0-dev.32`, verified with `nbgv get-version`. Two branches publishing an identical version from different code means the duplicate push is skipped silently on a green build. Moving `main` to `7.0-dev` separates the version spaces: `main` owns `7.0.0-dev.*`, `servicing/6.8` owns `6.8.0-dev.*`, with no offset needed.

### Scope

Version line only. The manifest migration — `SdkVersion`, the 7.0 package pins, the first-party group freeze and the SkiaSharp v4 move — is deliberately **not** in this PR; it is being handled separately in #2240 and #2244.

Nothing consumes a 7.0 `Uno.Sdk` yet: Toolkit, Themes, Extensions and C# Markup have reserved their 7.0-era version lines but have not retargeted their code, so their current builds still ship `net9.0` while `Uno.WinUI 7.0.0-dev.647` ships `net10.0`/`net11.0`. The 7.0 SDK becomes buildable as those libraries land, group by group.

The Uno.Sdk updater's PRs are reviewed and approved by hand — main requires an approving review and the workflow's auto-approve step is disabled — so this bump does not cause any unattended manifest change.

## PR Checklist

- [x] Associated with an issue (internal — Uno 7.0 release preparation)

## Other information

Follow-ups: cut `servicing/6.8` from this PR's merge-base, mirror `main`'s branch protection onto it, and repair its `Themes` pin back to the 6.8-compatible `7.2.0-dev.5`.
