### PR TITLE
fix(sdk): Pin Themes back to the 6.8-compatible line

### DIFF
--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -7,7 +7,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | UnoVersion* | 6.8.0-dev.130 |
 | UnoExtensionsVersion | 7.4.0-dev.29 |
 | UnoToolkitVersion | 9.2.0-dev.19 |
-| UnoThemesVersion | 8.0.0-dev.3 |
+| UnoThemesVersion | 7.2.0-dev.5 |
 | UnoCSharpMarkupVersion | 6.8.0-dev.3 |
 | UnoWasmBootstrapVersion** | 9.0.23 |
 | UnoLoggingVersion | 1.7.0 |
@@ -449,7 +449,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "Themes",
-    "version": "8.0.0-dev.3",
+    "version": "7.2.0-dev.5",
     "packages": [
       "Uno.Material.WinUI",
       "Uno.Material.WinUI.Markup",

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -402,7 +402,7 @@
   },
   {
     "group": "Themes",
-    "version": "8.0.0-dev.3",
+    "version": "7.2.0-dev.5",
     "packages": [
       "Uno.Material.WinUI",
       "Uno.Material.WinUI.Markup",


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Release-process change, tracked internally as part of the Uno 7.0 release preparation. -->

## PR Type

- Bugfix

## What is the current behavior?

`servicing/6.8` carries `Themes 8.0.0-dev.3`. That is the **Uno 7.0-era line** — `Uno.Themes` cut `8.0` on `master` and keeps its 6.x-compatible work on `servicing/7.2`.

It got there because the Uno.Sdk updater picks the *highest* prerelease of each group and has no notion of a release line. It advanced `main` to the 8.0 line while `main` was still the 6.8 SDK, and `servicing/6.8` inherited the pin when it was cut.

So the 6.8 dev SDK — the one clients validate 6.x fixes against — has been shipping a Themes from the 7.0 line.

## What is the new behavior?

`Themes` moves to **`7.2.0-dev.5`**, the head of `Uno.Themes`' `servicing/7.2` branch, which is the line that stays compatible with Uno 6.x.

All six packages in the group are published at that version:

```
Uno.Material.WinUI          Uno.Cupertino.WinUI
Uno.Material.WinUI.Markup   Uno.Simple.WinUI
Uno.Themes.WinUI.Markup     Uno.Simple.WinUI.Markup
```

`ReadMe.md` is re-rendered from the updater template, which updates both the version table and the embedded copy of `packages.json`.

### Rest of the manifest checked

Themes was the only group pointing at a 7.0-era line. The other first-party groups are all on their servicing lines already — `Core 6.8`, `CSharpMarkup 6.8`, `Extensions 7.4`, `Toolkit 9.2`, `AppMcp 1.4`, `settings 1.14` — and the groups without a 7.0 split (`Resizetizer`, `sdkextras`, `UnoFonts`, `Dsp`, `OSLogging`, `CoreLogging`, `WasmBootstrap`) are unaffected.

`hotdesign` is left as-is pending confirmation of which line serves 6.x.

## PR Checklist

- [x] Associated with an issue (internal — Uno 7.0 release preparation)

## Other information

`servicing/6.8` is intentionally kept out of the `uno-updater.yml` matrix, so this pin will not be advanced again automatically — the updater would re-select the 8.0 line for exactly the same reason. Version bumps on this branch are made by hand until the updater understands release lines.
