### PR TITLE
chore(sdk): Bump the 6.x lines on servicing/6.8

### DIFF
--- a/src/Uno.Sdk.Updater.targets
+++ b/src/Uno.Sdk.Updater.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <UnoVersion>6.8.0-dev.159</UnoVersion>
     <UnoWasmBootstrapVersionNet9>9.0.23</UnoWasmBootstrapVersionNet9>
-    <UnoWasmBootstrapVersionNet10>10.1.0-dev.214</UnoWasmBootstrapVersionNet10>
+    <UnoWasmBootstrapVersionNet10>10.1.0-dev.217</UnoWasmBootstrapVersionNet10>
     <UnoExtensionsLoggingVersion>1.7.0</UnoExtensionsLoggingVersion>
     <UnoCoreLoggingVersion>4.1.1</UnoCoreLoggingVersion>
     <UnoDspTasksVersion>1.4.0</UnoDspTasksVersion>

--- a/src/Uno.Sdk/ReadMe.md
+++ b/src/Uno.Sdk/ReadMe.md
@@ -5,16 +5,16 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
 | MSBuild Property | Default Version |
 |----------------|:---------------:|
 | UnoVersion* | 6.8.0-dev.159 |
-| UnoExtensionsVersion | 7.4.0-dev.30 |
-| UnoToolkitVersion | 9.2.0-dev.20 |
-| UnoThemesVersion | 7.2.0-dev.5 |
+| UnoExtensionsVersion | 7.4.0-dev.50 |
+| UnoToolkitVersion | 10.0.0-dev.1 |
+| UnoThemesVersion | 8.0.0-dev.15 |
 | UnoCSharpMarkupVersion | 6.8.0-dev.16 |
 | UnoWasmBootstrapVersion** | 9.0.23 |
 | UnoLoggingVersion | 1.7.0 |
 | UnoCoreLoggingSingletonVersion | 4.1.1 |
 | UnoUniversalImageLoaderVersion | 1.9.37 |
 | UnoDspTasksVersion | 1.4.0 |
-| UnoResizetizerVersion | 1.13.0-dev.17 |
+| UnoResizetizerVersion | 1.13.0-dev.18 |
 | SkiaSharpVersion | 3.119.2 |
 | SvgSkiaVersion | 3.0.6 |
 | WinAppSdkVersion | 1.7.250909003 |
@@ -86,7 +86,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
       "Uno.Wasm.Bootstrap.Server"
     ],
     "versionOverride": {
-      "net10.0": "10.1.0-dev.214"
+      "net10.0": "10.1.0-dev.217"
     }
   },
   {
@@ -120,7 +120,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "Resizetizer",
-    "version": "1.13.0-dev.17",
+    "version": "1.13.0-dev.18",
     "packages": [
       "Uno.Resizetizer"
     ]
@@ -134,14 +134,14 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "settings",
-    "version": "1.14.0-dev.8",
+    "version": "1.14.0-dev.9",
     "packages": [
       "Uno.Settings.DevServer"
     ]
   },
   {
     "group": "hotdesign",
-    "version": "1.23.0-dev.17",
+    "version": "1.23.0-dev.106",
     "packages": [
       "Uno.UI.HotDesign"
     ]
@@ -406,7 +406,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "Extensions",
-    "version": "7.4.0-dev.30",
+    "version": "7.4.0-dev.50",
     "packages": [
       "Uno.Extensions.Authentication.WinUI",
       "Uno.Extensions.Authentication.MSAL.WinUI",
@@ -436,7 +436,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "Toolkit",
-    "version": "9.2.0-dev.20",
+    "version": "10.0.0-dev.1",
     "packages": [
       "Uno.Toolkit.WinUI",
       "Uno.Toolkit.WinUI.Cupertino",
@@ -449,7 +449,7 @@ The Uno.Sdk powers the Uno Platform Single Project, including the ability to imp
   },
   {
     "group": "Themes",
-    "version": "7.2.0-dev.5",
+    "version": "8.0.0-dev.15",
     "packages": [
       "Uno.Material.WinUI",
       "Uno.Material.WinUI.Markup",

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -39,7 +39,7 @@
       "Uno.Wasm.Bootstrap.Server"
     ],
     "versionOverride": {
-      "net10.0": "10.1.0-dev.214"
+      "net10.0": "10.1.0-dev.217"
     }
   },
   {
@@ -73,7 +73,7 @@
   },
   {
     "group": "Resizetizer",
-    "version": "1.13.0-dev.17",
+    "version": "1.13.0-dev.18",
     "packages": [
       "Uno.Resizetizer"
     ]
@@ -87,14 +87,14 @@
   },
   {
     "group": "settings",
-    "version": "1.14.0-dev.8",
+    "version": "1.14.0-dev.9",
     "packages": [
       "Uno.Settings.DevServer"
     ]
   },
   {
     "group": "hotdesign",
-    "version": "1.23.0-dev.17",
+    "version": "1.23.0-dev.106",
     "packages": [
       "Uno.UI.HotDesign"
     ]
@@ -359,7 +359,7 @@
   },
   {
     "group": "Extensions",
-    "version": "7.4.0-dev.30",
+    "version": "7.4.0-dev.50",
     "packages": [
       "Uno.Extensions.Authentication.WinUI",
       "Uno.Extensions.Authentication.MSAL.WinUI",
@@ -389,7 +389,7 @@
   },
   {
     "group": "Toolkit",
-    "version": "9.2.0-dev.20",
+    "version": "10.0.0-dev.1",
     "packages": [
       "Uno.Toolkit.WinUI",
       "Uno.Toolkit.WinUI.Cupertino",
@@ -402,7 +402,7 @@
   },
   {
     "group": "Themes",
-    "version": "7.2.0-dev.5",
+    "version": "8.0.0-dev.15",
     "packages": [
       "Uno.Material.WinUI",
       "Uno.Material.WinUI.Markup",


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- No GitHub issue: routine SDK package alignment, tracked internally. -->

## PR Type

- Project automation

## What is the current behavior?

The Uno.Sdk updater does not yet open automated `Uno.Sdk Update - <branch>` PRs for
`servicing/6.8`, so the first-party groups have drifted behind the latest dev build of each
6.x servicing line. Two groups were still pinned to lines that are no longer built.

## What is the new behavior?

Each first-party group moves to the latest dev build of its 6.x servicing line:

| Group | Before | After | Line |
|---|---|---|---|
| Resizetizer | 1.13.0-dev.17 | **1.13.0-dev.18** | `servicing/1.13` |
| settings (Uno.Settings) | 1.14.0-dev.8 | **1.14.0-dev.9** | `servicing/1.14` |
| hotdesign | 1.23.0-dev.17 | **1.23.0-dev.106** | HD 1.23 line |
| Extensions | 7.4.0-dev.30 | **7.4.0-dev.50** | `servicing/7.4` |
| Toolkit | 9.2.0-dev.20 | **10.0.0-dev.1** | `servicing/10.0` ⚠️ line change |
| Themes | 7.2.0-dev.5 | **8.0.0-dev.15** | `servicing/8.0` ⚠️ line change |
| WasmBootstrap (`net10.0`) | 10.1.0-dev.214 | **10.1.0-dev.217** | net10 line |

Unchanged because they are already at the latest dev build of their line: `Core` (6.8.0-dev.159,
bumped in #2254), `sdkextras` (6.4.0-dev.13), `CSharpMarkup` (6.8.0-dev.16), `AppMcp` (1.4.0-dev.3).

Groups pinned to stable (`OSLogging`, `CoreLogging`, `Dsp`, `UnoFonts`, WinAppSdk, AndroidX,
Maui, …) are deliberately left alone — moving those off stable is a separate decision.

### Note on the two line changes

`Toolkit` and `Themes` move major line because their servicing branches now produce those lines:

- `uno.toolkit.ui` → `servicing/10.0`; the `9.2.0-dev` line stopped at `.20`, and `10.0.0-dev` has
  its first build (`10.0.0-dev.1`).
- `Uno.Themes` → `servicing/8.0`; the `7.2.0-dev` line stopped at `.5`, and `8.0.0-dev` is active
  (8 builds, latest `.15`).

`Toolkit 10.0.0-dev.1` is the very first build on that line, so it is the least exercised change
here and worth a closer look during validation.

## PR Checklist

- [x] Associated with an issue (GitHub or internal)

## Other information

Same file set the automation touches on the other lines: `Uno.Sdk.Updater.targets`,
`src/Uno.Sdk/packages.json` and the mirrored table + JSON block in `src/Uno.Sdk/ReadMe.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
