### PR TITLE
ci: wire the GitHub Actions canary to canaries/dev

### DIFF
--- a/.github/actions/ci/canary-updater/action.yml
+++ b/.github/actions/ci/canary-updater/action.yml
@@ -8,30 +8,26 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Determine Canary state
-      shell: pwsh
-      run: |
-        # if running in the canaries/dev branch, set IsCanaryBranch to true otherwise false
-        if ($env:GITHUB_REF_NAME -eq "canaries/dev") {
-          echo "IsCanaryBranch=true" >> $GITHUB_ENV
-        } else {
-          echo "IsCanaryBranch=false" >> $GITHUB_ENV
-        }
-
+    # IsCanaryBranch is resolved once in the CI workflow, from the ref that is actually checked
+    # out. It used to be recomputed here from GITHUB_REF_NAME - the ref that *triggered* the
+    # workflow, which is main for a scheduled run - so the updater never ran.
     - name: Run Canary Updater
       shell: pwsh
       if: env.IsCanaryBranch == 'true'
       run: |
-        dotnet.exe tool install Uno.NuGet.Updater.Tool --version 1.2.10 --tool-path ${{ env.RUNNER_TEMP }} --ignore-failed-sources
+        dotnet tool install Uno.NuGet.Updater.Tool --version 1.2.10 --tool-path "$env:RUNNER_TEMP" --ignore-failed-sources
 
-        ${{ env.RUNNER_TEMP }}/nugetupdater.exe `
-            --solution=D:\a\1\s `
+        # run-tests runs on windows and macOS runners, so resolve the tool name per platform.
+        $updater = Join-Path $env:RUNNER_TEMP ($IsWindows ? 'nugetupdater.exe' : 'nugetupdater')
+
+        & $updater `
+            --solution="$env:GITHUB_WORKSPACE" `
             --useNuGetorg `
             "--packageAuthor=unoplatform,uno platform" `
-            --outputFile=D:\a\1\a\Canary.md `
-            --result=D:\a\1\s\result.json `
+            --outputFile="$env:RUNNER_TEMP/Canary.md" `
+            --result="$env:GITHUB_WORKSPACE/result.json" `
             --strict `
-            --versionOverrides=D:\a\1\s/build/templates/versionOverrides.json `
+            --versionOverrides="$env:GITHUB_WORKSPACE/build/templates/versionOverrides.json" `
             --version=dev `
             --version=stable `
             --feed=https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json

--- a/.github/actions/ci/canary-updater/action.yml
+++ b/.github/actions/ci/canary-updater/action.yml
@@ -1,9 +1,13 @@
 name: "Canary Updater"
-description: "Canary Updater"
+description: "Merges the branch under test into the canary branch and bumps Uno packages to their latest dev versions"
 
 inputs:
    MergeBranch:
-     description: ".NET Version"
+     description: "Whether to merge MergeBranchName into the canary branch before updating packages"
+     default: "true"
+   MergeBranchName:
+     description: "The branch whose sources the canary should test"
+     default: "main"
 
 runs:
   using: "composite"
@@ -11,6 +15,26 @@ runs:
     # IsCanaryBranch is resolved once in the CI workflow, from the ref that is actually checked
     # out. It used to be recomputed here from GITHUB_REF_NAME - the ref that *triggered* the
     # workflow, which is main for a scheduled run - so the updater never ran.
+    - name: Merge the tested branch into the canary branch
+      shell: pwsh
+      if: env.IsCanaryBranch == 'true' && inputs.MergeBranch == 'true'
+      run: |
+        # The canary answers "does the current code still build against tomorrow's Uno packages",
+        # so the branch under test is merged in first. This only changes the runner working copy;
+        # nothing is pushed back to the canary branch.
+        git config user.email "uno-platform-bot@users.noreply.github.com"
+        git config user.name "Uno Platform Bot"
+
+        # Some jobs check out shallow, and a merge needs the history behind both sides.
+        if (Test-Path (Join-Path $env:GITHUB_WORKSPACE '.git/shallow')) { git fetch --unshallow }
+        git fetch --prune origin ${{ inputs.MergeBranchName }}
+
+        git merge origin/${{ inputs.MergeBranchName }} --no-edit -X theirs
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "Failed to merge origin/${{ inputs.MergeBranchName }} into the canary branch."
+          exit 1
+        }
+
     - name: Run Canary Updater
       shell: pwsh
       if: env.IsCanaryBranch == 'true'
@@ -28,6 +52,7 @@ runs:
             --result="$env:GITHUB_WORKSPACE/result.json" `
             --strict `
             --versionOverrides="$env:GITHUB_WORKSPACE/build/templates/versionOverrides.json" `
+            --updateProperties="$env:GITHUB_WORKSPACE/build/templates/propertiesToUpdate.json" `
             --version=dev `
             --version=stable `
             --feed=https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json

--- a/.github/actions/ci/run-tests/action.yml
+++ b/.github/actions/ci/run-tests/action.yml
@@ -122,7 +122,7 @@ runs:
   - name: "Canary Updater"
     uses: ./.github/actions/ci/canary-updater
     with:
-      MergeBranch: false
+      MergeBranch: true
   
   - name: 'OpenJDK (Linux)'
     if: runner.os == 'linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,15 @@ concurrency:
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-  CheckoutRef: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.ref }}
-  IsCanaryBranch: ${{ startsWith(github.ref, 'refs/heads/canaries/') }}
+  # The canary builds canaries/dev against the latest Uno dev packages. GitHub only fires
+  # `schedule` on the default branch, so the scheduled run checks out the canary branch
+  # explicitly; workflow_dispatch can target any ref.
+  #
+  # IsCanaryBranch must agree with what is actually checked out. It used to be derived from
+  # github.ref, which is refs/heads/main on a scheduled run, so it was never true and the
+  # canary updater never ran.
+  CheckoutRef: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.event_name == 'schedule' && 'refs/heads/canaries/dev' || github.ref }}
+  IsCanaryBranch: ${{ github.event_name == 'schedule' || contains(github.ref, 'canaries/') || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.branch, 'canaries/')) }}
   ValidationUnoCheckVersionNet9: '1.32.23'
   ValidationUnoCheckVersionNet10: '1.33.0-dev.30'
   ValidationDotNetVersion: '9.0.308'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ on:
       - release/**
 
   schedule:
-    - cron: '0 0 * * *' # Canary
+    - cron: '0 0 * * *' # nightly build of the branch this workflow runs on
+    - cron: '0 2 * * *' # canary: canaries/dev against the latest Uno dev packages
 
   workflow_dispatch:
     inputs:
@@ -43,8 +44,8 @@ env:
   # IsCanaryBranch must agree with what is actually checked out. It used to be derived from
   # github.ref, which is refs/heads/main on a scheduled run, so it was never true and the
   # canary updater never ran.
-  CheckoutRef: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.event_name == 'schedule' && 'refs/heads/canaries/dev' || github.ref }}
-  IsCanaryBranch: ${{ github.event_name == 'schedule' || contains(github.ref, 'canaries/') || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.branch, 'canaries/')) }}
+  CheckoutRef: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.event.schedule == '0 2 * * *' && 'refs/heads/canaries/dev' || github.ref }}
+  IsCanaryBranch: ${{ github.event.schedule == '0 2 * * *' || contains(github.ref, 'canaries/') || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.branch, 'canaries/')) }}
   ValidationUnoCheckVersionNet9: '1.32.23'
   ValidationUnoCheckVersionNet10: '1.33.0-dev.30'
   ValidationDotNetVersion: '9.0.308'


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## What is the current behavior?

**The GitHub Actions canary has never run.** `gh run list --branch canaries/dev` returns zero runs, ever.

The Azure pipelines were removed from `main` in #1314 / #1318 / #1319 (`ci: Move to github actions` and `ci: Remove unused files`, 2025-04-03/04), and the canary was ported alongside them. The port left three defects, each individually sufficient to disable it:

**1. The canary flag was derived from the wrong ref.**

```yaml
CheckoutRef:    ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.ref }}
IsCanaryBranch: ${{ startsWith(github.ref, 'refs/heads/canaries/') }}   # github.ref, not CheckoutRef
```

`CheckoutRef` already supported targeting another branch and both checkout steps honour it, but `IsCanaryBranch` read `github.ref` — the ref that *triggered* the workflow. `.github/actions/ci/canary-updater` then recomputed the same flag from `GITHUB_REF_NAME`, with the same outcome, and gated the updater on it.

**2. The nightly cron could not reach the canary branch.** GitHub only fires `schedule` on the default branch, so `github.ref` is always `refs/heads/main` for the nightly run — the flag could never be true, regardless of the `# Canary` comment on the cron.

**3. The action still used Azure DevOps paths.**

```
--solution=D:\a\1\s              # $(Build.SourcesDirectory)
--outputFile=D:\a\1\a\Canary.md  # $(Build.ArtifactStagingDirectory)
--tool-path ${{ env.RUNNER_TEMP }}
```

`D:\a\1\s` and `D:\a\1\a` do not exist on a GitHub runner, and `${{ env.RUNNER_TEMP }}` expands to an **empty string** — the `env` context only exposes variables declared in `env:` blocks, not runner defaults. So the tool installed with no `--tool-path` and was then invoked as `/nugetupdater.exe`.

Meanwhile the Azure pipeline (definition 127) still runs daily against `canaries/dev`, which is the only branch still carrying the Azure YAML. It has been red since **2025-03-19**.

## What is the new behavior?

- `IsCanaryBranch` is resolved **once**, in the workflow, in agreement with `CheckoutRef`. The duplicate derivation inside the action is removed, so the two can no longer disagree.
- The nightly `schedule` checks out `refs/heads/canaries/dev` explicitly.
- Azure paths are replaced with `$env:GITHUB_WORKSPACE` / `$env:RUNNER_TEMP`, read in pwsh rather than through the `env` expression context.
- The updater executable is resolved per platform (`$IsWindows`). `run-tests` runs on `windows-latest` **and** `macos-15` and the canary step has no OS condition, so enabling it would otherwise have failed every macOS job on `nugetupdater.exe`.

Expression behaviour was checked against every trigger:

| event | github.ref | input | CheckoutRef | IsCanaryBranch |
|---|---|---|---|---|
| push | refs/heads/main | — | refs/heads/main | false |
| pull_request | refs/heads/main | — | refs/heads/main | false |
| schedule | refs/heads/main | — | **refs/heads/canaries/dev** | **true** |
| workflow_dispatch | refs/heads/main | canaries/dev | canaries/dev | **true** |
| workflow_dispatch | refs/heads/main | main | main | false |
| push | refs/heads/canaries/dev | — | refs/heads/canaries/dev | **true** |

## PR Checklist

- [ ] Associated with an issue (GitHub or internal)

## Other information

### Not verified by this PR

GitHub Actions cannot be executed locally, so this is **unverified until it runs**. Both files parse as valid YAML and the expression semantics were simulated, but that is not the same as a green run. The safe first test is a manual **`workflow_dispatch` with `branch: canaries/dev`**, which exercises the same path without depending on the cron.

### Resolved in `b308de53`

The three points raised on the first commit are now implemented.

**1. The nightly build is preserved.** The original midnight cron still builds this workflow's own branch; the canary runs on a separate `0 2 * * *` schedule. The canary is keyed to `github.event.schedule` rather than "any scheduled run", so the two do not compete for one trigger.

**2. The canary now merges the tested branch.** `MergeBranch` is switched to `true` *and actually implemented* — the input was previously declared but never used, so the switch did nothing in either position. This restores what the Azure pipeline did (`mergeBranch: true, branchToMerge: main`), and it is what makes the result meaningful: the canary is meant to build **current** sources against the **latest dev** packages, and `canaries/dev` is 1424 commits behind `main` on its own. The merge touches only the runner's working copy — nothing is pushed back. Shallow checkouts are deepened first, since a merge needs history on both sides.

Worth noting for review: the Azure canary's merge used to fail because a pipeline step rewrote `global.json` *before* the merge ran, leaving the working copy dirty. The GitHub Actions flow has no equivalent step, so that failure mode does not apply here.

**3. `propertiesToUpdate.json` is applied — for the first time.** It is now passed as `--updateProperties`. The Azure template passed it as the ADO input `projectProperties:`, **which does not exist**: per [`unoplatform/nuget.updater`, `specs/property-package-fallback-mappings`](https://github.com/unoplatform/nuget.updater/blob/main/specs/property-package-fallback-mappings/spec.md) — *"the ADO task input they used (`projectProperties:`) doesn't exist; their workaround has been silently no-op since 2025-08."* The file's `[{ PropertyName, PackageId }]` shape matches what `--updateProperties` expects, and the flag is present in `NvGet.Tools.Updater`.

That spec also describes in-flight work to add built-in property→package fallbacks, which may make per-repo mapping files unnecessary later. Passing the file now is still correct, and strictly better than the silent no-op it replaces.

### Follow-up outside this PR

Azure pipeline **definition 127** (`Uno.Templates Canary`) should be retired once the GitHub Actions canary is confirmed working — not before, or the repository loses canary coverage entirely. That is an Azure DevOps administration change. `canaries/dev` also still carries the Azure YAML that `main` dropped in 2025-04 and can be cleaned up at the same time.

Internal Issue (If applicable):

